### PR TITLE
Disable the browser plugin, only useful for extensions.gnome.org

### DIFF
--- a/debian/gnome-shell.install
+++ b/debian/gnome-shell.install
@@ -1,6 +1,5 @@
 usr/bin
 usr/lib/gnome-shell
-usr/lib/mozilla
 usr/share/applications
 usr/share/dbus-1
 usr/share/man

--- a/debian/rules
+++ b/debian/rules
@@ -25,6 +25,7 @@ override_dh_auto_configure:
 		--libdir=/usr/lib \
 		--libexecdir="\$${libdir}/gnome-shell" \
 		--enable-compile-warnings \
+		--disable-browser-plugin \
 		$(CONFFLAGS)
 
 override_dh_install:


### PR DESCRIPTION
We disable extensions, so let's save some bits by disabling this plugin.

https://phabricator.endlessm.com/T12044