### PR TITLE
Add a dialog to force quit applications

### DIFF
--- a/data/org.gnome.shell.gschema.xml.in
+++ b/data/org.gnome.shell.gschema.xml.in
@@ -144,6 +144,14 @@
       <summary>Keybinding that pauses and resumes all running tweens, for debugging purposes</summary>
       <description></description>
     </key>
+
+    <!-- Endless-specific keys below this point -->
+
+    <key name="show-force-app-exit-dialog" type="as">
+      <default>["&lt;Ctrl&gt;&lt;Alt&gt;Delete"]</default>
+      <summary>Keybinding that shows the force app exit dialog</summary>
+      <description></description>
+    </key>
   </schema>
 
   <schema id="org.gnome.shell.keyboard" path="/org/gnome/shell/keyboard/"

--- a/data/theme/gnome-shell.css
+++ b/data/theme/gnome-shell.css
@@ -1849,3 +1849,48 @@ StScrollBar {
   border: 2px solid grey;
   border-radius: 4px;
   padding: 6px; }
+
+/* Endless-specific overrides below this point */
+
+.force-app-exit-dialog {
+    max-height: 500px;
+    min-height: 450px;
+    min-width: 470px;
+    border: 1px solid rgba(238, 238, 236, 0.2);
+}
+
+.force-app-exit-dialog-content {
+    spacing: 20px;
+    padding: 20px 17px;
+}
+
+.force-app-exit-dialog-header {
+    font-weight: bold;
+}
+
+.force-app-exit-dialog-subtitle {
+    color: #ccc;
+    font-size: 12pt;
+    max-width: 370px;
+}
+
+.force-app-exit-dialog-scroll-view {
+    border: 2px solid #666;
+    border-radius: 6px;
+    height: 288px;
+}
+
+.force-app-exit-dialog-item {
+    border: solid #242424;
+    padding: 16px;
+    spacing: 16px;
+    border-bottom-width: 1px;
+}
+
+.force-app-exit-dialog-item:hover {
+    background-color: rgba(255,255,255,0.1);
+}
+
+.force-app-exit-dialog-item:selected {
+    background-color: #333;
+}

--- a/js/gdm/loginDialog.js
+++ b/js/gdm/loginDialog.js
@@ -37,9 +37,9 @@ const Batch = imports.gdm.batch;
 const BoxPointer = imports.ui.boxpointer;
 const CtrlAltTab = imports.ui.ctrlAltTab;
 const GdmUtil = imports.gdm.util;
-const Layout = imports.ui.layout;
 const LoginManager = imports.misc.loginManager;
 const Main = imports.ui.main;
+const Monitor = imports.ui.monitor;
 const PopupMenu = imports.ui.popupMenu;
 const Realmd = imports.gdm.realmd;
 const Tweener = imports.ui.tweener;
@@ -387,7 +387,7 @@ const LoginDialog = new Lang.Class({
                                                   visible: false });
         this.actor.get_accessible().set_role(Atk.Role.WINDOW);
 
-        this.actor.add_constraint(new Layout.MonitorConstraint({ primary: true }));
+        this.actor.add_constraint(new Monitor.MonitorConstraint({ primary: true }));
         this.actor.connect('allocate', Lang.bind(this, this._onAllocate));
         this.actor.connect('destroy', Lang.bind(this, this._onDestroy));
         parentActor.add_child(this.actor);

--- a/js/js-resources.gresource.xml
+++ b/js/js-resources.gresource.xml
@@ -66,6 +66,7 @@
     <file>ui/messageTray.js</file>
     <file>ui/messageList.js</file>
     <file>ui/modalDialog.js</file>
+    <file>ui/monitor.js</file>
     <file>ui/mpris.js</file>
     <file>ui/notificationDaemon.js</file>
     <file>ui/osdWindow.js</file>

--- a/js/js-resources.gresource.xml
+++ b/js/js-resources.gresource.xml
@@ -127,5 +127,6 @@
     <!-- Endless-specific UI resources below this point -->
 
     <file>ui/appActivation.js</file>
+    <file>ui/forceAppExitDialog.js</file>
   </gresource>
 </gresources>

