### PR TITLE
Adapt the background menu to Endless-specific use cases

### DIFF
--- a/js/ui/backgroundMenu.js
+++ b/js/ui/backgroundMenu.js
@@ -5,6 +5,7 @@ const Lang = imports.lang;
 const St = imports.gi.St;
 const Shell = imports.gi.Shell;
 
+const AppActivation = imports.ui.appActivation;
 const BoxPointer = imports.ui.boxpointer;
 const Main = imports.ui.main;
 const PopupMenu = imports.ui.popupMenu;
@@ -18,8 +19,20 @@ const BackgroundMenu = new Lang.Class({
 
         this.addSettingsAction(_("Change Background…"), 'gnome-background-panel.desktop');
         this.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
-        this.addSettingsAction(_("Display Settings"), 'gnome-display-panel.desktop');
-        this.addSettingsAction(_("Settings"), 'gnome-control-center.desktop');
+
+        this.addAction(_("Add App"), Lang.bind(this, function() {
+            let app = Shell.AppSystem.get_default().lookup_app('org.gnome.Software.desktop');
+            let activationContext = new AppActivation.AppActivationContext(app);
+            activationContext.activate(Clutter.get_current_event());
+        }));
+
+        this.addAction(_("Add Website"), Lang.bind(this, function() {
+            Main.appStore.showPage(global.get_current_time(), 'web');
+        }));
+
+        this.addAction(_("Add Folder"), Lang.bind(this, function() {
+            Main.appStore.showPage(global.get_current_time(), 'folders');
+        }));
 
         this.actor.add_style_class_name('background-menu');
 


### PR DESCRIPTION
Replace the "Display Settings" and "Settings" items with links to
"Add App", "Add Website" and "Add Folder" instead.

https://phabricator.endlessm.com/T2212