### PR TITLE
Update Debian's GSettings overrides for the Endless use case

### DIFF
--- a/debian/gnome-shell.gsettings-override
+++ b/debian/gnome-shell.gsettings-override
@@ -1,2 +1,2 @@
 [org.gnome.shell]
-favorite-apps=[ 'firefox-esr.desktop', 'evolution.desktop', 'rhythmbox.desktop', 'libreoffice-writer.desktop', 'org.gnome.Nautilus.desktop', 'org.gnome.Software.desktop', 'yelp.desktop' ]
+favorite-apps=[ 'org.gnome.Software.desktop', 'chromium-browser.desktop', 'org.gnome.Nautilus.desktop' ]


### PR DESCRIPTION
We will ship our own list of favourite apps for Endless, and tweak
some other keys, so we repurpose this file from Debian for us.

https://phabricator.endlessm.com/T2212