--- a/js/ui/forceAppExitDialog.js
+++ b/js/ui/forceAppExitDialog.js
@@ -1,0 +1,135 @@
+// -*- mode: js; js-indent-level: 4; indent-tabs-mode: nil -*-
+
+const Clutter = imports.gi.Clutter;
+const Gtk = imports.gi.Gtk;
+const Lang = imports.lang;
+const Signals = imports.signals;
+const Shell = imports.gi.Shell;
+const St = imports.gi.St;
+
+const Main = imports.ui.main;
+const ModalDialog = imports.ui.modalDialog;
+
+const GNOME_SYSTEM_MONITOR_DESKTOP_ID = 'gnome-system-monitor.desktop';
+
+const ForceAppExitDialogItem = new Lang.Class({
+    Name: 'ForceAppExitDialogItem',
+    ICON_SIZE: 32,
+
+    _init: function(app) {
+        this.app = app;
+
+        this.actor = new St.BoxLayout({ style_class: 'force-app-exit-dialog-item',
+                                        can_focus: true,
+                                        reactive: true,
+                                        track_hover: true });
+        this.actor.connect('key-focus-in', Lang.bind(this, function() {
+            this.emit('selected');
+        }));
+        let action = new Clutter.ClickAction();
+        action.connect('clicked', Lang.bind(this, function() {
+            this.actor.grab_key_focus();
+        }));
+        this.actor.add_action(action);
+
+        this._icon = this.app.create_icon_texture(this.ICON_SIZE);
+        this.actor.add(this._icon);
+
+        this._label = new St.Label({ text: this.app.get_name(),
+                                     y_expand: true,
+                                     y_align: Clutter.ActorAlign.CENTER });
+        this.actor.label_actor = this._label;
+        this.actor.add(this._label);
+    },
+});
+Signals.addSignalMethods(ForceAppExitDialogItem.prototype);
+
+const ForceAppExitDialog = new Lang.Class({
+    Name: 'ForceAppExitDialog',
+    Extends: ModalDialog.ModalDialog,
+
+    _init: function() {
+        this.parent({ styleClass: 'force-app-exit-dialog' });
+
+        let title = new St.Label({ style_class: 'force-app-exit-dialog-header',
+                                   text: _("Quit applications") });
+
+        this.contentLayout.style_class = 'force-app-exit-dialog-content';
+        this.contentLayout.add(title);
+
+        let subtitle = new St.Label({ style_class: 'force-app-exit-dialog-subtitle',
+                                      text: _("If an application doesn't respond for a while, select its name and click Quit Application.") });
+        subtitle.clutter_text.line_wrap = true;
+        this.contentLayout.add(subtitle, { x_fill: false,
+                                           x_align: St.Align.START });
+
+        this._itemBox = new St.BoxLayout({ vertical: true });
+        this._scrollView = new St.ScrollView({ style_class: 'force-app-exit-dialog-scroll-view',
+                                               hscrollbar_policy: Gtk.PolicyType.NEVER,
+                                               vscrollbar_policy: Gtk.PolicyType.AUTOMATIC,
+                                               overlay_scrollbars: true,
+                                               x_expand: true,
+                                               y_expand: true });
+        this._scrollView.add_actor(this._itemBox);
+
+        this.contentLayout.add(this._scrollView, { expand: true });
+
+        this._cancelButton = this.addButton({ action: Lang.bind(this, this.close),
+                                              label: _("Cancel"),
+                                              key: Clutter.Escape });
+
+        let appSystem = Shell.AppSystem.get_default();
+        if (appSystem.lookup_app(GNOME_SYSTEM_MONITOR_DESKTOP_ID))
+            this.addButton({ action: Lang.bind(this, this._launchSystemMonitor),
+                             label: _("System Monitor") },
+                           { x_align: St.Align.END });
+
+        this._quitButton = this.addButton({ action: Lang.bind(this, this._quitApp),
+                                            label: _("Quit Application"),
+                                            key: Clutter.Return },
+                                          { expand: true,
+                                            x_fill: false,
+                                            x_align: St.Align.END });
+
+        appSystem.get_running().forEach(Lang.bind(this, function(app) {
+            let item = new ForceAppExitDialogItem(app);
+            item.connect('selected', Lang.bind(this, this._selectApp));
+            this._itemBox.add_child(item.actor);
+        }));
+
+        this._selectedAppItem = null;
+        this._updateSensitivity();
+    },
+
+    _updateSensitivity: function() {
+        let quitSensitive = this._selectedAppItem != null;
+        this._quitButton.reactive = quitSensitive;
+        this._quitButton.can_focus = quitSensitive;
+    },
+
+    _launchSystemMonitor: function() {
+        let appSystem = Shell.AppSystem.get_default();
+        let systemMonitor = appSystem.lookup_app(GNOME_SYSTEM_MONITOR_DESKTOP_ID);
+        systemMonitor.activate();
+
+        this.close();
+        Main.overview.hide();
+    },
+
+    _quitApp: function() {
+        let app = this._selectedAppItem.app;
+        app.request_quit();
+        this.close();
+    },
+
+    _selectApp: function(appItem) {
+        if (this._selectedAppItem)
+            this._selectedAppItem.actor.remove_style_pseudo_class('selected');
+
+        this._selectedAppItem = appItem;
+        this._updateSensitivity();
+
+        if (this._selectedAppItem)
+            this._selectedAppItem.actor.add_style_pseudo_class('selected');
+    },
+});

--- a/js/ui/layout.js
+++ b/js/ui/layout.js
@@ -2,7 +2,6 @@
 
 const Clutter = imports.gi.Clutter;
 const GLib = imports.gi.GLib;
-const GObject = imports.gi.GObject;
 const Lang = imports.lang;
 const Meta = imports.gi.Meta;
 const Shell = imports.gi.Shell;
@@ -15,6 +14,7 @@ const LoginManager = imports.misc.loginManager;
 
 const DND = imports.ui.dnd;
 const Main = imports.ui.main;
+const Monitor = imports.ui.monitor;
 const Params = imports.misc.params;
 const Tweener = imports.ui.tweener;
 
@@ -35,133 +35,6 @@ function isPopupMetaWindow(actor) {
         return false;
     }
 }
-
-const MonitorConstraint = new Lang.Class({
-    Name: 'MonitorConstraint',
-    Extends: Clutter.Constraint,
-    Properties: {'primary': GObject.ParamSpec.boolean('primary', 
-                                                      'Primary', 'Track primary monitor',
-                                                      GObject.ParamFlags.READABLE | GObject.ParamFlags.WRITABLE,
-                                                      false),
-                 'index': GObject.ParamSpec.int('index',
-                                                'Monitor index', 'Track specific monitor',
-                                                GObject.ParamFlags.READABLE | GObject.ParamFlags.WRITABLE,
-                                                -1, 64, -1),
-                 'work-area': GObject.ParamSpec.boolean('work-area',
-                                                        'Work-area', 'Track monitor\'s work-area',
-                                                        GObject.ParamFlags.READABLE | GObject.ParamFlags.WRITABLE,
-                                                        false)},
-
-    _init: function(props) {
-        this._primary = false;
-        this._index = -1;
-        this._workArea = false;
-
-        this.parent(props);
-    },
-
-    get primary() {
-        return this._primary;
-    },
-
-    set primary(v) {
-        if (v)
-            this._index = -1;
-        this._primary = v;
-        if (this.actor)
-            this.actor.queue_relayout();
-        this.notify('primary');
-    },
-
-    get index() {
-        return this._index;
-    },
-
-    set index(v) {
-        this._primary = false;
-        this._index = v;
-        if (this.actor)
-            this.actor.queue_relayout();
-        this.notify('index');
-    },
-
-    get work_area() {
-        return this._workArea;
-    },
-
-    set work_area(v) {
-        if (v == this._workArea)
-            return;
-        this._workArea = v;
-        if (this.actor)
-            this.actor.queue_relayout();
-        this.notify('work-area');
-    },
-
-    vfunc_set_actor: function(actor) {
-        if (actor) {
-            if (!this._monitorsChangedId) {
-                this._monitorsChangedId = Main.layoutManager.connect('monitors-changed', Lang.bind(this, function() {
-                    this.actor.queue_relayout();
-                }));
-            }
-
-            if (!this._workareasChangedId) {
-                this._workareasChangedId = global.screen.connect('workareas-changed', Lang.bind(this, function() {
-                    if (this._workArea)
-                        this.actor.queue_relayout();
-                }));
-            }
-        } else {
-            if (this._monitorsChangedId)
-                Main.layoutManager.disconnect(this._monitorsChangedId);
-            this._monitorsChangedId = 0;
-
-            if (this._workareasChangedId)
-                global.screen.disconnect(this._workareasChangedId);
-            this._workareasChangedId = 0;
-        }
-
-        this.parent(actor);
-    },
-
-    vfunc_update_allocation: function(actor, actorBox) {
-        if (!this._primary && this._index < 0)
-            return;
-
-        let index;
-        if (this._primary)
-            index = Main.layoutManager.primaryIndex;
-        else
-            index = Math.min(this._index, Main.layoutManager.monitors.length - 1);
-
-        let rect;
-        if (this._workArea) {
-            let ws = global.screen.get_workspace_by_index(0);
-            rect = ws.get_work_area_for_monitor(index);
-        } else {
-            rect = Main.layoutManager.monitors[index];
-        }
-
-        actorBox.init_rect(rect.x, rect.y, rect.width, rect.height);
-    }
-});
-
-const Monitor = new Lang.Class({
-    Name: 'Monitor',
-
-    _init: function(index, geometry) {
-        this.index = index;
-        this.x = geometry.x;
-        this.y = geometry.y;
-        this.width = geometry.width;
-        this.height = geometry.height;
-    },
-
-    get inFullscreen() {
-        return global.screen.get_monitor_in_fullscreen(this.index);
-    }
-})
 
 const defaultParams = {
     trackFullscreen: false,
@@ -321,7 +194,7 @@ const LayoutManager = new Lang.Class({
         this.monitors = [];
         let nMonitors = screen.get_n_monitors();
         for (let i = 0; i < nMonitors; i++)
-            this.monitors.push(new Monitor(i, screen.get_monitor_geometry(i)));
+            this.monitors.push(new Monitor.Monitor(i, screen.get_monitor_geometry(i)));
 
         if (nMonitors == 1) {
             this.primaryIndex = this.bottomIndex = 0;

--- a/js/ui/legacyTray.js
+++ b/js/ui/legacyTray.js
@@ -9,6 +9,7 @@ const CtrlAltTab = imports.ui.ctrlAltTab;
 const Lang = imports.lang;
 const Layout = imports.ui.layout;
 const Main = imports.ui.main;
+const Monitor = imports.ui.monitor;
 const Overview = imports.ui.overview;
 const OverviewControls = imports.ui.overviewControls;
 const Tweener = imports.ui.tweener;
@@ -42,8 +43,8 @@ const LegacyTray = new Lang.Class({
     _init: function() {
         this.actor = new St.Widget({ clip_to_allocation: true,
                                      layout_manager: new Clutter.BinLayout() });
-        let constraint = new Layout.MonitorConstraint({ primary: true,
-                                                        work_area: true });
+        let constraint = new Monitor.MonitorConstraint({ primary: true,
+                                                         work_area: true });
         this.actor.add_constraint(constraint);
 
         this._slideLayout = new OverviewControls.SlideLayout();

--- a/js/ui/messageTray.js
+++ b/js/ui/messageTray.js
@@ -16,8 +16,8 @@ const St = imports.gi.St;
 
 const Calendar = imports.ui.calendar;
 const GnomeSession = imports.misc.gnomeSession;
-const Layout = imports.ui.layout;
 const Main = imports.ui.main;
+const Monitor = imports.ui.monitor;
 const Params = imports.misc.params;
 const Tweener = imports.ui.tweener;
 const Util = imports.misc.util;
@@ -861,7 +861,7 @@ const MessageTray = new Lang.Class({
         this.actor = new St.Widget({ visible: false,
                                      clip_to_allocation: true,
                                      layout_manager: new Clutter.BinLayout() });
-        let constraint = new Layout.MonitorConstraint({ primary: true });
+        let constraint = new Monitor.MonitorConstraint({ primary: true });
         Main.layoutManager.panelBox.bind_property('visible',
                                                   constraint, 'work-area',
                                                   GObject.BindingFlags.SYNC_CREATE);

--- a/js/ui/modalDialog.js
+++ b/js/ui/modalDialog.js
@@ -14,9 +14,9 @@ const Atk = imports.gi.Atk;
 
 const Params = imports.misc.params;
 
-const Layout = imports.ui.layout;
 const Lightbox = imports.ui.lightbox;
 const Main = imports.ui.main;
+const Monitor = imports.ui.monitor;
 const Tweener = imports.ui.tweener;
 
 const OPEN_AND_CLOSE_TIME = 0.1;
@@ -69,7 +69,7 @@ const ModalDialog = new Lang.Class({
         this.backgroundStack = new St.Widget({ layout_manager: new Clutter.BinLayout() });
         this._backgroundBin = new St.Bin({ child: this.backgroundStack,
                                            x_fill: true, y_fill: true });
-        this._monitorConstraint = new Layout.MonitorConstraint();
+        this._monitorConstraint = new Monitor.MonitorConstraint();
         this._backgroundBin.add_constraint(this._monitorConstraint);
         this._group.add_actor(this._backgroundBin);
 

--- a/js/ui/monitor.js
+++ b/js/ui/monitor.js
@@ -1,0 +1,135 @@
+// -*- mode: js; js-indent-level: 4; indent-tabs-mode: nil -*-
+
+const Clutter = imports.gi.Clutter;
+const GObject = imports.gi.GObject;
+const Lang = imports.lang;
+
+const Main = imports.ui.main;
+const Params = imports.misc.params;
+
+const MonitorConstraint = new Lang.Class({
+    Name: 'MonitorConstraint',
+    Extends: Clutter.Constraint,
+    Properties: {'primary': GObject.ParamSpec.boolean('primary', 
+                                                      'Primary', 'Track primary monitor',
+                                                      GObject.ParamFlags.READABLE | GObject.ParamFlags.WRITABLE,
+                                                      false),
+                 'index': GObject.ParamSpec.int('index',
+                                                'Monitor index', 'Track specific monitor',
+                                                GObject.ParamFlags.READABLE | GObject.ParamFlags.WRITABLE,
+                                                -1, 64, -1),
+                 'work-area': GObject.ParamSpec.boolean('work-area',
+                                                        'Work-area', 'Track monitor\'s work-area',
+                                                        GObject.ParamFlags.READABLE | GObject.ParamFlags.WRITABLE,
+                                                        false)},
+
+    _init: function(props) {
+        this._primary = false;
+        this._index = -1;
+        this._workArea = false;
+
+        this.parent(props);
+    },
+
+    get primary() {
+        return this._primary;
+    },
+
+    set primary(v) {
+        if (v)
+            this._index = -1;
+        this._primary = v;
+        if (this.actor)
+            this.actor.queue_relayout();
+        this.notify('primary');
+    },
+
+    get index() {
+        return this._index;
+    },
+
+    set index(v) {
+        this._primary = false;
+        this._index = v;
+        if (this.actor)
+            this.actor.queue_relayout();
+        this.notify('index');
+    },
+
+    get work_area() {
+        return this._workArea;
+    },
+
+    set work_area(v) {
+        if (v == this._workArea)
+            return;
+        this._workArea = v;
+        if (this.actor)
+            this.actor.queue_relayout();
+        this.notify('work-area');
+    },
+
+    vfunc_set_actor: function(actor) {
+        if (actor) {
+            if (!this._monitorsChangedId) {
+                this._monitorsChangedId = Main.layoutManager.connect('monitors-changed', Lang.bind(this, function() {
+                    this.actor.queue_relayout();
+                }));
+            }
+
+            if (!this._workareasChangedId) {
+                this._workareasChangedId = global.screen.connect('workareas-changed', Lang.bind(this, function() {
+                    if (this._workArea)
+                        this.actor.queue_relayout();
+                }));
+            }
+        } else {
+            if (this._monitorsChangedId)
+                Main.layoutManager.disconnect(this._monitorsChangedId);
+            this._monitorsChangedId = 0;
+
+            if (this._workareasChangedId)
+                global.screen.disconnect(this._workareasChangedId);
+            this._workareasChangedId = 0;
+        }
+
+        this.parent(actor);
+    },
+
+    vfunc_update_allocation: function(actor, actorBox) {
+        if (!this._primary && this._index < 0)
+            return;
+
+        let index;
+        if (this._primary)
+            index = Main.layoutManager.primaryIndex;
+        else
+            index = Math.min(this._index, Main.layoutManager.monitors.length - 1);
+
+        let rect;
+        if (this._workArea) {
+            let ws = global.screen.get_workspace_by_index(0);
+            rect = ws.get_work_area_for_monitor(index);
+        } else {
+            rect = Main.layoutManager.monitors[index];
+        }
+
+        actorBox.init_rect(rect.x, rect.y, rect.width, rect.height);
+    }
+});
+
+const Monitor = new Lang.Class({
+    Name: 'Monitor',
+
+    _init: function(index, geometry) {
+        this.index = index;
+        this.x = geometry.x;
+        this.y = geometry.y;
+        this.width = geometry.width;
+        this.height = geometry.height;
+    },
+
+    get inFullscreen() {
+        return global.screen.get_monitor_in_fullscreen(this.index);
+    }
+})

--- a/js/ui/osdWindow.js
+++ b/js/ui/osdWindow.js
@@ -5,9 +5,9 @@ const GLib = imports.gi.GLib;
 const St = imports.gi.St;
 
 const Lang = imports.lang;
-const Layout = imports.ui.layout;
 const Main = imports.ui.main;
 const Mainloop = imports.mainloop;
+const Monitor = imports.ui.monitor;
 const Tweener = imports.ui.tweener;
 const Meta = imports.gi.Meta;
 
@@ -87,7 +87,7 @@ const OsdWindow = new Lang.Class({
                                      y_align: Clutter.ActorAlign.CENTER });
 
         this._monitorIndex = monitorIndex;
-        let constraint = new Layout.MonitorConstraint({ index: monitorIndex });
+        let constraint = new Monitor.MonitorConstraint({ index: monitorIndex });
         this.actor.add_constraint(constraint);
 
         this._boxConstraint = new OsdWindowConstraint();

--- a/js/ui/overview.js
+++ b/js/ui/overview.js
@@ -13,7 +13,7 @@ const Gdk = imports.gi.Gdk;
 
 const Background = imports.ui.background;
 const DND = imports.ui.dnd;
-const LayoutManager = imports.ui.layout;
+const Monitor = imports.ui.monitor;
 const Lightbox = imports.ui.lightbox;
 const Main = imports.ui.main;
 const MessageTray = imports.ui.messageTray;
@@ -112,7 +112,7 @@ const Overview = new Lang.Class({
         this._overview = new St.BoxLayout({ name: 'overview',
                                             accessible_name: _("Overview"),
                                             vertical: true });
-        this._overview.add_constraint(new LayoutManager.MonitorConstraint({ primary: true }));
+        this._overview.add_constraint(new Monitor.MonitorConstraint({ primary: true }));
         this._overview._delegate = this;
 
         // The main Background actors are inside global.window_group which are

--- a/js/ui/screenShield.js
+++ b/js/ui/screenShield.js
@@ -17,11 +17,11 @@ const TweenerEquations = imports.tweener.equations;
 
 const Background = imports.ui.background;
 const GnomeSession = imports.misc.gnomeSession;
-const Layout = imports.ui.layout;
 const OVirt = imports.gdm.oVirt;
 const LoginManager = imports.misc.loginManager;
 const Lightbox = imports.ui.lightbox;
 const Main = imports.ui.main;
+const Monitor = imports.ui.monitor;
 const Overview = imports.ui.overview;
 const MessageTray = imports.ui.messageTray;
 const ShellDBus = imports.ui.shellDBus;
@@ -450,7 +450,7 @@ const ScreenShield = new Lang.Class({
 
         this._lockScreenContents = new St.Widget({ layout_manager: new Clutter.BinLayout(),
                                                    name: 'lockScreenContents' });
-        this._lockScreenContents.add_constraint(new Layout.MonitorConstraint({ primary: true }));
+        this._lockScreenContents.add_constraint(new Monitor.MonitorConstraint({ primary: true }));
 
         this._lockScreenGroup.add_actor(this._lockScreenContents);
 

--- a/js/ui/unlockDialog.js
+++ b/js/ui/unlockDialog.js
@@ -14,8 +14,8 @@ const Signals = imports.signals;
 const Shell = imports.gi.Shell;
 const St = imports.gi.St;
 
-const Layout = imports.ui.layout;
 const Main = imports.ui.main;
+const Monitor = imports.ui.monitor;
 const Panel = imports.ui.panel;
 const Tweener = imports.ui.tweener;
 const UserWidget = imports.ui.userWidget;
@@ -37,7 +37,7 @@ const UnlockDialog = new Lang.Class({
                                      layout_manager: new Clutter.BoxLayout(),
                                      visible: false });
 
-        this.actor.add_constraint(new Layout.MonitorConstraint({ primary: true }));
+        this.actor.add_constraint(new Monitor.MonitorConstraint({ primary: true }));
         parentActor.add_child(this.actor);
 
         this._userManager = AccountsService.UserManager.get_default();

--- a/js/ui/windowManager.js
+++ b/js/ui/windowManager.js
@@ -12,6 +12,7 @@ const Shell = imports.gi.Shell;
 const Signals = imports.signals;
 
 const AltTab = imports.ui.altTab;
+const ForceAppExitDialog = imports.ui.forceAppExitDialog;
 const WorkspaceSwitcherPopup = imports.ui.workspaceSwitcherPopup;
 const Main = imports.ui.main;
 const ModalDialog = imports.ui.modalDialog;
@@ -895,6 +896,13 @@ const WindowManager = new Lang.Class({
                                         Shell.ActionMode.UNLOCK_SCREEN |
                                         Shell.ActionMode.LOGIN_SCREEN,
                                         Lang.bind(this, this._startA11ySwitcher));
+
+        this.addKeybinding('show-force-app-exit-dialog',
+                           new Gio.Settings({ schema_id: SHELL_KEYBINDINGS_SCHEMA }),
+                           Meta.KeyBindingFlags.NONE,
+                           Shell.ActionMode.NORMAL |
+                           Shell.ActionMode.OVERVIEW,
+                           Lang.bind(this, this._showForceAppExitDialog));
 
         this.addKeybinding('pause-resume-tweens',
                            new Gio.Settings({ schema_id: SHELL_KEYBINDINGS_SCHEMA }),
@@ -1829,6 +1837,14 @@ const WindowManager = new Lang.Class({
 
     _startA11ySwitcher : function(display, screen, window, binding) {
         Main.ctrlAltTabManager.popup(binding.is_reversed(), binding.get_name(), binding.get_mask());
+    },
+
+    _showForceAppExitDialog: function() {
+        if (!Main.sessionMode.hasOverview)
+            return;
+
+        let dialog = new ForceAppExitDialog.ForceAppExitDialog();
+        dialog.open();
     },
 
     _toggleAppMenu : function(display, screen, window, event, binding) {

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -70,3 +70,5 @@ src/shell-global.c
 src/shell-keyring-prompt.c
 src/shell-polkit-authentication-agent.c
 src/shell-util.c
+# Endless-specific files below this point
+js/ui/forceAppExitDialog.js


### PR DESCRIPTION
This PR also includes another commit necessary for this, since otherwise GNOME Shell will throw an error when trying to create the ForceAppExitDialog class due to circular imports problem:

Since modalDialog.js imports layout.js, which ends up getting windowManager.js imported, which imports forceAppExitDialog.js... which imports modalDialog.js again, at the time that the ForceAppExitDialog class is being created its super class is not completely defined yet, causing the constructor of the ModalDialog not to be called and therefore the whole thing to fail.

The first commit addresses that problem (which would get worse with GJS 1.48) by splitting out Monitor and MonitorConstraint out of layout.js, as those are the classes typically used in most places, preventing importing the whole layout.js in most cases.