### PR TITLE
More infrastructure to bring EOS desktop back to life

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -104,7 +104,8 @@ SHARED_PCS="gio-unix-2.0 >= $GIO_MIN_VERSION
             gobject-introspection-1.0 >= $GOBJECT_INTROSPECTION_MIN_VERSION
             libcanberra libcanberra-gtk3
             polkit-agent-1 >= $POLKIT_MIN_VERSION
-            gcr-base-3 >= $GCR_MIN_VERSION"
+            gcr-base-3 >= $GCR_MIN_VERSION
+            eosmetrics-0"
 if test x$have_systemd = xyes; then
   SHARED_PCS="${SHARED_PCS} libsystemd"
 fi

--- a/data/gnome-shell-theme.gresource.xml
+++ b/data/gnome-shell-theme.gresource.xml
@@ -47,6 +47,7 @@
     <file>hot-corner-symbolic.svg</file>
     <file>hot-corner-rtl-symbolic.svg</file>
     <file>mini-icon-active-indicator.png</file>
+    <file>process-working-dark.svg</file>
     <file>system-logout.png</file>
   </gresource>
 </gresources>

--- a/data/org.gnome.shell.gschema.xml.in
+++ b/data/org.gnome.shell.gschema.xml.in
@@ -151,6 +151,13 @@
         key by the shell on start, and then cleared from here.
       </description>
     </key>
+    <key name="icon-grid-layout" type="a{sas}">
+      <default>{}</default>
+      <summary>Layout of application launcher icons in the grid</summary>
+      <description>
+        This key specifies the exact order of the icons shown in the applications launcher view.
+      </description>
+    </key>
     <child name="keybindings" schema="org.gnome.shell.keybindings"/>
     <child name="keyboard" schema="org.gnome.shell.keyboard"/>
   </schema>

--- a/data/theme/gnome-shell.css
+++ b/data/theme/gnome-shell.css
@@ -2102,3 +2102,73 @@ stage {
 #panel .powermenu {
   margin-left: 16px;
 }
+
+#searchEntry {
+    width: 350px;
+    height: 38px;
+
+    margin-top: 8px;
+    padding: 0 12px 0 0;
+
+    font-family: lato, sans-serif;
+    font-size: 11.5pt;
+
+    color: #484645;
+    selected-color: #ededed;
+    caret-color: #333;
+    background-color: rgba(255, 255, 255, 0.8);
+
+    border-radius: 19px;
+    box-shadow: 0px 0px 4px rgba(0,0,0,0.7);
+
+
+    -minimum-vpadding: 48px;
+}
+
+#searchEntry.low-resolution {
+    width: 300px;
+
+    -minimum-vpadding: 20px;
+}
+
+#searchEntry:rtl {
+    padding-left: 4px;
+    padding-right: 8px;
+}
+
+#searchEntry:hover,
+#searchEntry:focus {
+    background-color: rgba(255, 255, 255, 0.95);
+}
+
+.search-entry-text-hint {
+    padding-left: 6px;
+    padding-right: 6px;
+    padding-bottom: 2px;
+
+    font-family: lato, sans-serif;
+    font-size: 12pt;
+    color: #424040;
+}
+
+.search-icon {
+    background-gradient-start: rgba(255,95,42,0.9);
+    background-gradient-end: rgba(248,63,0,0.9);
+    background-gradient-direction: vertical;
+
+    color: white;
+
+    width: 38px;
+    height: 38px;
+    border-radius: 19px;
+
+    box-shadow: inset 0 -1px 1px rgba(0,0,0,0.25);
+}
+
+.dash-label {
+    border-radius: 7px;
+    padding: 4px 12px;
+    background-color: rgba(0,0,0,0.5);
+    text-align: center;
+    -x-offset: 8px;
+}

--- a/data/theme/process-working-dark.svg
+++ b/data/theme/process-working-dark.svg
@@ -1,0 +1,261 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg5369"
+   version="1.1"
+   inkscape:version="0.48+devel r10053 custom"
+   width="96"
+   height="48"
+   sodipodi:docname="process-working.svg"
+   style="display:inline">
+  <metadata
+     id="metadata5375">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs5373" />
+  <sodipodi:namedview
+     pagecolor="#808080"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1975"
+     inkscape:window-height="1098"
+     id="namedview5371"
+     showgrid="true"
+     borderlayer="true"
+     inkscape:showpageshadow="false"
+     inkscape:zoom="16"
+     inkscape:cx="53.997662"
+     inkscape:cy="22.367695"
+     inkscape:window-x="1600"
+     inkscape:window-y="33"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="layer2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid11933"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <g
+     inkscape:groupmode="layer"
+     id="layer1"
+     inkscape:label="tiles"
+     style="display:none">
+    <rect
+       style="color:#000000;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="rect12451"
+       width="24"
+       height="24"
+       x="0"
+       y="0" />
+    <rect
+       y="24"
+       x="0"
+       height="24"
+       width="24"
+       id="rect12453"
+       style="color:#000000;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    <rect
+       y="0"
+       x="24"
+       height="24"
+       width="24"
+       id="rect12455"
+       style="color:#000000;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    <rect
+       style="color:#000000;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="rect12457"
+       width="24"
+       height="24"
+       x="24"
+       y="24" />
+    <rect
+       style="color:#000000;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="rect12459"
+       width="24"
+       height="24"
+       x="48"
+       y="0" />
+    <rect
+       y="24"
+       x="48"
+       height="24"
+       width="24"
+       id="rect12461"
+       style="color:#000000;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    <rect
+       y="0"
+       x="72"
+       height="24"
+       width="24"
+       id="rect12463"
+       style="color:#000000;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    <rect
+       style="color:#000000;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="rect12465"
+       width="24"
+       height="24"
+       x="72"
+       y="24" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="spinner">
+    <g
+       transform="matrix(0.28240106,0,0,0.28240106,146.92015,-382.52444)"
+       id="g10450-5"
+       style="display:inline">
+      <path
+         inkscape:connector-curvature="0"
+         style="opacity:0.6;color:#000000;fill:none;stroke:#333333;stroke-width:7.08212566;stroke-linecap:round;stroke-opacity:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         d="m -477.76072,1373.3569 0,9.4717"
+         id="path18768"
+         sodipodi:nodetypes="cc"
+         inkscape:transform-center-y="-4.6808838" />
+      <path
+         inkscape:connector-curvature="0"
+         inkscape:transform-center-y="-3.3099227"
+         sodipodi:nodetypes="cc"
+         id="path18770"
+         d="m -461.0171,1380.2922 -7.23427,7.3824"
+         style="opacity:0.7;color:#000000;fill:none;stroke:#333333;stroke-width:7.08212566;stroke-linecap:round;stroke-opacity:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         inkscape:transform-center-x="-3.3098966" />
+      <path
+         inkscape:connector-curvature="0"
+         inkscape:transform-center-x="-4.6808962"
+         style="opacity:0.8;color:#000000;fill:none;stroke:#333333;stroke-width:7.08212566;stroke-linecap:round;stroke-opacity:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         d="m -454.08163,1397.0359 -9.47165,0"
+         id="path18772"
+         sodipodi:nodetypes="cc"
+         inkscape:transform-center-y="-2.6596956e-05" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc"
+         id="path18774"
+         d="m -461.01709,1413.7796 -6.93831,-7.0864"
+         style="opacity:0.9;color:#000000;fill:none;stroke:#333333;stroke-width:7.08212566;stroke-linecap:round;stroke-opacity:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         inkscape:transform-center-x="-3.3098966"
+         inkscape:transform-center-y="3.3098652" />
+      <path
+         inkscape:connector-curvature="0"
+         inkscape:transform-center-y="4.6808757"
+         style="color:#000000;fill:none;stroke:#333333;stroke-width:7.08212566;stroke-linecap:round;stroke-opacity:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         d="m -477.76074,1420.715 9e-5,-9.4716"
+         id="path18776"
+         sodipodi:nodetypes="cc" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc"
+         id="path18778"
+         d="m -494.50442,1413.7796 6.79048,-6.9384"
+         style="opacity:0.3;color:#000000;fill:none;stroke:#333333;stroke-width:7.08212566;stroke-linecap:round;stroke-opacity:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         inkscape:transform-center-y="3.3098769"
+         inkscape:transform-center-x="3.3098883" />
+      <path
+         inkscape:connector-curvature="0"
+         inkscape:transform-center-x="4.6808941"
+         style="opacity:0.4;color:#000000;fill:none;stroke:#333333;stroke-width:7.08212566;stroke-linecap:round;stroke-opacity:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         d="m -501.43987,1397.0359 9.47174,0"
+         id="path18780"
+         sodipodi:nodetypes="cc"
+         inkscape:transform-center-y="-2.6596956e-05" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc"
+         id="path18782"
+         d="m -494.5044,1380.2922 6.64243,6.9384"
+         style="opacity:0.5;color:#000000;fill:none;stroke:#333333;stroke-width:7.08212566;stroke-linecap:round;stroke-opacity:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         inkscape:transform-center-x="3.3098902"
+         inkscape:transform-center-y="-3.3099302" />
+    </g>
+    <use
+       style="display:inline"
+       x="0"
+       y="0"
+       xlink:href="#g10450-5"
+       id="use4981"
+       transform="matrix(0.70710678,0.70710678,-0.70710678,0.70710678,36,-4.9705636)"
+       width="400"
+       height="400" />
+    <use
+       style="display:inline"
+       x="0"
+       y="0"
+       xlink:href="#use4981"
+       id="use4983"
+       transform="matrix(0.70710678,0.70710678,-0.70710678,0.70710678,43.032478,-21.909695)"
+       width="400"
+       height="400" />
+    <use
+       style="display:inline"
+       x="0"
+       y="0"
+       xlink:href="#use4983"
+       id="use4985"
+       transform="matrix(0.70710678,0.70710678,-0.70710678,0.70710678,50.081986,-38.904617)"
+       width="400"
+       height="400" />
+    <use
+       style="display:inline"
+       x="0"
+       y="0"
+       xlink:href="#use4985"
+       id="use4987"
+       transform="matrix(0.70710678,0.70710678,-0.70710678,0.70710678,-38.919996,-31.872139)"
+       width="400"
+       height="400" />
+    <use
+       style="display:inline"
+       x="0"
+       y="0"
+       xlink:href="#use4987"
+       id="use4989"
+       transform="matrix(0.70710678,0.70710678,-0.70710678,0.70710678,52.986628,2.0890543)"
+       width="400"
+       height="400" />
+    <use
+       style="display:inline"
+       x="0"
+       y="0"
+       xlink:href="#use4989"
+       id="use4991"
+       transform="matrix(0.70710678,0.70710678,-0.70710678,0.70710678,60.013026,-14.912936)"
+       width="400"
+       height="400" />
+    <use
+       style="display:inline"
+       x="0"
+       y="0"
+       xlink:href="#use4991"
+       id="use4993"
+       transform="matrix(0.70710678,0.70710678,-0.70710678,0.70710678,67.022396,-31.859127)"
+       width="400"
+       height="400" />
+  </g>
+</svg>

--- a/js/js-resources.gresource.xml
+++ b/js/js-resources.gresource.xml
@@ -128,6 +128,7 @@
 
     <file>ui/appActivation.js</file>
     <file>ui/appIconBar.js</file>
+    <file>ui/components/discoveryFeed.js</file>
     <file>ui/endlessButton.js</file>
     <file>ui/forceAppExitDialog.js</file>
     <file>ui/hotCorner.js</file>

--- a/js/js-resources.gresource.xml
+++ b/js/js-resources.gresource.xml
@@ -132,6 +132,7 @@
     <file>ui/forceAppExitDialog.js</file>
     <file>ui/hotCorner.js</file>
     <file>ui/iconGridLayout.js</file>
+    <file>ui/internetSearch.js</file>
     <file>ui/userMenu.js</file>
     <file>ui/workspaceMonitor.js</file>
   </gresource>

--- a/js/js-resources.gresource.xml
+++ b/js/js-resources.gresource.xml
@@ -133,6 +133,7 @@
     <file>ui/hotCorner.js</file>
     <file>ui/iconGridLayout.js</file>
     <file>ui/internetSearch.js</file>
+    <file>ui/sideComponent.js</file>
     <file>ui/userMenu.js</file>
     <file>ui/workspaceMonitor.js</file>
   </gresource>

--- a/js/js-resources.gresource.xml
+++ b/js/js-resources.gresource.xml
@@ -132,5 +132,6 @@
     <file>ui/forceAppExitDialog.js</file>
     <file>ui/hotCorner.js</file>
     <file>ui/userMenu.js</file>
+    <file>ui/workspaceMonitor.js</file>
   </gresource>
 </gresources>

--- a/js/js-resources.gresource.xml
+++ b/js/js-resources.gresource.xml
@@ -131,6 +131,7 @@
     <file>ui/endlessButton.js</file>
     <file>ui/forceAppExitDialog.js</file>
     <file>ui/hotCorner.js</file>
+    <file>ui/iconGridLayout.js</file>
     <file>ui/userMenu.js</file>
     <file>ui/workspaceMonitor.js</file>
   </gresource>

--- a/js/misc/util.js
+++ b/js/misc/util.js
@@ -7,11 +7,15 @@ const Lang = imports.lang;
 const Shell = imports.gi.Shell;
 const St = imports.gi.St;
 
+const Json = imports.gi.Json;
 const Main = imports.ui.main;
 const Tweener = imports.ui.tweener;
 const Params = imports.misc.params;
 
 const SCROLL_TIME = 0.1;
+
+const FALLBACK_BROWSER_ID = 'chromium-browser.desktop';
+const GOOGLE_CHROME_ID = 'google-chrome.desktop';
 
 // http://daringfireball.net/2010/07/improved_regex_for_matching_urls
 const _balancedParens = '\\((?:[^\\s()<>]+|(?:\\(?:[^\\s()<>]+\\)))*\\)';
@@ -54,6 +58,28 @@ function findUrls(str) {
     let res = [], match;
     while ((match = _urlRegexp.exec(str)))
         res.push({ url: match[2], pos: match.index + match[1].length });
+    return res;
+}
+
+// http://stackoverflow.com/questions/4691070/validate-url-without-www-or-http
+const _searchUrlRegexp = new RegExp(
+    '^([a-zA-Z0-9]+(\.[a-zA-Z0-9]+)+.*)\\.+[A-Za-z0-9\.\/%&=\?\-_]+$',
+    'gi');
+
+// findSearchUrls:
+// @terms: list of searchbar terms to find URLs in
+//
+// Similar to "findUrls", but for use only with terms from the searchbar.
+// The regex for these URLs matches strings such as "google.com" (note the
+// lack of preceding scheme).
+//
+// Return value: the list of URLs found in the string
+function findSearchUrls(terms) {
+    let res = [], match;
+    for (let i in terms) {
+        while ((match = _searchUrlRegexp.exec(terms[i])))
+            res.push(match[0]);
+    }
     return res;
 }
 
@@ -397,4 +423,80 @@ function ensureActorVisibleInScrollView(scrollView, actor) {
                      { value: value,
                        time: SCROLL_TIME,
                        transition: 'easeOutQuad' });
+}
+
+function getBrowserId() {
+    let id = FALLBACK_BROWSER_ID;
+    let app = Gio.app_info_get_default_for_type('x-scheme-handler/http', true);
+    if (app != null)
+        id = app.get_id();
+    return id;
+}
+
+function getBrowserApp() {
+    let id = getBrowserId();
+    let appSystem = Shell.AppSystem.get_default();
+    let browserApp = appSystem.lookup_app(id);
+    return browserApp;
+}
+
+function _getJsonSearchEngine(folder) {
+    let path = GLib.build_filenamev([GLib.get_user_config_dir(), folder, 'Default', 'Preferences']);
+    let parser = new Json.Parser();
+
+    /*
+     * Translators: this is the name of the search engine that shows in the
+     * Shell's desktop search entry.
+     */
+    let default_string = _("Google");
+
+    try {
+        parser.load_from_file(path);
+    } catch(e if e.matches(GLib.FileError, GLib.FileError.NOENT)) {
+        // User has not run Chromium yet.
+        return default_string;
+    } catch (e) {
+        logError(e, 'error while parsing Chromium preferences');
+        return null;
+    }
+
+    let root = parser.get_root().get_object();
+
+    let searchProviderDataNode = root.get_member('default_search_provider_data');
+    if (!searchProviderDataNode || searchProviderDataNode.get_node_type() != Json.NodeType.OBJECT)
+        return default_string;
+
+    let searchProviderData = searchProviderDataNode.get_object();
+    if (!searchProviderData)
+        return default_string;
+
+    let templateUrlDataNode = searchProviderData.get_member('template_url_data');
+    if (!templateUrlDataNode || templateUrlDataNode.get_node_type() != Json.NodeType.OBJECT)
+        return default_string;
+
+    let templateUrlData = templateUrlDataNode.get_object();
+    if (!templateUrlData)
+        return default_string;
+
+    let shortNameNode = templateUrlData.get_member('short_name');
+    if (!shortNameNode || shortNameNode.get_node_type() != Json.NodeType.VALUE)
+        return default_string;
+
+    return shortNameNode.get_string();
+}
+
+// getSearchEngineName:
+//
+// Retrieves the current search engine from
+// the default browser.
+function getSearchEngineName() {
+    let browser = getBrowserId();
+
+    if (browser === FALLBACK_BROWSER_ID)
+        return _getJsonSearchEngine('chromium');
+
+    if (browser === GOOGLE_CHROME_ID)
+        return _getJsonSearchEngine('google-chrome');
+
+    return null;
 }

--- a/js/ui/appDisplay.js
+++ b/js/ui/appDisplay.js
@@ -849,8 +849,7 @@ const FrequentView = new Lang.Class({
 });
 
 const Views = {
-    FREQUENT: 0,
-    ALL: 1
+    ALL: 0
 };
 
 const ControlsBoxLayout = Lang.Class({
@@ -899,125 +898,29 @@ const AppDisplay = new Lang.Class({
 
     _init: function() {
         this._privacySettings = new Gio.Settings({ schema_id: 'org.gnome.desktop.privacy' });
-        this._privacySettings.connect('changed::remember-app-usage',
-                                      Lang.bind(this, this._updateFrequentVisibility));
 
-        this._views = [];
+        this._allView = new AllView();
 
-        let view, button;
-        view = new FrequentView();
-        button = new St.Button({ label: _("Frequent"),
-                                 style_class: 'app-view-control button',
-                                 can_focus: true,
-                                 x_expand: true });
-        this._views[Views.FREQUENT] = { 'view': view, 'control': button };
+        let viewStackLayout = new ViewStackLayout();
+        this.actor = new St.Widget({ x_expand: true, y_expand: true,
+                                     layout_manager: viewStackLayout });
+        viewStackLayout.connect('allocated-size-changed', Lang.bind(this, this._onAllocatedSizeChanged));
 
-        view = new AllView();
-        button = new St.Button({ label: _("All"),
-                                 style_class: 'app-view-control button',
-                                 can_focus: true,
-                                 x_expand: true });
-        this._views[Views.ALL] = { 'view': view, 'control': button };
-
-        this.actor = new St.BoxLayout ({ style_class: 'app-display',
-                                         x_expand: true, y_expand: true,
-                                         vertical: true });
-        this._viewStackLayout = new ViewStackLayout();
-        this._viewStack = new St.Widget({ x_expand: true, y_expand: true,
-                                          layout_manager: this._viewStackLayout });
-        this._viewStackLayout.connect('allocated-size-changed', Lang.bind(this, this._onAllocatedSizeChanged));
-        this.actor.add_actor(this._viewStack);
-        let layout = new ControlsBoxLayout({ homogeneous: true });
-        this._controls = new St.Widget({ style_class: 'app-view-controls',
-                                         layout_manager: layout });
-        this._controls.connect('notify::mapped', Lang.bind(this,
-            function() {
-                // controls are faded either with their parent or
-                // explicitly in animate(); we can't know how they'll be
-                // shown next, so make sure to restore their opacity
-                // when they are hidden
-                if (this._controls.mapped)
-                  return;
-
-                Tweener.removeTweens(this._controls);
-                this._controls.opacity = 255;
-            }));
-
-        layout.hookup_style(this._controls);
-        this.actor.add_actor(new St.Bin({ child: this._controls }));
-
-        for (let i = 0; i < this._views.length; i++) {
-            this._viewStack.add_actor(this._views[i].view.actor);
-            this._controls.add_actor(this._views[i].control);
-
-            let viewIndex = i;
-            this._views[i].control.connect('clicked', Lang.bind(this,
-                function(actor) {
-                    this._showView(viewIndex);
-                    global.settings.set_uint('app-picker-view', viewIndex);
-                }));
-        }
-        let initialView = Math.min(global.settings.get_uint('app-picker-view'),
-                                   this._views.length - 1);
-        let frequentUseful = this._views[Views.FREQUENT].view.hasUsefulData();
-        if (initialView == Views.FREQUENT && !frequentUseful)
-            initialView = Views.ALL;
-        this._showView(initialView);
-        this._updateFrequentVisibility();
+        this.actor.add_actor(this._allView.actor);
+        this._showView();
     },
 
     animate: function(animationDirection, onComplete) {
-        let currentView = this._views[global.settings.get_uint('app-picker-view')].view;
-
-        // Animate controls opacity using iconGrid animation time, since
-        // it will be the time the AllView or FrequentView takes to show
-        // it entirely.
-        let finalOpacity;
-        if (animationDirection == IconGrid.AnimationDirection.IN) {
-            this._controls.opacity = 0;
-            finalOpacity = 255;
-        } else {
-            finalOpacity = 0
-        }
-
-        Tweener.addTween(this._controls,
-                         { time: IconGrid.ANIMATION_TIME_IN,
-                           transition: 'easeInOutQuad',
-                           opacity: finalOpacity,
-                          });
-
-        currentView.animate(animationDirection, onComplete);
+        this._allView.animate(animationDirection, onComplete);
     },
 
-    _showView: function(activeIndex) {
-        for (let i = 0; i < this._views.length; i++) {
-            if (i == activeIndex)
-                this._views[i].control.add_style_pseudo_class('checked');
-            else
-                this._views[i].control.remove_style_pseudo_class('checked');
-
-            let animationDirection = i == activeIndex ? IconGrid.AnimationDirection.IN :
-                                                        IconGrid.AnimationDirection.OUT;
-            this._views[i].view.animateSwitch(animationDirection);
-        }
-    },
-
-    _updateFrequentVisibility: function() {
-        let enabled = this._privacySettings.get_boolean('remember-app-usage');
-        this._views[Views.FREQUENT].control.visible = enabled;
-
-        let visibleViews = this._views.filter(function(v) {
-            return v.control.visible;
-        });
-        this._controls.visible = visibleViews.length > 1;
-
-        if (!enabled && this._views[Views.FREQUENT].view.actor.visible)
-            this._showView(Views.ALL);
+    _showView: function() {
+        this._allView.animateSwitch(IconGrid.AnimationDirection.IN);
     },
 
     selectApp: function(id) {
-        this._showView(Views.ALL);
-        this._views[Views.ALL].view.selectApp(id);
+        this._showView();
+        this._allView.selectApp(id);
     },
 
     _onAllocatedSizeChanged: function(actor, width, height) {
@@ -1025,11 +928,11 @@ const AppDisplay = new Lang.Class({
         box.x1 = box.y1 =0;
         box.x2 = width;
         box.y2 = height;
-        box = this._viewStack.get_theme_node().get_content_box(box);
+        box = this.actor.get_theme_node().get_content_box(box);
         let availWidth = box.x2 - box.x1;
         let availHeight = box.y2 - box.y1;
-        for (let i = 0; i < this._views.length; i++)
-            this._views[i].view.adaptToSize(availWidth, availHeight);
+
+        this._allView.adaptToSize(availWidth, availHeight);
     }
 })
 

--- a/js/ui/appDisplay.js
+++ b/js/ui/appDisplay.js
@@ -164,7 +164,6 @@ const BaseAppView = new Lang.Class({
     },
 
     loadGrid: function() {
-        this._allItems.sort(this._compareItems);
         this._allItems.forEach(Lang.bind(this, function(item) {
             this._grid.addItem(item);
         }));
@@ -468,10 +467,12 @@ const AllView = new Lang.Class({
         Shell.AppSystem.get_default().connect('installed-changed', Lang.bind(this, function() {
             Main.queueDeferredWork(this._redisplayWorkId);
         }));
-        this._folderSettings = new Gio.Settings({ schema_id: 'org.gnome.desktop.app-folders' });
-        this._folderSettings.connect('changed::folder-children', Lang.bind(this, function() {
+
+        IconGridLayout.layout.connect('changed', Lang.bind(this, function() {
             Main.queueDeferredWork(this._redisplayWorkId);
         }));
+
+        this._loadApps();
     },
 
     removeAll: function() {
@@ -490,44 +491,22 @@ const AllView = new Lang.Class({
         this._grid.addItem(item, newIdx);
     },
 
-    _refilterApps: function() {
-        this._allItems.forEach(function(icon) {
-            if (icon instanceof AppIcon)
-                icon.actor.visible = true;
-        });
-
-        this.folderIcons.forEach(Lang.bind(this, function(folder) {
-            let folderApps = folder.getAppIds();
-            folderApps.forEach(Lang.bind(this, function(appId) {
-                let appIcon = this._items[appId];
-                appIcon.actor.visible = false;
-            }));
-        }));
-    },
-
     _loadApps: function() {
-        let apps = Gio.AppInfo.get_all().filter(function(appInfo) {
-            try {
-                let id = appInfo.get_id(); // catch invalid file encodings
-            } catch(e) {
-                return false;
-            }
-            return appInfo.should_show();
-        }).map(function(app) {
-            return app.get_id();
-        });
+        let gridLayout = IconGridLayout.layout;
+        let desktopIds = gridLayout.getIcons(IconGridLayout.DESKTOP_GRID_ID);
+
+        let apps = [];
+        let folders = [];
+        for (let idx in desktopIds) {
+            let itemId = desktopIds[idx];
+            if (gridLayout.iconIsFolder(itemId))
+                folders.push(itemId);
+            else
+                apps.push(itemId);
+        }
 
         let appSys = Shell.AppSystem.get_default();
 
-        let folders = this._folderSettings.get_strv('folder-children');
-        folders.forEach(Lang.bind(this, function(id) {
-            let path = this._folderSettings.path + 'folders/' + id + '/';
-            let icon = new FolderIcon(id, path, this);
-            icon.connect('name-changed', Lang.bind(this, this._itemNameChanged));
-            icon.connect('apps-changed', Lang.bind(this, this._refilterApps));
-            this.addItem(icon);
-            this.folderIcons.push(icon);
-        }));
 
         // Allow dragging of the icon only if the Dash would accept a drop to
         // change favorite-apps. There are no other possible drop targets from
@@ -540,13 +519,21 @@ const AllView = new Lang.Class({
         apps.forEach(Lang.bind(this, function(appId) {
             let app = appSys.lookup_app(appId);
 
-            let icon = new AppIcon(app,
-                                   { isDraggable: favoritesWritable });
+            // Some apps defined by the icon grid layout might not be installed
+            if (app) {
+                let icon = new AppIcon(app, { isDraggable: favoritesWritable });
+                this.addItem(icon);
+            }
+        }));
+
+        folders.forEach(Lang.bind(this, function(id) {
+            let icon = new FolderIcon(id, this);
+            icon.connect('name-changed', Lang.bind(this, this._itemNameChanged));
             this.addItem(icon);
+            this.folderIcons.push(icon);
         }));
 
         this.loadGrid();
-        this._refilterApps();
     },
 
     // Overriden from BaseAppView
@@ -1123,8 +1110,11 @@ const FolderView = new Lang.Class({
     Name: 'FolderView',
     Extends: BaseAppView,
 
-    _init: function() {
+    _init: function(dirInfo) {
         this.parent(null, null);
+
+        this._dirInfo = dirInfo;
+
         // If it not expand, the parent doesn't take into account its preferred_width when allocating
         // the second time it allocates, so we apply the "Standard hack for ClutterBinLayout"
         this._grid.actor.x_expand = true;
@@ -1150,26 +1140,8 @@ const FolderView = new Lang.Class({
     },
 
     createFolderIcon: function(size) {
-        let layout = new Clutter.GridLayout();
-        let icon = new St.Widget({ layout_manager: layout,
-                                   style_class: 'app-folder-icon' });
-        layout.hookup_style(icon);
-        let subSize = Math.floor(FOLDER_SUBICON_FRACTION * size);
-
-        let numItems = this._allItems.length;
-        let rtl = icon.get_text_direction() == Clutter.TextDirection.RTL;
-        for (let i = 0; i < 4; i++) {
-            let bin;
-            if (i < numItems) {
-                let texture = this._allItems[i].app.create_icon_texture(subSize);
-                bin = new St.Bin({ child: texture });
-            } else {
-                bin = new St.Bin({ width: subSize, height: subSize });
-            }
-            layout.attach(bin, rtl ? (i + 1) % 2 : i % 2, Math.floor(i / 2), 1, 1);
-        }
-
-        return icon;
+        let icon = this._dirInfo.get_icon();
+        return new St.Icon({ gicon: icon });
     },
 
     _onPan: function(action) {
@@ -1238,12 +1210,12 @@ const FolderView = new Lang.Class({
 const FolderIcon = new Lang.Class({
     Name: 'FolderIcon',
 
-    _init: function(id, path, parentView) {
+    _init: function(id, parentView) {
         this.id = id;
         this._parentView = parentView;
 
-        this._folder = new Gio.Settings({ schema_id: 'org.gnome.desktop.app-folders.folder',
-                                          path: path });
+        this._dirInfo = Shell.DesktopDirInfo.new(id);
+
         this.actor = new St.Button({ style_class: 'app-well-app app-folder',
                                      button_mask: St.ButtonMask.ONE,
                                      toggle_mode: true,
@@ -1258,7 +1230,7 @@ const FolderIcon = new Lang.Class({
         this.actor.set_child(this.icon.actor);
         this.actor.label_actor = this.icon.label;
 
-        this.view = new FolderView();
+        this.view = new FolderView(this._dirInfo);
 
         this.actor.connect('clicked', Lang.bind(this,
             function() {
@@ -1272,7 +1244,6 @@ const FolderIcon = new Lang.Class({
                     this._popup.popdown();
             }));
 
-        this._folder.connect('changed', Lang.bind(this, this._redisplay));
         this._redisplay();
     },
 
@@ -1283,7 +1254,7 @@ const FolderIcon = new Lang.Class({
     },
 
     _updateName: function() {
-        let name = _getFolderName(this._folder);
+        let name = this._dirInfo.get_name();
         if (this.name == name)
             return;
 
@@ -1297,12 +1268,8 @@ const FolderIcon = new Lang.Class({
 
         this.view.removeAll();
 
-        let excludedApps = this._folder.get_strv('excluded-apps');
         let appSys = Shell.AppSystem.get_default();
         let addAppId = (function addAppId(appId) {
-            if (excludedApps.indexOf(appId) >= 0)
-                return;
-
             let app = appSys.lookup_app(appId);
             if (!app)
                 return;
@@ -1314,20 +1281,8 @@ const FolderIcon = new Lang.Class({
             this.view.addItem(icon);
         }).bind(this);
 
-        let folderApps = this._folder.get_strv('apps');
+        let folderApps = IconGridLayout.layout.getIcons(this.id);
         folderApps.forEach(addAppId);
-
-        let folderCategories = this._folder.get_strv('categories');
-        Gio.AppInfo.get_all().forEach(function(appInfo) {
-            let appCategories = _getCategories(appInfo);
-            if (!_listsIntersect(folderCategories, appCategories))
-                return;
-
-            try {
-                addAppId(appInfo.get_id()); // catch invalid file encodings
-            } catch(e) {
-            }
-        });
 
         this.actor.visible = this.view.getAllItems().length > 0;
         this.view.loadGrid();

--- a/js/ui/appDisplay.js
+++ b/js/ui/appDisplay.js
@@ -18,6 +18,7 @@ const BoxPointer = imports.ui.boxpointer;
 const DND = imports.ui.dnd;
 const GrabHelper = imports.ui.grabHelper;
 const IconGrid = imports.ui.iconGrid;
+const IconGridLayout = imports.ui.iconGridLayout;
 const Main = imports.ui.main;
 const Overview = imports.ui.overview;
 const OverviewControls = imports.ui.overviewControls;
@@ -59,6 +60,12 @@ const PAGE_SWITCH_TIME = 0.3;
 
 const VIEWS_SWITCH_TIME = 0.4;
 const VIEWS_SWITCH_ANIMATION_DELAY = 0.1;
+
+
+// Endless-specific definitions below this point
+
+const EOS_LINK_PREFIX = 'eos-link-';
+
 
 function _getCategories(info) {
     let categoriesStr = info.get_categories();
@@ -1073,11 +1080,31 @@ const AppSearchProvider = new Lang.Class({
         groups.forEach(function(group) {
             group = group.filter(function(appID) {
                 let app = Gio.DesktopAppInfo.new(appID);
+                let isLink = appID.startsWith(EOS_LINK_PREFIX);
+                let isOnDesktop = IconGridLayout.layout.hasIcon(appID);
+
+                // exclude links that are not part of the desktop grid
+                if (!(app && app.should_show() && !(isLink && !isOnDesktop)))
+                    return false;
+
                 return app && app.should_show();
             });
             results = results.concat(group.sort(function(a, b) {
                 return usage.compare('', a, b);
             }));
+        });
+
+        // resort to keep results on the desktop grid before the others
+        results = results.sort(function(a, b) {
+            let hasA = IconGridLayout.layout.hasIcon(a);
+            let hasB = IconGridLayout.layout.hasIcon(b);
+
+            if (hasA)
+                return -1;
+            if (hasB)
+                return 1;
+
+            return 0;
         });
         callback(results);
     },

--- a/js/ui/backgroundMenu.js
+++ b/js/ui/backgroundMenu.js
@@ -5,6 +5,7 @@ const Lang = imports.lang;
 const St = imports.gi.St;
 const Shell = imports.gi.Shell;
 
+const AppActivation = imports.ui.appActivation;
 const BoxPointer = imports.ui.boxpointer;
 const Main = imports.ui.main;
 const PopupMenu = imports.ui.popupMenu;
@@ -18,8 +19,20 @@ const BackgroundMenu = new Lang.Class({
 
         this.addSettingsAction(_("Change Background…"), 'gnome-background-panel.desktop');
         this.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
-        this.addSettingsAction(_("Display Settings"), 'gnome-display-panel.desktop');
-        this.addSettingsAction(_("Settings"), 'gnome-control-center.desktop');
+
+        this.addAction(_("Add App"), Lang.bind(this, function() {
+            let app = Shell.AppSystem.get_default().lookup_app('org.gnome.Software.desktop');
+            let activationContext = new AppActivation.AppActivationContext(app);
+            activationContext.activate(Clutter.get_current_event());
+        }));
+
+        this.addAction(_("Add Website"), Lang.bind(this, function() {
+            Main.appStore.showPage(global.get_current_time(), 'web');
+        }));
+
+        this.addAction(_("Add Folder"), Lang.bind(this, function() {
+            Main.appStore.showPage(global.get_current_time(), 'folders');
+        }));
 
         this.actor.add_style_class_name('background-menu');
 

--- a/js/ui/components/discoveryFeed.js
+++ b/js/ui/components/discoveryFeed.js
@@ -1,0 +1,49 @@
+// -*- mode: js; js-indent-level: 4; indent-tabs-mode: nil -*-
+
+const Lang = imports.lang;
+
+const Main = imports.ui.main;
+const SideComponent = imports.ui.sideComponent;
+
+const DISCOVERY_FEED_NAME = 'com.endlessm.DiscoveryFeed';
+const DISCOVERY_FEED_PATH = '/com/endlessm/DiscoveryFeed';
+
+const DiscoveryFeedIface = '<node> \
+<interface name="' + DISCOVERY_FEED_NAME + '"> \
+<method name="show"> \
+  <arg type="u" direction="in" name="timestamp"/> \
+</method> \
+<method name="hide"> \
+  <arg type="u" direction="in" name="timestamp"/> \
+</method> \
+<property name="Visible" type="b" access="read"/> \
+</interface> \
+</node>';
+
+const DiscoveryFeed = new Lang.Class({
+    Name: 'DiscoveryFeed',
+    Extends: SideComponent.SideComponent,
+
+    _init: function() {
+        this.parent(DiscoveryFeedIface, DISCOVERY_FEED_NAME, DISCOVERY_FEED_PATH);
+    },
+
+    enable: function() {
+        this.parent();
+        Main.discoveryFeed = this;
+    },
+
+    disable: function() {
+        this.parent();
+        Main.discoveryFeed = null;
+    },
+
+    callShow: function(timestamp) {
+        this.proxy.showRemote(timestamp);
+    },
+
+    callHide: function(timestamp) {
+        this.proxy.hideRemote(timestamp);
+    }
+});
+const Component = DiscoveryFeed;

--- a/js/ui/iconGridLayout.js
+++ b/js/ui/iconGridLayout.js
@@ -1,0 +1,439 @@
+// -*- mode: js; js-indent-level: 4; indent-tabs-mode: nil -*-
+
+const Lang = imports.lang;
+const Signals = imports.signals;
+const Gio = imports.gi.Gio;
+const GLib = imports.gi.GLib;
+const Json = imports.gi.Json;
+
+const Config = imports.misc.config;
+const EosMetrics = imports.gi.EosMetrics;
+const Main = imports.ui.main;
+const Shell = imports.gi.Shell;
+
+const DESKTOP_GRID_ID = 'desktop';
+
+const SCHEMA_KEY = 'icon-grid-layout';
+const DESKTOP_EXT = '.desktop';
+const DIRECTORY_EXT = '.directory';
+const APP_DIR_NAME = 'applications';
+const FOLDER_DIR_NAME = 'desktop-directories';
+
+const DEFAULT_CONFIGS_DIR = Config.DATADIR + '/eos-shell-content/icon-grid-defaults';
+const DEFAULT_CONFIG_NAME_BASE = 'icon-grid';
+
+const OVERRIDE_CONFIGS_DIR = Config.LOCALSTATEDIR + '/eos-image-defaults/icon-grid';
+const OVERRIDE_CONFIG_NAME_BASE = 'icon-grid';
+
+const PREPEND_CONFIGS_DIR = Config.LOCALSTATEDIR + '/eos-image-defaults/icon-grid';
+const PREPEND_CONFIG_NAME_BASE = 'icon-grid-prepend';
+
+const APPEND_CONFIGS_DIR = Config.LOCALSTATEDIR + '/eos-image-defaults/icon-grid';
+const APPEND_CONFIG_NAME_BASE = 'icon-grid-append';
+
+/* Occurs when an application is uninstalled, meaning removed from the desktop's
+ * app grid. Applications can be uninstalled in the app store or via dragging
+ * and dropping to the trash.
+ */
+const SHELL_APP_REMOVED_EVENT = '683b40a7-cac0-4f9a-994c-4b274693a0a0';
+
+const IconGridLayout = new Lang.Class({
+    Name: 'IconGridLayout',
+
+    _init: function(params) {
+        this._updateIconTree();
+
+        this._removeUndone = false;
+
+        global.settings.connect('changed::' + SCHEMA_KEY, Lang.bind(this, function() {
+            this._updateIconTree();
+            this.emit('changed');
+        }));
+    },
+
+    _getIconTreeFromVariant: function(allIcons) {
+        let iconTree = {};
+        let appSys = Shell.AppSystem.get_default();
+
+        for (let i = 0; i < allIcons.n_children(); i++) {
+            let context = allIcons.get_child_value(i);
+            let [folder, ] = context.get_child_value(0).get_string();
+            let children = context.get_child_value(1).get_strv();
+            iconTree[folder] = children.map(function(appId) {
+                // Some older versions of eos-app-store incorrectly added eos-app-*.desktop
+                // files to the icon grid layout, instead of the proper unprefixed .desktop
+                // files, which should never leak out of the Shell. Take these out of the
+                // icon layout.
+                if (appId.startsWith('eos-app-'))
+                    return appId.slice('eos-app-'.length);
+
+                // Some apps have their name superceded, for instance gedit -> org.gnome.gedit.
+                // We want the new name, not the old one.
+                let app = appSys.lookup_alias(appId);
+                if (app)
+                    return app.get_id();
+
+                return appId;
+            });
+        }
+
+        return iconTree;
+    },
+
+    _updateIconTree: function() {
+        let allIcons = global.settings.get_value(SCHEMA_KEY);
+        let nIcons = allIcons.n_children();
+        let iconTree = this._getIconTreeFromVariant(allIcons);
+
+        if (nIcons > 0 && !iconTree[DESKTOP_GRID_ID]) {
+            // Missing toplevel desktop ID indicates we are reading a
+            // corrupted setting. Reset grid to defaults, and let the logic
+            // below run after the GSettings notification
+            log('Corrupted icon-grid-layout detected, resetting to defaults');
+            global.settings.reset(SCHEMA_KEY);
+            return;
+        }
+
+        if (nIcons == 0) {
+            // Entirely empty indicates that we need to read in the defaults
+            allIcons = this._getDefaultIcons();
+            iconTree = this._getIconTreeFromVariant(allIcons);
+        }
+
+        this._iconTree = iconTree;
+    },
+
+    _loadConfigJsonString: function(dir, base) {
+        let jsonString = null;
+        let defaultFiles = GLib.get_language_names()
+            .filter(function(name) {
+                return name.indexOf('.') == -1;
+            })
+            .map(function(name) {
+                let path = GLib.build_filenamev([dir, base + '-' + name + '.json']);
+                return Gio.File.new_for_path(path);
+            })
+            .some(function(defaultsFile) {
+                try {
+                    let [success, data] = defaultsFile.load_contents(null, null,
+                                                                     null);
+                    jsonString = data.toString();
+                    return true;
+                } catch (e) {
+                    // Ignore errors, as we always have a fallback
+                }
+                return false;
+            });
+        return jsonString;
+    },
+
+    _mergeJsonStrings: function(base, override, prepend, append) {
+        let baseNode = {};
+        let prependNode = null;
+        let appendNode = null;
+        // If any image default override matches the user's locale,
+        // give that priority over the default from the base OS
+        if (override)
+            baseNode = JSON.parse(override);
+        else if (base)
+            baseNode = JSON.parse(base);
+
+        if (prepend)
+            prependNode = JSON.parse(prepend);
+
+        if (append)
+            appendNode = JSON.parse(append);
+
+        for (let key in baseNode) {
+            if (prependNode && prependNode[key])
+                baseNode[key] = prependNode[key].concat(baseNode[key]);
+
+            if (appendNode && appendNode[key])
+                baseNode[key] = baseNode[key].concat(appendNode[key]);
+        }
+        return JSON.stringify(baseNode);
+    },
+
+    _getDefaultIcons: function() {
+        let mergedJson = this._mergeJsonStrings(
+            this._loadConfigJsonString(DEFAULT_CONFIGS_DIR, DEFAULT_CONFIG_NAME_BASE),
+            this._loadConfigJsonString(OVERRIDE_CONFIGS_DIR, OVERRIDE_CONFIG_NAME_BASE),
+            this._loadConfigJsonString(PREPEND_CONFIGS_DIR, PREPEND_CONFIG_NAME_BASE),
+            this._loadConfigJsonString(APPEND_CONFIGS_DIR ,APPEND_CONFIG_NAME_BASE)
+        );
+        let iconTree = Json.gvariant_deserialize_data(mergedJson, -1, 'a{sas}');
+
+        if (iconTree === null || iconTree.n_children() == 0) {
+            log('No icon grid defaults found!');
+            // At the minimum, put in something that avoids exceptions later
+            let fallback = {};
+            fallback[DESKTOP_GRID_ID] = [];
+            iconTree = GLib.Variant.new('a{sas}', fallback);
+        }
+
+        return iconTree;
+    },
+
+    hasIcon: function(id) {
+        for (let folderId in this._iconTree) {
+            let folder = this._iconTree[folderId];
+            if (folder.indexOf(id) != -1)
+                return true;
+        }
+
+        return false;
+    },
+
+    _getIconLocation: function(id) {
+        for (let folderId in this._iconTree) {
+            let folder = this._iconTree[folderId];
+            let nIcons = folder.length;
+
+            let itemIdx = folder.indexOf(id);
+            let nextId;
+
+            if (itemIdx < nIcons) {
+                nextId = folder[itemIdx + 1];
+            } else {
+                // append to the folder
+                nextId = null;
+            }
+
+            if (itemIdx != -1)
+                return [folderId, nextId];
+        }
+        return null;
+    },
+
+    getIcons: function(folder) {
+        if (this._iconTree && this._iconTree[folder])
+            return this._iconTree[folder];
+
+        return [];
+    },
+
+    iconIsFolder: function(id) {
+        return id && (id.endsWith(DIRECTORY_EXT));
+    },
+
+    appendIcon: function(id, folderId) {
+        this.repositionIcon(id, null, folderId);
+    },
+
+    removeIcon: function(id, interactive) {
+        if (!this.hasIcon(id))
+            return;
+
+        this._removeUndone = false;
+
+        let undoInfo = null;
+        let currentLocation = this._getIconLocation(id);
+        if (currentLocation)
+            undoInfo = { id: id,
+                         folderId: currentLocation[0],
+                         insertId: currentLocation[1] };
+
+        this.repositionIcon(id, null, null);
+
+        let info = null;
+        if (this.iconIsFolder(id)) {
+            info = Shell.DesktopDirInfo.new(id);
+        } else {
+            let appSystem = Shell.AppSystem.get_default();
+            let app = appSystem.lookup_alias(id);
+            if (app)
+                info = app.get_app_info();
+        }
+
+        if (!info)
+            return;
+
+        if (interactive)
+            Main.overview.setMessage(_("%s has been deleted").format(info.get_name()),
+                                     { forFeedback: true,
+                                       destroyCallback: Lang.bind(this, this._onMessageDestroy, info),
+                                       undoCallback: Lang.bind(this, this._undoRemoveItem, undoInfo)
+                                     });
+        else
+            this._onMessageDestroy(info);
+    },
+
+    _onMessageDestroy: function(info) {
+        if (this._removeUndone) {
+            this._removeUndone = false;
+            return;
+        }
+
+        if (!this.iconIsFolder(info.get_id())) {
+            let eventRecorder = EosMetrics.EventRecorder.get_default();
+            let appId = new GLib.Variant('s', info.get_id());
+            eventRecorder.record_event(SHELL_APP_REMOVED_EVENT, appId);
+        }
+
+        let filename = info.get_filename();
+        let userDir = GLib.get_user_data_dir();
+        if (filename && userDir && GLib.str_has_prefix(filename, userDir) &&
+            info.get_string('X-Endless-CreatedBy') === 'eos-desktop') {
+            // only delete .desktop files if they are in the user's local data
+            // folder and they were created by eos-desktop
+            info.delete();
+        }
+    },
+
+    _undoRemoveItem: function(undoInfo) {
+        if (undoInfo != null)
+            this.repositionIcon(undoInfo.id, undoInfo.insertId, undoInfo.folderId);
+
+        this._removeUndone = true;
+    },
+
+    listApplications: function() {
+        let allApplications = [];
+
+        for (let folderId in this._iconTree) {
+            let folder = this._iconTree[folderId];
+            for (let iconIdx in folder) {
+                let icon = folder[iconIdx];
+                if (!this.iconIsFolder(icon))
+                    allApplications.push(icon);
+            }
+        }
+
+        return allApplications;
+    },
+
+    repositionIcon: function(id, insertId, newFolderId) {
+        let icons;
+        let existing = false;
+        let isFolder = this.iconIsFolder(id);
+
+        for (let i in this._iconTree) {
+            icons = this._iconTree[i];
+            let oldPos = icons.indexOf(id);
+            if (oldPos != -1) {
+                existing = true;
+                break;
+            }
+        }
+
+        if (newFolderId != null) {
+            // We're adding or repositioning an icon
+            icons = this._iconTree[newFolderId];
+
+            // Invalid destination folder
+            if (!icons)
+                return;
+
+            this._insertIcon(icons, id, insertId);
+
+            if (isFolder && !existing) {
+                // We're adding a folder, need to initialize an
+                // array for its contents
+                this._iconTree[id] = [];
+            }
+        } else {
+            // We're removing an entry
+            if (isFolder && existing) {
+                // We're removing a folder, need to delete the array
+                // for its contents as well
+                delete this._iconTree[id];
+            }
+        }
+
+        // Recreate GVariant from iconTree
+        let newLayout = GLib.Variant.new('a{sas}', this._iconTree);
+
+        // Store gsetting
+        global.settings.set_value(SCHEMA_KEY, newLayout);
+    },
+
+    resetDesktop: function() {
+        // Reset the gsetting to restore the default layout
+        global.settings.reset(SCHEMA_KEY);
+
+        // Remove any user-specified desktop files,
+        // to restore all default names
+        // and clean up any unused resources
+        let userPath = GLib.get_user_data_dir();
+        let userDir = Gio.File.new_for_path(userPath);
+
+        if (!userDir)
+            return;
+
+        let appDir = userDir.get_child(APP_DIR_NAME);
+        if (appDir)
+            appDir.enumerate_children_async(
+                Gio.FILE_ATTRIBUTE_STANDARD_NAME,
+                Gio.FileQueryInfoFlags.NONE,
+                GLib.PRIORITY_DEFAULT,
+                null,
+                Lang.bind(this, this._enumerateDesktopFiles));
+
+        let folderDir = userDir.get_child(FOLDER_DIR_NAME);
+        if (folderDir)
+            folderDir.enumerate_children_async(
+                Gio.FILE_ATTRIBUTE_STANDARD_NAME,
+                Gio.FileQueryInfoFlags.NONE,
+                GLib.PRIORITY_DEFAULT,
+                null,
+                Lang.bind(this, this._enumerateDirectoryFiles));
+    },
+
+    _enumerateFiles: function(file, result, removeCallback) {
+        let enumerator = file.enumerate_children_finish(result);
+        enumerator.next_files_async(
+            GLib.MAXINT32, GLib.PRIORITY_DEFAULT, null, removeCallback);
+    },
+
+    _enumerateDesktopFiles: function(file, result) {
+        this._enumerateFiles(file, result,
+                             Lang.bind(this, this._removeDesktopFiles));
+    },
+
+    _enumerateDirectoryFiles: function(file, result) {
+        this._enumerateFiles(file, result,
+                             Lang.bind(this, this._removeDirectoryFiles));
+    },
+
+    _removeFiles: function(enumerator, result, extension) {
+        let fileInfos = enumerator.next_files_finish(result);
+        for (let i = 0; i < fileInfos.length; i++) {
+            let fileInfo = fileInfos[i];
+            let fileName = fileInfo.get_name();
+            if (fileName.endsWith(extension)) {
+                let file = enumerator.get_child(fileInfo);
+                file.delete_async(GLib.PRIORITY_DEFAULT, null, null);
+            }
+        }
+    },
+
+    _removeDesktopFiles: function(enumerator, result) {
+        this._removeFiles(enumerator, result, DESKTOP_EXT);
+    },
+
+    _removeDirectoryFiles: function(enumerator, result) {
+        this._removeFiles(enumerator, result, DIRECTORY_EXT);
+    },
+
+    // We use the insert Id instead of the index here since gsettings
+    // includes the full application list that the desktop may have.
+    // Relying on the position leads to faulty behaviour if some
+    // apps are not present on the system
+    _insertIcon: function(icons, id, insertId) {
+        let insertIdx = -1;
+
+        if (insertId != null)
+            insertIdx = icons.indexOf(insertId);
+
+        // We were dropped to the left of the trashcan,
+        // or we were asked to append
+        if (insertIdx == -1)
+            insertIdx = icons.length;
+
+        icons.splice(insertIdx, 0, id);
+    }
+});
+Signals.addSignalMethods(IconGridLayout.prototype);
+
+// to be used as singleton
+const layout = new IconGridLayout();

--- a/js/ui/internetSearch.js
+++ b/js/ui/internetSearch.js
@@ -1,0 +1,136 @@
+// -*- mode: js; js-indent-level: 4; indent-tabs-mode: nil -*-
+
+const GLib = imports.gi.GLib;
+const Gio = imports.gi.Gio;
+const Lang = imports.lang;
+
+const Main = imports.ui.main;
+const Util = imports.misc.util;
+
+// Returns a plain URI if the user types in
+// something like "facebook.com"
+function getURIForSearch(terms) {
+    let searchedUris = Util.findSearchUrls(terms);
+    // Make sure search contains only a uri
+    // Avoid cases like "what is github.com"
+    if (searchedUris.length == 1 && terms.length == 1) {
+        let uri = searchedUris[0];
+        // Ensure all uri has a scheme name
+        if (!GLib.uri_parse_scheme(uri))
+            uri = 'http://' + uri;
+
+        return uri;
+    } else {
+        return null;
+    }
+}
+
+function getInternetSearchProvider() {
+    let browserApp = Util.getBrowserApp();
+    if (browserApp)
+        return new InternetSearchProvider(browserApp);
+
+    return null;
+}
+
+const InternetSearchProvider = new Lang.Class({
+    Name: 'InternetSearchProvider',
+
+    _init: function(browserApp) {
+        this.id = 'internet';
+        this.appInfo = browserApp.get_app_info();
+        this.canLaunchSearch = true;
+
+        this._engineNameParsed = false;
+        this._engineName = null;
+
+        this._networkMonitor = Gio.NetworkMonitor.get_default();
+    },
+
+    _getEngineName: function() {
+        if (!this._engineNameParsed) {
+            this._engineNameParsed = true;
+            this._engineName = Util.getSearchEngineName();
+        }
+
+        return this._engineName;
+    },
+
+    _launchURI: function(uri) {
+        try {
+            this.appInfo.launch_uris([uri], null);
+        } catch (e) {
+            logError(e, 'error while launching browser for uri: ' + uri);
+        }
+    },
+
+    getResultMetas: function(results, callback) {
+        let metas = results.map(Lang.bind(this, function(resultId) {
+            let name;
+            if (resultId.startsWith('uri:')) {
+                let uri = resultId.slice('uri:'.length);
+                name = _("Open \"%s\" in browser").format(uri);
+            } else if (resultId.startsWith('search:')) {
+                let query = resultId.slice('search:'.length);
+                let engineName = this._getEngineName();
+
+                if (engineName) {
+                    /* Translators: the first %s is the search engine name, and the second
+                     * is the search string. For instance, 'Search Google for "hello"'.
+                     */
+                    name = _("Search %s for \"%s\"").format(engineName, query);
+                } else {
+                    name = _("Search the internet for \"%s\"").format(query);
+                }
+            }
+
+            return { id: resultId,
+                     name: name,
+                     // We will already have an app icon next to our result,
+                     // so we don't need an individual result icon.
+                     createIcon: function() { return null; } };
+        }));
+        callback(metas);
+    },
+
+    filterResults: function(results, maxNumber) {
+        return results.slice(0, maxNumber);
+    },
+
+    getInitialResultSet: function(terms, callback, cancellable) {
+        let results = [];
+
+        if (this._networkMonitor.network_available) {
+            let uri = getURIForSearch(terms);
+            let query = terms.join(' ');
+            if (uri)
+                results.push('uri:' + query);
+            else
+                results.push('search:' + query);
+        }
+
+        callback(results);
+    },
+
+    getSubsearchResultSet: function(previousResults, terms, callback, cancellable) {
+        this.getInitialResultSet(terms, callback, cancellable);
+    },
+
+    activateResult: function(metaId) {
+        if (metaId.startsWith('uri:')) {
+            let uri = metaId.slice('uri:'.length);
+            uri = getURIForSearch([uri]);
+            this._launchURI(uri);
+        } else if (metaId.startsWith('search:')) {
+            let query = metaId.slice('search:'.length);
+            this._launchURI('? '.concat(query));
+        }
+    },
+
+    launchSearch: function(terms) {
+        this.getInitialResultSet(terms, Lang.bind(this, function(results) {
+            if (results)
+                this.activateResult(results[0]);
+        }));
+    },
+});

--- a/js/ui/layout.js
+++ b/js/ui/layout.js
@@ -69,6 +69,7 @@ const LayoutManager = new Lang.Class({
         this._inOverview = false;
         this._updateRegionIdle = 0;
 
+        this._overlayRegion = null;
         this._trackedActors = [];
         this._topActors = [];
         this._isPopupWindowVisible = false;
@@ -674,6 +675,11 @@ const LayoutManager = new Lang.Class({
         this._trackActor(actor, params);
     },
 
+    setOverlayRegion: function(region) {
+        this._overlayRegion = region;
+        this._queueUpdateRegions();
+    },
+
     // trackChrome:
     // @actor: a descendant of the chrome to begin tracking
     // @params: parameters describing how to track @actor
@@ -922,6 +928,18 @@ const LayoutManager = new Lang.Class({
                 let strutRect = new Meta.Rectangle({ x: x1, y: y1, width: x2 - x1, height: y2 - y1});
                 let strut = new Meta.Strut({ rect: strutRect, side: side });
                 struts.push(strut);
+            }
+        }
+
+        if (this._overlayRegion != null) {
+            let numOverlayRects = this._overlayRegion.numRectangles();
+            for (let idx = 0; idx < numOverlayRects; idx++) {
+                let rect = this._overlayRegion.getRectangle(idx);
+                let metaRect = new Meta.Rectangle({ x: rect.x,
+                                                    y: rect.y,
+                                                    width: rect.width,
+                                                    height: rect.height });
+                rects.push(metaRect);
             }
         }
 

--- a/js/ui/main.js
+++ b/js/ui/main.js
@@ -42,6 +42,7 @@ const SessionMode = imports.ui.sessionMode;
 const ShellDBus = imports.ui.shellDBus;
 const ShellMountOperation = imports.ui.shellMountOperation;
 const WindowManager = imports.ui.windowManager;
+const WorkspaceMonitor = imports.ui.workspaceMonitor;
 const Magnifier = imports.ui.magnifier;
 const XdndHandler = imports.ui.xdndHandler;
 const Util = imports.misc.util;
@@ -80,6 +81,7 @@ let xdndHandler = null;
 let keyboard = null;
 let layoutManager = null;
 let desktopAppClient = null;
+let workspaceMonitor = null;
 let _startDate;
 let _defaultCssStylesheet = null;
 let _cssStylesheet = null;
@@ -177,8 +179,14 @@ function _initializeUI() {
     componentManager = new Components.ComponentManager();
     desktopAppClient = new AppActivation.DesktopAppClient();
 
+    /*
+     * Since workspaceMonitor expects layoutManager to be ready, initialize it
+     * before workspaceMonitor
+     */
     layoutManager.init();
     overview.init();
+
+    workspaceMonitor = new WorkspaceMonitor.WorkspaceMonitor();
 
     _a11ySettings = new Gio.Settings({ schema_id: A11Y_SCHEMA });
 

--- a/js/ui/main.js
+++ b/js/ui/main.js
@@ -82,6 +82,7 @@ let keyboard = null;
 let layoutManager = null;
 let desktopAppClient = null;
 let workspaceMonitor = null;
+let discoveryFeed = null;
 let _startDate;
 let _defaultCssStylesheet = null;
 let _cssStylesheet = null;

--- a/js/ui/panel.js
+++ b/js/ui/panel.js
@@ -936,8 +936,8 @@ const Panel = new Lang.Class({
             childBox.x2 = allocWidth;
         } else {
             childBox.x1 = 0;
-            childBox.x2 = Math.min(Math.floor(sideWidth),
-                                   leftNaturalWidth);
+            childBox.x2 = Math.max(0, Math.min(Math.floor(sideWidth),
+                                               leftNaturalWidth));
         }
         this._leftBox.allocate(childBox, flags);
 

--- a/js/ui/search.js
+++ b/js/ui/search.js
@@ -14,6 +14,7 @@ const Atk = imports.gi.Atk;
 const AppDisplay = imports.ui.appDisplay;
 const DND = imports.ui.dnd;
 const IconGrid = imports.ui.iconGrid;
+const InternetSearch = imports.ui.internetSearch;
 const Main = imports.ui.main;
 const Overview = imports.ui.overview;
 const RemoteSearch = imports.ui.remoteSearch;
@@ -425,6 +426,11 @@ const SearchResults = new Lang.Class({
         this._cancellable = new Gio.Cancellable();
 
         this._registerProvider(new AppDisplay.AppSearchProvider());
+
+        this._internetProvider = InternetSearch.getInternetSearchProvider();
+        if (this._internetProvider)
+            this._registerProvider(this._internetProvider);
+
         this._reloadRemoteProviders();
     },
 

--- a/js/ui/sessionMode.js
+++ b/js/ui/sessionMode.js
@@ -97,9 +97,11 @@ const _modes = {
         unlockDialog: imports.ui.unlockDialog.UnlockDialog,
         components: Config.HAVE_NETWORKMANAGER ?
                     ['networkAgent', 'polkitAgent',
-                     'keyring', 'autorunManager', 'automountManager'] :
+                     'keyring', 'autorunManager', 'automountManager',
+                     'discoveryFeed'] :
                     ['polkitAgent',
-                     'keyring', 'autorunManager', 'automountManager'],
+                     'keyring', 'autorunManager', 'automountManager',
+                     'discoveryFeed'],
 
         panel: {
             left: ['endlessButton', 'appIcons'],

--- a/js/ui/shellEntry.js
+++ b/js/ui/shellEntry.js
@@ -1,21 +1,34 @@
 // -*- mode: js; js-indent-level: 4; indent-tabs-mode: nil -*-
 
 const Clutter = imports.gi.Clutter;
+const Gio = imports.gi.Gio;
+const GObject = imports.gi.GObject;
 const Gtk = imports.gi.Gtk;
 const Lang = imports.lang;
 const St = imports.gi.St;
 
+const Animation = imports.ui.animation;
 const BoxPointer = imports.ui.boxpointer;
 const Main = imports.ui.main;
+const Panel = imports.ui.panel;
 const Params = imports.misc.params;
 const PopupMenu = imports.ui.popupMenu;
+
+const Tweener = imports.ui.tweener;
+const Util = imports.misc.util;
+
+const SPINNER_ICON_SIZE = 24;
+const SPINNER_MIN_DURATION = 1000;
+
+const OVERVIEW_ENTRY_BLINK_DURATION = 0.4;
+const OVERVIEW_ENTRY_BLINK_BRIGHTNESS = 1.4;
 
 const EntryMenu = new Lang.Class({
     Name: 'ShellEntryMenu',
     Extends: PopupMenu.PopupMenu,
 
     _init: function(entry) {
-        this.parent(entry, 0, St.Side.TOP);
+        this.parent(entry, 0.025, St.Side.BOTTOM);
 
         this._entry = entry;
         this._clipboard = St.Clipboard.get_default();
@@ -118,6 +131,296 @@ const EntryMenu = new Lang.Class({
     _onPasswordActivated: function() {
         let visible = !!(this._entry.clutter_text.password_char);
         this._entry.clutter_text.set_password_char(visible ? '' : '\u25cf');
+    }
+});
+
+const OverviewEntry = new Lang.Class({
+    Name: 'OverviewEntry',
+    Extends: St.Entry,
+    Signals: {
+        'search-activated': { },
+        'search-active-changed': { },
+        'search-navigate-focus': { param_types: [GObject.TYPE_INT] },
+        'search-terms-changed': { }
+    },
+
+    _init: function() {
+        this._active = false;
+
+        this._capturedEventId = 0;
+
+        let primaryIcon = new St.Icon({ icon_name: 'edit-find-symbolic',
+                                        style_class: 'search-icon',
+                                        icon_size: 16,
+                                        track_hover: true });
+
+        let iconFile = Gio.File.new_for_uri('resource:///org/gnome/shell/theme/process-working-dark.svg')
+        this._spinnerAnimation = new Animation.AnimatedIcon(iconFile, SPINNER_ICON_SIZE);
+        this._spinnerAnimation.actor.hide();
+
+        // Set the search entry's text based on the current search engine
+        let entryText;
+        let searchEngine = Util.getSearchEngineName();
+
+        if (searchEngine != null)
+            entryText = _("Search %s and more…").format(searchEngine);
+        else
+            entryText = _("Search the internet and more…");
+
+        let hintActor = new St.Label({ text: entryText,
+                                       style_class: 'search-entry-text-hint' });
+
+        this.parent({ name: 'searchEntry',
+                      track_hover: true,
+                      reactive: true,
+                      can_focus: true,
+                      hint_text: '',
+                      hint_actor: hintActor,
+                      primary_icon: primaryIcon,
+                      secondary_icon: this._spinnerAnimation.actor,
+                      x_align: Clutter.ActorAlign.CENTER,
+                      y_align: Clutter.ActorAlign.CENTER });
+
+        this._blinkBrightnessEffect = new Clutter.BrightnessContrastEffect({
+            enabled: false,
+        });
+        this.add_effect(this._blinkBrightnessEffect);
+
+        addContextMenu(this);
+
+        this.connect('primary-icon-clicked', Lang.bind(this, function() {
+            this.grab_key_focus();
+        }));
+        this.connect('notify::mapped', Lang.bind(this, this._onMapped));
+        this.clutter_text.connect('key-press-event', Lang.bind(this, this._onKeyPress));
+        this.clutter_text.connect('text-changed', Lang.bind(this, this._onTextChanged));
+        global.stage.connect('notify::key-focus', Lang.bind(this, this._onStageKeyFocusChanged));
+    },
+
+    _isActivated: function() {
+        return !this.hint_actor.visible;
+    },
+
+    _getTermsForSearchString: function(searchString) {
+        searchString = searchString.replace(/^\s+/g, '').replace(/\s+$/g, '');
+        if (searchString == '')
+            return [];
+
+        let terms = searchString.split(/\s+/);
+        return terms;
+    },
+
+    _onCapturedEvent: function(actor, event) {
+        if (event.type() != Clutter.EventType.BUTTON_PRESS)
+            return false;
+
+        let source = event.get_source();
+        if (source != this.clutter_text &&
+            !Main.layoutManager.keyboardBox.contains(source)) {
+            // If the user clicked outside after activating the entry,
+            // drop the focus from the search bar, but avoid resetting
+            // the entry state.
+            // If no search terms entered were entered, also reset the
+            // entry to its initial state.
+            if (this.clutter_text.text == '')
+                this.resetSearch();
+            else
+                this._stopSearch();
+        }
+
+        return false;
+    },
+
+    _onKeyPress: function(entry, event) {
+        let symbol = event.get_key_symbol();
+        if (symbol == Clutter.Escape && this._isActivated()) {
+            this.resetSearch();
+            return true;
+        }
+
+        if (!this.active)
+            return false;
+
+        let arrowNext, nextDirection;
+        if (entry.get_text_direction() == Clutter.TextDirection.RTL) {
+            arrowNext = Clutter.Left;
+            nextDirection = Gtk.DirectionType.LEFT;
+        } else {
+            arrowNext = Clutter.Right;
+            nextDirection = Gtk.DirectionType.RIGHT;
+        }
+
+        if (symbol == Clutter.Down)
+            nextDirection = Gtk.DirectionType.DOWN;
+
+        if ((symbol == arrowNext && this.clutter_text.position == -1) ||
+            (symbol == Clutter.Down)) {
+            this.emit('search-navigate-focus', nextDirection);
+            return true;
+        } else if (symbol == Clutter.Return || symbol == Clutter.KP_Enter) {
+            this._activateSearch();
+            return true;
+        }
+
+        return false;
+    },
+
+    _onMapped: function() {
+        if (this.mapped) {
+            // Enable 'find-as-you-type'
+            this._capturedEventId = global.stage.connect('captured-event',
+                                 Lang.bind(this, this._onCapturedEvent));
+
+            this.clutter_text.set_cursor_visible(true);
+            // Move the cursor at the end of the current text
+            let buffer = this.clutter_text.get_buffer();
+            let nChars = buffer.get_length();
+            this.clutter_text.set_selection(nChars, nChars);
+        } else {
+            // Disable 'find-as-you-type'
+            if (this._capturedEventId > 0) {
+                global.stage.disconnect(this._capturedEventId);
+                this._capturedEventId = 0;
+            }
+        }
+    },
+
+    _onStageKeyFocusChanged: function() {
+        let focus = global.stage.get_key_focus();
+        let appearFocused = this.contains(focus);
+
+        this.clutter_text.set_cursor_visible(appearFocused);
+
+        if (appearFocused)
+            this.add_style_pseudo_class('focus');
+        else
+            this.remove_style_pseudo_class('focus');
+    },
+
+    _onTextChanged: function (se, prop) {
+        this.emit('search-terms-changed');
+        let terms = this._getTermsForSearchString(this.get_text());
+        this.active = (terms.length > 0);
+    },
+
+    _searchCancelled: function() {
+        // Leave the entry focused when it doesn't have any text;
+        // when replacing a selected search term, Clutter emits
+        // two 'text-changed' signals, one for deleting the previous
+        // text and one for the new one - the second one is handled
+        // incorrectly when we remove focus
+        // (https://bugzilla.gnome.org/show_bug.cgi?id=636341) */
+        if (this.clutter_text.text != '')
+            this.resetSearch();
+    },
+
+    _shouldTriggerSearch: function(symbol) {
+        let unicode = Clutter.keysym_to_unicode(symbol);
+        if (unicode == 0)
+            return symbol == Clutter.BackSpace && this.active;
+
+        return this._getTermsForSearchString(String.fromCharCode(unicode)).length > 0;
+    },
+
+    _activateSearch: function() {
+        this.emit('search-activated');
+    },
+
+    _stopSearch: function() {
+        global.stage.set_key_focus(null);
+    },
+
+    _startSearch: function(event) {
+        global.stage.set_key_focus(this.clutter_text);
+        this.clutter_text.event(event, false);
+    },
+
+    resetSearch: function () {
+        this._stopSearch();
+        this.text = '';
+
+        this.clutter_text.set_cursor_visible(true);
+        this.clutter_text.set_selection(0, 0);
+    },
+
+    handleStageEvent: function(event) {
+        let symbol = event.get_key_symbol();
+
+        if (symbol == Clutter.Escape && this.active) {
+            this.resetSearch();
+            return true;
+        }
+
+        if (this._shouldTriggerSearch(symbol)) {
+            this._startSearch(event);
+            return true;
+        }
+
+        return false;
+    },
+
+    setSpinning: function(visible) {
+        if (visible) {
+            this._spinnerAnimation.play();
+            this._spinnerAnimation.actor.show();
+        } else {
+            this._spinnerAnimation.stop();
+            this._spinnerAnimation.actor.hide();
+        }
+    },
+
+    get blinkBrightness() {
+        return this._blinkBrightness;
+    },
+
+    set blinkBrightness(v) {
+        this._blinkBrightness = v;
+        this._blinkBrightnessEffect.enabled = this._blinkBrightness !== 1;
+        let colorval = this._blinkBrightness * 127;
+        this._blinkBrightnessEffect.brightness = new Clutter.Color({
+            red: colorval,
+            green: colorval,
+            blue: colorval,
+        });
+    },
+
+    blink: function() {
+        let tweenBack = function () {
+            Tweener.addTween(this,
+                             { blinkBrightness: 1,
+                               transition: 'easeOutQuad',
+                               time: OVERVIEW_ENTRY_BLINK_DURATION / 2,
+                             });
+        };
+        this.blinkBrightness = 1;
+        Tweener.addTween(this,
+                         { blinkBrightness: OVERVIEW_ENTRY_BLINK_BRIGHTNESS,
+                           transition: 'easeOutQuad',
+                           time: OVERVIEW_ENTRY_BLINK_DURATION / 2,
+                           onComplete: tweenBack,
+                         });
+
+    },
+
+    set active(value) {
+        if (value == this._active)
+            return;
+
+        this._active = value;
+        this._ongoing = false;
+
+        if (!this._active)
+            this._searchCancelled();
+
+        this.emit('search-active-changed');
+    },
+
+    get active() {
+        return this._active;
+    },
+
+    getSearchTerms: function() {
+        return this._getTermsForSearchString(this.get_text());
     }
 });
 

--- a/js/ui/sideComponent.js
+++ b/js/ui/sideComponent.js
@@ -26,7 +26,8 @@ function isSideComponentWindow (metaWindow) {
  * @return: whether other windows should be hidden while this one is open
  */
 function shouldHideOtherWindows (metaWindow) {
-    return isSideComponentWindow(metaWindow);
+    return isSideComponentWindow(metaWindow) &&
+        Main.discoveryFeed.launchedFromDesktop;
 };
 
 /**

--- a/js/ui/sideComponent.js
+++ b/js/ui/sideComponent.js
@@ -1,0 +1,163 @@
+// -*- mode: js; js-indent-level: 4; indent-tabs-mode: nil -*-
+
+const GObject = imports.gi.GObject;
+const GLib = imports.gi.GLib;
+const Gio = imports.gi.Gio;
+const Lang = imports.lang;
+const Meta = imports.gi.Meta;
+
+const Main = imports.ui.main;
+const ViewSelector = imports.ui.viewSelector;
+
+const SIDE_COMPONENT_ROLE = 'eos-side-component';
+
+/**
+ * isSideComponentWindow:
+ * @metaWindow: an instance of #Meta.Window
+ * @return: whether the #Meta.Window belongs to a #SideComponent 
+ */
+function isSideComponentWindow (metaWindow) {
+    return metaWindow && (metaWindow.get_role() == SIDE_COMPONENT_ROLE);
+};
+
+/**
+ * shouldHideOtherWindows:
+ * @metaWindow: an instance of #Meta.Window
+ * @return: whether other windows should be hidden while this one is open
+ */
+function shouldHideOtherWindows (metaWindow) {
+    return isSideComponentWindow(metaWindow);
+};
+
+/**
+ * launchedFromDesktop:
+ * @metaWindow: an instance of #Meta.Window
+ * @return: whether the side component was launched from the desktop
+ */
+function launchedFromDesktop (metaWindow) {
+    return false;
+};
+
+/**
+ * isDiscoveryFeedWindow:
+ * @metaWindow: an instance of #Meta.Window
+ * @return: whether the #Meta.Window is from the DiscoveryFeed application
+ */
+function isDiscoveryFeedWindow (metaWindow) {
+    return metaWindow && (metaWindow.get_wm_class() == 'Com.endlessm.DiscoveryFeed');
+};
+
+const SideComponent = new Lang.Class({
+    Name: 'SideComponent',
+    Extends: GObject.Object,
+
+    _init: function(proxyIface, proxyName, proxyPath) {
+        this.parent();
+        this._propertiesChangedId = 0;
+        this._desktopShownId = 0;
+
+        this._proxyIface = proxyIface;
+        this._proxyInfo = Gio.DBusInterfaceInfo.new_for_xml(this._proxyIface);
+        this._proxyName = proxyName;
+        this._proxyPath = proxyPath;
+
+        this._visible = false;
+        this._launchedFromDesktop = false;
+    },
+
+    enable: function() {
+        if (!this.proxy) {
+            this.proxy = new Gio.DBusProxy({ g_connection: Gio.DBus.session,
+                                             g_interface_name: this._proxyInfo.name,
+                                             g_interface_info: this._proxyInfo,
+                                             g_name: this._proxyName,
+                                             g_object_path: this._proxyPath,
+                                             g_flags: Gio.DBusProxyFlags.DO_NOT_AUTO_START_AT_CONSTRUCTION });
+            this.proxy.init_async(GLib.PRIORITY_DEFAULT, null, Lang.bind(this, this._onProxyConstructed));
+        }
+
+        this._propertiesChangedId =
+            this.proxy.connect('g-properties-changed', Lang.bind(this, this._onPropertiesChanged));
+
+        // Clicking the background (which calls overview.showApps) hides the component,
+        // so trying to open it again will call WindowManager._mapWindow(),
+        // which will hide the overview and animate the window.
+        // Note that this is not the case when opening the window picker.
+        this._desktopShownId = Main.layoutManager.connect('background-clicked', Lang.bind(this, function() {
+            if (this._visible)
+                this.hide(global.get_current_time());
+        }));
+
+        // Same when clicking the background from the window picker.
+        this._overviewPageChangedId = Main.overview.connect('page-changed', Lang.bind(this, function() {
+            if (this._visible && Main.overview.visible &&
+                Main.overview.getActivePage() == ViewSelector.ViewPage.APPS)
+                this.hide(global.get_current_time());
+        }));
+    },
+
+    disable: function() {
+        if (this._propertiesChangedId > 0) {
+            this.proxy.disconnect(this._propertiesChangedId);
+            this._propertiesChangedId = 0;
+        }
+
+        if (this._desktopShownId > 0) {
+            Main.layoutManager.disconnect(this._desktopShownId);
+            this._desktopShownId = 0;
+        }
+
+        if (this._overviewPageChangedId > 0) {
+            Main.overview.disconnect(this._overviewPageChangedId);
+            this._overviewPageChangedId = 0;
+        }
+    },
+
+    _onProxyConstructed: function(object, res) {
+        try {
+            object.init_finish(res);
+        } catch (e) {
+            logError(e, 'Error while constructing the DBus proxy for ' + this._proxyName);
+        }
+    },
+
+    _onPropertiesChanged: function(proxy, changedProps, invalidatedProps) {
+        let propsDict = changedProps.deep_unpack();
+        if (propsDict.hasOwnProperty('Visible'))
+            this._onVisibilityChanged();
+    },
+
+    _onVisibilityChanged: function() {
+        if (this._visible == this.proxy.Visible)
+            return;
+
+        // resync visibility
+        this._visible = this.proxy.Visible;
+    },
+
+    toggle: function(timestamp, params) {
+        if (this._visible)
+            this.hide(timestamp, params);
+        else
+            this.show(timestamp, params);
+    },
+
+    show: function(timestamp, params) {
+        this._launchedFromDesktop = Main.overview.visible &&
+                                    Main.overview.getActivePage() == ViewSelector.ViewPage.APPS;
+
+        if (this._visible && Main.overview.visible)
+            // the component is already open, but obscured by the overview
+            Main.overview.hide();
+        else
+            this.callShow(timestamp, params);
+    },
+
+    hide: function(timestamp, params) {
+        this.callHide(timestamp, params);
+    },
+
+    get launchedFromDesktop() {
+        return this._launchedFromDesktop;
+    }
+});

--- a/js/ui/windowManager.js
+++ b/js/ui/windowManager.js
@@ -1,5 +1,6 @@
 // -*- mode: js; js-indent-level: 4; indent-tabs-mode: nil -*-
 
+const Cairo = imports.cairo;
 const Clutter = imports.gi.Clutter;
 const GLib = imports.gi.GLib;
 const Gio = imports.gi.Gio;
@@ -16,6 +17,8 @@ const ForceAppExitDialog = imports.ui.forceAppExitDialog;
 const WorkspaceSwitcherPopup = imports.ui.workspaceSwitcherPopup;
 const Main = imports.ui.main;
 const ModalDialog = imports.ui.modalDialog;
+const SideComponent = imports.ui.sideComponent;
+const BackgroundMenu = imports.ui.backgroundMenu;
 const Tweener = imports.ui.tweener;
 const WindowMenu = imports.ui.windowMenu;
 
@@ -670,6 +673,248 @@ const ResizePopup = new Lang.Class({
     },
 });
 
+const DesktopOverlay = new Lang.Class({
+    Name: 'DesktopOverlay',
+    Extends: St.Widget,
+
+    Signals: {
+        'clicked': {},
+    },
+
+    _init: function() {
+        this.parent({ reactive: true });
+
+        this._shellwm = global.window_manager;
+
+        this._actorDestroyId = 0;
+        this._allocationId = 0;
+        this._destroyId = 0;
+        this._mapId = 0;
+        this._visibleId = 0;
+        this._showing = false;
+
+        this._overlayActor = null;
+        this._transientActors = [];
+
+        let action = new Clutter.ClickAction();
+        action.connect('clicked', Lang.bind(this, function(action) {
+            if (action.get_button() != Gdk.BUTTON_PRIMARY)
+                return;
+
+            if (this._showing && this._overlayActor)
+                this.emit('clicked');
+        }));
+        this.add_action(action);
+        BackgroundMenu.addBackgroundMenu(this, Main.layoutManager);
+
+        Main.overview.connect('showing', Lang.bind(this, function() {
+            // hide the overlay so it doesn't conflict with the desktop
+            if (this._showing)
+                this.hide();
+        }));
+        Main.overview.connect('hiding', Lang.bind(this, function() {
+            // show the overlay if needed
+            if (this._showing)
+                this.show();
+        }));
+
+        Main.uiGroup.add_actor(this);
+        if (Main.uiGroup.contains(global.top_window_group))
+            Main.uiGroup.set_child_below_sibling(this, global.top_window_group);
+    },
+
+    _rebuildRegion: function() {
+        if (!this._overlayActor.get_paint_visibility()) {
+            Main.layoutManager.setOverlayRegion(null);
+            return;
+        }
+
+        let overlayWindow = this._overlayActor.meta_window;
+        let monitorIdx = overlayWindow.get_monitor();
+        let monitor = Main.layoutManager.monitors[monitorIdx];
+        if (!monitor)
+            return;
+
+        let workArea = Main.layoutManager.getWorkAreaForMonitor(overlayWindow.get_monitor());
+        let region = new Cairo.Region();
+        region.unionRectangle(workArea);
+
+        let [x, y] = this._overlayActor.get_transformed_position();
+        let [width, height] = this._overlayActor.get_transformed_size();
+        let rect = { x: Math.round(x), y: Math.round(y),
+                     width: Math.round(width), height: Math.round(height) };
+
+        region.subtractRectangle(rect);
+
+        this._transientActors.forEach(Lang.bind(this, function(actorData) {
+            let transientActor = actorData.actor;
+
+            let [x, y] = transientActor.get_transformed_position();
+            let [width, height] = transientActor.get_transformed_size();
+            let rect = { x: Math.round(x), y: Math.round(y),
+                         width: Math.round(width), height: Math.round(height) };
+
+            region.subtractRectangle(rect);
+        }));
+
+        Main.layoutManager.setOverlayRegion(region);
+    },
+
+    _findTransientActor: function(actor) {
+        for (let i = 0; i < this._transientActors.length; i++) {
+            let actorData = this._transientActors[i];
+            if (actorData.actor == actor)
+                return i;
+        }
+        return -1;
+    },
+
+    _untrackTransientActor: function(actor) {
+        let idx = this._findTransientActor(actor);
+        if (idx == -1) {
+            log('Trying to untrack a non-tracked transient actor!');
+            return;
+        }
+
+        let actorData = this._transientActors[idx];
+        this._transientActors.splice(idx, 1);
+
+        actor.disconnect(actorData.visibleId);
+        actor.disconnect(actorData.allocationId);
+        actor.disconnect(actorData.destroyId);
+
+        this._rebuildRegion();
+    },
+
+    _trackTransientActor: function(actor) {
+        if (this._findTransientActor(actor) != -1) {
+            log('Trying to track twice the same transient actor!');
+            return;
+        }
+
+        let actorData = {};
+        actorData.actor = actor;
+        actorData.visibleId = actor.connect('notify::visible',
+                                            Lang.bind(this, this._rebuildRegion));
+        actorData.allocationId = actor.connect('notify::allocation',
+                                               Lang.bind(this, this._rebuildRegion));
+        actorData.destroyId = actor.connect('destroy',
+                                            Lang.bind(this, this._untrackTransientActor));
+
+        this._transientActors.push(actorData);
+        this._rebuildRegion();
+    },
+
+    _untrackActor: function() {
+        this._transientActors.forEach(Lang.bind(this, function(actorData) {
+            this._untrackTransientActor(actorData.actor);
+        }));
+        this._transientActors = [];
+
+        if (this._visibleId > 0) {
+            this._overlayActor.disconnect(this._visibleId);
+            this._visibleId = 0;
+        }
+
+        if (this._allocationId > 0) {
+            this._overlayActor.disconnect(this._allocationId);
+            this._allocationId = 0;
+        }
+
+        if (this._actorDestroyId > 0) {
+            this._overlayActor.disconnect(this._actorDestroyId);
+            this._actorDestroyId = 0;
+        }
+
+        if (this._destroyId > 0) {
+            this._shellwm.disconnect(this._destroyId);
+            this._destroyId = 0;
+        }
+
+        if (this._mapId > 0) {
+            this._shellwm.disconnect(this._mapId);
+            this._mapId = 0;
+        }
+
+        Main.layoutManager.setOverlayRegion(null);
+    },
+
+    _trackActor: function() {
+        let overlayWindow = this._overlayActor.meta_window;
+        let monitorIdx = overlayWindow.get_monitor();
+        let monitor = Main.layoutManager.monitors[monitorIdx];
+        if (!monitor)
+            return;
+
+        // cover other windows with an invisible overlay at the side of the SideComponent
+        let workArea = Main.layoutManager.getWorkAreaForMonitor(monitorIdx);
+        this.width = monitor.width - this._overlayActor.width;
+        this.height = workArea.height;
+        this.y = this._overlayActor.y;
+
+        if (this._overlayActor.x <= monitor.x)
+            this.x = monitor.x + monitor.width - this.width;
+        else
+            this.x = monitor.x;
+
+        this._visibleId = this._overlayActor.connect('notify::visible',
+                                                     Lang.bind(this, this._rebuildRegion));
+        this._allocationId = this._overlayActor.connect('notify::allocation',
+                                                        Lang.bind(this, this._rebuildRegion));
+        this._actorDestroyId = this._overlayActor.connect('destroy',
+                                                          Lang.bind(this, this._untrackActor));
+
+        this._mapId = this._shellwm.connect('map', Lang.bind(this, function(shellwm, actor) {
+            let newWindow = actor.meta_window;
+            if (overlayWindow.is_ancestor_of_transient(newWindow))
+                this._trackTransientActor(actor);
+        }));
+        this._destroyId = this._shellwm.connect('destroy', Lang.bind(this, function(shellwm, actor) {
+            let destroyedWindow = actor.meta_window;
+            if (overlayWindow.is_ancestor_of_transient(destroyedWindow))
+                this._untrackTransientActor(actor);
+        }));
+
+        // seed the transient actors
+        overlayWindow.foreach_transient(Lang.bind(this, function(transientWindow) {
+            let transientActor = overlayWindow.get_compositor_private();
+            if (transientActor != null)
+                this._trackTransientActor(transientActor);
+        }));
+
+        this._rebuildRegion();
+    },
+
+    _setOverlayActor: function(actor) {
+        if (actor == this._overlayActor)
+            return;
+
+        this._untrackActor();
+        this._overlayActor = actor;
+
+        if (this._overlayActor)
+            this._trackActor();
+    },
+
+    get overlayActor() {
+        return this._overlayActor;
+    },
+
+    showOverlay: function(actor) {
+        this._setOverlayActor(actor);
+
+        this._showing = true;
+        this.show();
+    },
+
+    hideOverlay: function() {
+        this._setOverlayActor(null);
+
+        this._showing = false;
+        this.hide();
+    }
+});
+
 const WindowManager = new Lang.Class({
     Name: 'WindowManager',
 
@@ -688,6 +933,19 @@ const WindowManager = new Lang.Class({
         this._skippedActors = [];
 
         this._allowedKeybindings = {};
+
+        this._desktopOverlay = new DesktopOverlay();
+        this._showDesktopOnDestroyDone = false;
+
+        // The desktop overlay needs to replicate the background's functionality;
+        // when clicked, we animate the side component out before emitting "background-clicked".
+        this._desktopOverlay.connect('clicked', Lang.bind(this, function() {
+            Main.layoutManager.prepareForOverview();
+            this._slideSideComponentOut(this._shellwm,
+                                        this._desktopOverlay.overlayActor,
+                                        function () { Main.layoutManager.emit('background-clicked'); },
+                                        function () { Main.layoutManager.emit('background-clicked'); });
+        }));
 
         this._isWorkspacePrepended = false;
 
@@ -1082,6 +1340,9 @@ const WindowManager = new Lang.Class({
         if (!this._shouldAnimate())
             return false;
 
+        if (SideComponent.isSideComponentWindow(actor.meta_window))
+            return true;
+
         let type = actor.meta_window.get_window_type();
         return types.indexOf(type) >= 0;
     },
@@ -1093,6 +1354,50 @@ const WindowManager = new Lang.Class({
             return true;
         }
         return false;
+    },
+
+    _slideSideComponentOut : function(shellwm, actor, onComplete, onOverwrite) {
+        let monitor = Main.layoutManager.monitors[actor.meta_window.get_monitor()];
+        if (!monitor) {
+            onComplete.apply(this, [shellwm, actor]);
+            return;
+        }
+
+        actor.opacity = 255;
+        actor.show();
+
+        if (SideComponent.isDiscoveryFeedWindow(actor.meta_window)) {
+            let endY = monitor.y - actor.height;
+            Tweener.addTween(actor,
+                             { y: endY,
+                               time: WINDOW_ANIMATION_TIME,
+                               transition: "easeOutQuad",
+                               onComplete: onComplete,
+                               onCompleteScope: this,
+                               onCompleteParams: [shellwm, actor],
+                               onOverwrite: onOverwrite,
+                               onOverwriteScope: this,
+                               onOverwriteParams: [shellwm, actor]
+                             });
+        } else {
+            let endX;
+            if (actor.x <= monitor.x)
+                endX = monitor.x - actor.width;
+            else
+                endX = monitor.x + monitor.width;
+
+            Tweener.addTween(actor,
+                             { x: endX,
+                               time: WINDOW_ANIMATION_TIME,
+                               transition: "easeOutQuad",
+                               onComplete: onComplete,
+                               onCompleteScope: this,
+                               onCompleteParams: [shellwm, actor],
+                               onOverwrite: onOverwrite,
+                               onOverwriteScope: this,
+                               onOverwriteParams: [shellwm, actor]
+                             });
+        }
     },
 
     _minimizeWindow : function(shellwm, actor) {
@@ -1427,6 +1732,115 @@ const WindowManager = new Lang.Class({
             dimmer.dimFactor = 0.0;
     },
 
+    _hideOtherWindows: function(actor, animate) {
+        let winActors = global.get_window_actors();
+        for (let i = 0; i < winActors.length; i++) {
+            if (!winActors[i].get_meta_window().showing_on_its_workspace())
+                continue;
+
+            if (SideComponent.isSideComponentWindow(winActors[i].meta_window))
+                continue;
+
+            if (animate) {
+                Tweener.addTween(winActors[i],
+                                 { opacity: 0,
+                                   time: WINDOW_ANIMATION_TIME,
+                                   transition: 'easeOutQuad',
+                                   onComplete: function(winActor) { winActor.hide(); },
+                                   onCompleteParams: [winActors[i]],
+                                   onOverwrite: function(winActor) { winActor.hide(); },
+                                   onOverwriteParams: [winActors[i]]
+                                 });
+            } else {
+                winActors[i].opacity = 0;
+                winActors[i].hide();
+            }
+        }
+
+        this._desktopOverlay.showOverlay(actor);
+    },
+
+    _showOtherWindows: function(actor, animate) {
+        let winActors = global.get_window_actors();
+        for (let i = 0; i < winActors.length; i++) {
+            if (!winActors[i].get_meta_window().showing_on_its_workspace())
+                continue;
+
+            if (SideComponent.isSideComponentWindow(winActors[i].meta_window))
+                continue;
+
+            if (animate && winActors[i].opacity != 255) {
+                winActors[i].show();
+                Tweener.addTween(winActors[i],
+                                 { opacity: 255,
+                                   time: WINDOW_ANIMATION_TIME,
+                                   transition: 'easeOutQuad',
+                                   onOverwrite: function(winActor) { winActor.opacity = 255; },
+                                   onOverwriteParams: [winActors[i]]
+                                 });
+            } else {
+                winActors[i].opacity = 255;
+                winActors[i].show();
+            }
+        }
+
+        this._desktopOverlay.hideOverlay();
+    },
+
+    _mapSideComponent : function (shellwm, actor, animateFade) {
+        let monitor = Main.layoutManager.monitors[actor.meta_window.get_monitor()];
+        if (!monitor) {
+            this._mapWindowDone(shellwm, actor);
+            return;
+        }
+
+        if (SideComponent.isDiscoveryFeedWindow(actor.meta_window)) {
+            // the DiscoveryFeed window will appear from the top center
+            let origY = actor.y;
+            actor.set_position(actor.x, monitor.y - actor.height);
+
+            Tweener.addTween(actor,
+                             { y: origY,
+                               time: WINDOW_ANIMATION_TIME,
+                               transition: "easeOutQuad",
+                               onComplete: this._mapWindowDone,
+                               onCompleteScope: this,
+                               onCompleteParams: [shellwm, actor],
+                               onOverwrite: this._mapWindowOverwrite,
+                               onOverwriteScope: this,
+                               onOverwriteParams: [shellwm, actor]
+                             });
+        }
+        else {
+            let origX = actor.x;
+            if (origX == monitor.x) {
+                // the side bar will appear from the left side
+                actor.set_position(monitor.x - actor.width, actor.y);
+            } else {
+                // ... from the right side
+                actor.set_position(monitor.x + monitor.width, actor.y);
+            }
+
+            Tweener.addTween(actor,
+                             { x: origX,
+                               time: WINDOW_ANIMATION_TIME,
+                               transition: "easeOutQuad",
+                               onComplete: this._mapWindowDone,
+                               onCompleteScope: this,
+                               onCompleteParams: [shellwm, actor],
+                               onOverwrite: this._mapWindowOverwrite,
+                               onOverwriteScope: this,
+                               onOverwriteParams: [shellwm, actor]
+                             });
+        }
+
+        actor.opacity = 255;
+        actor.show();
+
+        if (SideComponent.shouldHideOtherWindows(actor.meta_window))
+            this._hideOtherWindows(actor, animateFade);
+    },
+
     _mapWindow : function(shellwm, actor) {
         actor._windowType = actor.meta_window.get_window_type();
         actor._notifyWindowTypeSignalId = actor.meta_window.connect('notify::window-type', Lang.bind(this, function () {
@@ -1471,7 +1885,25 @@ const WindowManager = new Lang.Class({
                      Meta.WindowType.DIALOG,
                      Meta.WindowType.MODAL_DIALOG];
         if (!this._shouldAnimateActor(actor, types)) {
+            if (SideComponent.shouldHideOtherWindows(actor.meta_window))
+                this._showOtherWindows(actor, false);
+
             shellwm.completed_map(actor);
+            return;
+        }
+
+        if (SideComponent.isSideComponentWindow(actor.meta_window)) {
+            this._mapping.push(actor);
+
+            if (Main.overview.visible) {
+                let overviewHiddenId = Main.overview.connect('hidden', Lang.bind(this, function() {
+                    Main.overview.disconnect(overviewHiddenId);
+                    this._mapSideComponent(shellwm, actor, false);
+                }));
+                Main.overview.hide();
+            } else {
+                this._mapSideComponent(shellwm, actor, true);
+            }
             return;
         }
 
@@ -1568,6 +2000,27 @@ const WindowManager = new Lang.Class({
             return;
         }
 
+        if (SideComponent.isSideComponentWindow(actor.meta_window)) {
+            this._slideSideComponentOut(shellwm, actor,
+                                        this._destroyWindowDone,
+                                        this._destroyWindowDone);
+
+            // if the side component does not have the focus at this point,
+            // that means that it is closing because another window has gotten it
+            // and therefore we should not try to show the desktop
+            this._showDesktopOnDestroyDone = actor.meta_window.has_focus() &&
+                                             SideComponent.launchedFromDesktop(actor.meta_window);
+
+            if (!this._showDesktopOnDestroyDone && SideComponent.shouldHideOtherWindows(actor.meta_window)) {
+                // reveal other windows while we slide out the side component
+                this._showOtherWindows(actor, true);
+            } else if (this._showDesktopOnDestroyDone) {
+                Main.layoutManager.prepareForOverview();
+            }
+
+            return;
+        }
+
         switch (actor._windowType) {
         case Meta.WindowType.NORMAL:
             actor.set_pivot_point(0.5, 0.5);
@@ -1625,6 +2078,12 @@ const WindowManager = new Lang.Class({
                 parent.disconnect(actor._parentDestroyId);
                 actor._parentDestroyId = 0;
             }
+
+            if (SideComponent.isSideComponentWindow(actor.meta_window) && this._showDesktopOnDestroyDone) {
+                if (SideComponent.shouldHideOtherWindows(actor.meta_window))
+                    this._showOtherWindows(actor, false);
+            }
+
             shellwm.completed_destroy(actor);
         }
     },

--- a/js/ui/workspaceMonitor.js
+++ b/js/ui/workspaceMonitor.js
@@ -1,0 +1,66 @@
+// -*- mode: js; js-indent-level: 4; indent-tabs-mode: nil -*-
+
+const Lang = imports.lang;
+const Shell = imports.gi.Shell;
+
+const Main = imports.ui.main;
+
+const WorkspaceMonitor = new Lang.Class({
+    Name: 'WorkspaceMonitor',
+
+    _init: function() {
+        this._shellwm = global.window_manager;
+        this._shellwm.connect('minimize-completed', Lang.bind(this, this._updateOverview));
+        this._shellwm.connect('destroy-completed', Lang.bind(this, this._updateOverview));
+
+        this._metaScreen = global.screen;
+        this._metaScreen.connect('in-fullscreen-changed', Lang.bind(this, this._fullscreenChanged));
+
+        let primaryMonitor = Main.layoutManager.primaryMonitor;
+        this._inFullscreen = primaryMonitor && primaryMonitor.inFullscreen;
+    },
+
+    _fullscreenChanged: function() {
+        let primaryMonitor = Main.layoutManager.primaryMonitor;
+        let inFullscreen = primaryMonitor && primaryMonitor.inFullscreen;
+
+        if (this._inFullscreen != inFullscreen) {
+            this._inFullscreen = inFullscreen;
+            this._updateOverview();
+        }
+    },
+
+    _updateOverview: function() {
+        let visibleApps = this._getVisibleApps();
+        if (visibleApps.length != 0 && this._inFullscreen)
+            Main.overview.hide();
+    },
+
+    _getVisibleApps: function() {
+        let runningApps = Shell.AppSystem.get_default().get_running();
+        return runningApps.filter(function(app) {
+            let windows = app.get_windows();
+            for (let window of windows) {
+                // We do not count transient windows because of an issue with Audacity
+                // where a transient window was always being counted as visible even
+                // though it was minimized
+                if (window.get_transient_for())
+                    continue;
+
+                if (!window.minimized)
+                    return true;
+            }
+
+            return false;
+        });
+    },
+
+    get hasVisibleWindows() {
+        // Count anything fullscreen as an extra window
+        if (this._inFullscreen)
+            return true;
+
+        let visibleApps = this._getVisibleApps();
+        return visibleApps.length > 0;
+    }
+});

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -93,6 +93,8 @@ shell_public_headers_h =		\
 	shell-app.h			\
 	shell-app-system.h		\
 	shell-app-usage.h		\
+	shell-desktop-dir-info.h	\
+	shell-dir-info.h		\
 	shell-embedded-window.h		\
 	shell-generic-container.h	\
 	shell-glsl-quad.h		\
@@ -165,6 +167,8 @@ libgnome_shell_sources =		\
 	shell-app.c			\
 	shell-app-system.c		\
 	shell-app-usage.c		\
+	shell-desktop-dir-info.c	\
+	shell-dir-info.c		\
 	shell-global.c			\
 	shell-grid-desaturate-effect.c  \
 	shell-gtk-embed.c		\

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -98,6 +98,7 @@ shell_public_headers_h =		\
 	shell-glsl-quad.h		\
 	shell-gtk-embed.h		\
 	shell-global.h			\
+	shell-grid-desaturate-effect.h  \
 	shell-invert-lightness-effect.h	\
 	shell-action-modes.h		\
 	shell-mount-operation.h		\
@@ -165,6 +166,7 @@ libgnome_shell_sources =		\
 	shell-app-system.c		\
 	shell-app-usage.c		\
 	shell-global.c			\
+	shell-grid-desaturate-effect.c  \
 	shell-gtk-embed.c		\
 	shell-screenshot.c		\
 	shell-tray-icon.c		\

--- a/src/shell-app-system.c
+++ b/src/shell-app-system.c
@@ -9,11 +9,21 @@
 #include <gio/gio.h>
 #include <glib/gi18n.h>
 
+#include <eosmetrics/eosmetrics.h>
+
 #include "shell-app-private.h"
 #include "shell-window-tracker-private.h"
 #include "shell-app-system-private.h"
 #include "shell-global.h"
 #include "shell-util.h"
+
+/* Occurs when an application visible to the shell is opened or closed. The
+ * payload varies depending on whether it is given as an opening event or a
+ * closed event. If it is an opening event, the payload is a human-readable
+ * application name. If it is a closing event, the payload is empty. The key
+ * used is a pointer to the corresponding ShellApp.
+ */
+#define SHELL_APP_IS_OPEN_EVENT "b5e11a3d-13f8-4219-84fd-c9ba0bf3d1f0"
 
 /* Vendor prefixes are something that can be preprended to a .desktop
  * file name.  Undo this.
@@ -364,20 +374,40 @@ _shell_app_system_notify_app_state_changed (ShellAppSystem *self,
 {
   ShellAppState state = shell_app_get_state (app);
 
+  gchar *app_address = g_strdup_printf ("%p", app);
+  GDesktopAppInfo *app_info = shell_app_get_app_info (app);
+  const gchar *app_info_id = NULL;
+  if (app_info != NULL)
+    app_info_id = g_app_info_get_id (G_APP_INFO (app_info));
+
   switch (state)
     {
     case SHELL_APP_STATE_RUNNING:
+      {
+        emtr_event_recorder_record_start (emtr_event_recorder_get_default (),
+                                          SHELL_APP_IS_OPEN_EVENT,
+                                          g_variant_new ("s", app_address),
+                                          g_variant_new ("s", app_info_id));
+      }
       g_hash_table_insert (self->priv->running_apps, g_object_ref (app), NULL);
       break;
     case SHELL_APP_STATE_STARTING:
       break;
     case SHELL_APP_STATE_STOPPED:
-      g_hash_table_remove (self->priv->running_apps, app);
+      if (g_hash_table_remove (self->priv->running_apps, app) && app_info_id != NULL)
+        {
+          emtr_event_recorder_record_stop (emtr_event_recorder_get_default (),
+                                           SHELL_APP_IS_OPEN_EVENT,
+                                           g_variant_new ("s", app_address),
+                                           NULL);
+        }
       break;
     default:
       g_warn_if_reached();
       break;
     }
+  g_free (app_address);
+
   g_signal_emit (self, signals[APP_STATE_CHANGED], 0, app);
 }
 

--- a/src/shell-app-system.c
+++ b/src/shell-app-system.c
@@ -25,6 +25,12 @@
  */
 #define SHELL_APP_IS_OPEN_EVENT "b5e11a3d-13f8-4219-84fd-c9ba0bf3d1f0"
 
+/* Additional key used to map a renamed desktop file to its previous name;
+ * for instance, org.gnome.Totem.desktop would use this key to point to
+ * 'totem.desktop'
+ */
+#define X_ENDLESS_ALIAS_KEY     "X-Endless-Alias"
+
 /* Vendor prefixes are something that can be preprended to a .desktop
  * file name.  Undo this.
  */
@@ -60,6 +66,7 @@ struct _ShellAppSystemPrivate {
   GHashTable *running_apps;
   GHashTable *id_to_app;
   GHashTable *startup_wm_class_to_id;
+  GHashTable *alias_to_id;
 };
 
 static void shell_app_system_finalize (GObject *object);
@@ -86,6 +93,37 @@ static void shell_app_system_class_init(ShellAppSystemClass *klass)
                   0,
                   NULL, NULL, NULL,
 		  G_TYPE_NONE, 0);
+}
+
+
+static void
+scan_alias_to_id (ShellAppSystem *self)
+{
+  ShellAppSystemPrivate *priv = self->priv;
+  GList *apps, *l;
+
+  g_hash_table_remove_all (priv->alias_to_id);
+
+  apps = g_app_info_get_all ();
+  for (l = apps; l != NULL; l = l->next)
+    {
+      GAppInfo *info = l->data;
+      const char *alias, *id;
+      char *desktop_alias;
+
+      id = g_app_info_get_id (info);
+      alias = g_desktop_app_info_get_string (G_DESKTOP_APP_INFO (info), X_ENDLESS_ALIAS_KEY);
+      if (alias == NULL)
+        continue;
+
+      desktop_alias = g_strconcat (alias, ".desktop", NULL);
+
+      g_hash_table_insert (priv->alias_to_id, g_strdup (desktop_alias), g_strdup (id));
+
+      g_free (desktop_alias);
+    }
+
+  g_list_free_full (apps, g_object_unref);
 }
 
 static void
@@ -172,6 +210,8 @@ installed_changed (GAppInfoMonitor *monitor,
 {
   ShellAppSystem *self = user_data;
 
+  scan_alias_to_id (self);
+
   scan_startup_wm_class_to_id (self);
 
   g_hash_table_foreach_remove (self->priv->id_to_app, stale_app_remove_func, NULL);
@@ -193,6 +233,7 @@ shell_app_system_init (ShellAppSystem *self)
                                            (GDestroyNotify)g_object_unref);
 
   priv->startup_wm_class_to_id = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_free);
+  priv->alias_to_id = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_free);
 
   monitor = g_app_info_monitor_get ();
   g_signal_connect (monitor, "changed", G_CALLBACK (installed_changed), self);
@@ -208,6 +249,7 @@ shell_app_system_finalize (GObject *object)
   g_hash_table_destroy (priv->running_apps);
   g_hash_table_destroy (priv->id_to_app);
   g_hash_table_destroy (priv->startup_wm_class_to_id);
+  g_hash_table_destroy (priv->alias_to_id);
 
   G_OBJECT_CLASS (shell_app_system_parent_class)->finalize (object);
 }
@@ -242,6 +284,7 @@ shell_app_system_lookup_app (ShellAppSystem   *self,
   ShellAppSystemPrivate *priv = self->priv;
   ShellApp *app;
   GDesktopAppInfo *info;
+  char *alias;
 
   app = g_hash_table_lookup (priv->id_to_app, id);
   if (app)
@@ -253,7 +296,20 @@ shell_app_system_lookup_app (ShellAppSystem   *self,
 
   app = _shell_app_new (info);
   g_hash_table_insert (priv->id_to_app, (char *) shell_app_get_id (app), app);
+
+  alias = g_desktop_app_info_get_string (info, X_ENDLESS_ALIAS_KEY);
+  if (alias != NULL && g_hash_table_lookup (priv->alias_to_id, alias) == NULL)
+    {
+      char *desktop_alias = g_strconcat (alias, ".desktop", NULL);
+
+      g_hash_table_insert (priv->alias_to_id, g_strdup (desktop_alias), g_strdup (id));
+
+      g_free (desktop_alias);
+    }
+
   g_object_unref (info);
+  g_free (alias);
+
   return app;
 }
 
@@ -289,6 +345,38 @@ shell_app_system_lookup_heuristic_basename (ShellAppSystem *system,
     }
 
   return NULL;
+}
+
+/**
+ * shell_app_system_lookup_alias:
+ * @system: a #ShellAppSystem
+ * @alias: alternative application id
+ *
+ * Find a valid application corresponding to a given
+ * alias string, or %NULL if none.
+ *
+ * Returns: (transfer none): A #ShellApp for @alias
+ */
+ShellApp *
+shell_app_system_lookup_alias (ShellAppSystem *system,
+                               const char     *alias)
+{
+  ShellApp *result;
+  const char *id;
+
+  g_return_val_if_fail (alias != NULL, NULL);
+
+  result = shell_app_system_lookup_app (system, alias);
+  if (result != NULL)
+    return result;
+
+  id = g_hash_table_lookup (system->priv->alias_to_id, alias);
+  if (id == NULL)
+    return NULL;
+
+  result = shell_app_system_lookup_app (system, id);
+
+  return result;
 }
 
 /**

--- a/src/shell-app-system.c
+++ b/src/shell-app-system.c
@@ -48,6 +48,7 @@ enum {
 enum {
   APP_STATE_CHANGED,
   INSTALLED_CHANGED,
+  APP_INFO_CHANGED,
   LAST_SIGNAL
 };
 
@@ -94,6 +95,15 @@ static void shell_app_system_class_init(ShellAppSystemClass *klass)
                   0,
                   NULL, NULL, NULL,
 		  G_TYPE_NONE, 0);
+
+  signals[APP_INFO_CHANGED] =
+    g_signal_new ("app-info-changed",
+                  SHELL_TYPE_APP_SYSTEM,
+                  G_SIGNAL_RUN_LAST,
+                  0,
+                  NULL, NULL, NULL,
+                  G_TYPE_NONE, 1,
+                  SHELL_TYPE_APP);
 }
 
 
@@ -197,12 +207,86 @@ app_is_stale (ShellApp *app)
   return !is_unchanged;
 }
 
-static gboolean
-stale_app_remove_func (gpointer key,
-                       gpointer value,
-                       gpointer user_data)
+static GDesktopAppInfo *
+get_new_desktop_app_info_from_app (ShellApp *app)
 {
-  return app_is_stale (value);
+  const char *id;
+
+  if (shell_app_is_window_backed (app))
+    return NULL;
+
+  /* If g_app_info_delete() was called, such as when a custom desktop
+   * icon is removed, the desktop ID of the underlying GDesktopAppInfo
+   * will be set to NULL.
+   * So we explicitly check for that case and mark the app as stale.
+   * See https://git.gnome.org/browse/glib/tree/gio/gdesktopappinfo.c?h=glib-2-44&id=2.44.0#n3682
+   */
+  id = shell_app_get_id (app);
+  if (id == NULL)
+    return NULL;
+
+  return g_desktop_app_info_new (id);
+}
+
+static gboolean
+app_info_changed (ShellApp *app, GDesktopAppInfo *desk_new_info)
+{
+  GIcon *app_icon;
+  GIcon *new_icon;
+  GDesktopAppInfo *desk_app_info = shell_app_get_app_info (app);
+  GAppInfo *app_info = G_APP_INFO (desk_app_info);
+  GAppInfo *new_info = G_APP_INFO (desk_new_info);
+
+  if (!app_info)
+    return TRUE;
+
+  app_icon = g_app_info_get_icon (app_info);
+  new_icon = g_app_info_get_icon (new_info);
+
+  return !(g_app_info_equal (app_info, new_info) &&
+           g_icon_equal (app_icon, new_icon) &&
+           g_app_info_should_show (app_info) == g_app_info_should_show (new_info) &&
+           strcmp (g_desktop_app_info_get_filename (desk_app_info),
+                   g_desktop_app_info_get_filename (desk_new_info)) == 0 &&
+           g_strcmp0 (g_app_info_get_executable (app_info),
+                      g_app_info_get_executable (new_info)) == 0 &&
+           g_strcmp0 (g_app_info_get_commandline (app_info),
+                      g_app_info_get_commandline (new_info)) == 0 &&
+           strcmp (g_app_info_get_name (app_info),
+                   g_app_info_get_name (new_info)) == 0 &&
+           strcmp (g_app_info_get_display_name (app_info),
+                   g_app_info_get_display_name (new_info)) == 0 &&
+           g_strcmp0 (g_app_info_get_description (app_info),
+                      g_app_info_get_description (new_info)) == 0);
+}
+
+static void
+remove_or_update_app_from_info (ShellAppSystem *self)
+{
+  GHashTableIter iter;
+  ShellApp *app;
+
+  g_hash_table_iter_init (&iter, self->priv->id_to_app);
+  while (g_hash_table_iter_next (&iter, NULL, (gpointer) &app))
+    {
+      GDesktopAppInfo *app_info = NULL;
+
+      if (app_is_stale (app))
+        {
+          /* App is stale, we remove it */
+          g_hash_table_iter_remove (&iter);
+          continue;
+        }
+
+      app_info = get_new_desktop_app_info_from_app (app);
+      if (app_info_changed (app, app_info))
+        {
+          _shell_app_set_app_info (app, app_info);
+          g_signal_emit (self, signals[APP_INFO_CHANGED], 0, app);
+        }
+
+      g_object_unref (app_info);
+    }
 }
 
 static void
@@ -215,7 +299,7 @@ installed_changed (GAppInfoMonitor *monitor,
 
   scan_startup_wm_class_to_id (self);
 
-  g_hash_table_foreach_remove (self->priv->id_to_app, stale_app_remove_func, NULL);
+  remove_or_update_app_from_info (self);
 
   g_signal_emit (self, signals[INSTALLED_CHANGED], 0, NULL);
 }

--- a/src/shell-app-system.c
+++ b/src/shell-app-system.c
@@ -507,6 +507,13 @@ shell_app_system_lookup_desktop_wmclass (ShellAppSystem *system,
    * Note g_strdelimit is modify-in-place. */
   g_strdelimit (canonicalized, " ", '-');
 
+    /* HACK: Handle GIMP here as a special case. */
+  if (g_strcmp0 (canonicalized, "gimp-2.8") == 0)
+    {
+      g_free (canonicalized);
+      canonicalized = g_strdup ("gimp");
+    }
+
   desktop_file = g_strconcat (canonicalized, ".desktop", NULL);
 
   app = shell_app_system_lookup_heuristic_basename (system, desktop_file);

--- a/src/shell-app-system.h
+++ b/src/shell-app-system.h
@@ -23,6 +23,8 @@ ShellApp       *shell_app_system_lookup_startup_wmclass       (ShellAppSystem *s
                                                                const char     *wmclass);
 ShellApp       *shell_app_system_lookup_desktop_wmclass       (ShellAppSystem *system,
                                                                const char     *wmclass);
+ShellApp       *shell_app_system_lookup_alias                 (ShellAppSystem  *system,
+                                                               const char      *alias);
 
 GSList         *shell_app_system_get_running               (ShellAppSystem  *self);
 char         ***shell_app_system_search                    (const char *search_string);

--- a/src/shell-app-system.h
+++ b/src/shell-app-system.h
@@ -29,4 +29,6 @@ ShellApp       *shell_app_system_lookup_alias                 (ShellAppSystem  *
 GSList         *shell_app_system_get_running               (ShellAppSystem  *self);
 char         ***shell_app_system_search                    (const char *search_string);
 
+gboolean        shell_app_system_has_starting_apps         (ShellAppSystem  *self);
+
 #endif /* __SHELL_APP_SYSTEM_H__ */

--- a/src/shell-app.c
+++ b/src/shell-app.c
@@ -3,6 +3,7 @@
 #include "config.h"
 
 #include <string.h>
+#include <errno.h>
 
 #include <glib/gi18n-lib.h>
 
@@ -1296,6 +1297,94 @@ GDesktopAppInfo *
 shell_app_get_app_info (ShellApp *app)
 {
   return app->info;
+}
+
+gboolean
+shell_app_create_custom_launcher_with_name (ShellApp *app,
+                                            const char *label)
+{
+  GError *internal_error;
+  const char *filename;
+  char *new_path, *buf;
+  GKeyFile *keyfile;
+  gsize len;
+
+  if (app->info == NULL)
+    return FALSE;
+
+  filename = g_desktop_app_info_get_filename (app->info);
+  if (filename == NULL || *filename == '\0')
+    return FALSE;
+
+  keyfile = g_key_file_new ();
+
+  internal_error = NULL;
+
+  /* we ignore comments and translations */
+  g_key_file_load_from_file (keyfile, filename, 0, &internal_error);
+  if (internal_error != NULL)
+    {
+      g_warning ("Unable to load desktop file '%s': %s", filename, internal_error->message);
+
+      g_error_free (internal_error);
+      g_key_file_unref (keyfile);
+
+      return FALSE;
+    }
+
+  /* replace the 'Name' key with the new one */
+  g_key_file_set_string (keyfile,
+                         G_KEY_FILE_DESKTOP_GROUP,
+                         G_KEY_FILE_DESKTOP_KEY_NAME,
+                         label);
+
+  buf = g_key_file_to_data (keyfile, &len, &internal_error);
+  if (internal_error != NULL)
+    {
+      g_warning ("Unable to save desktop file: %s", internal_error->message);
+
+      g_error_free (internal_error);
+      g_key_file_unref (keyfile);
+
+      return FALSE;
+    }
+
+  g_key_file_unref (keyfile);
+
+  new_path = g_build_filename (g_get_user_data_dir (), "applications", NULL);
+
+  if (g_mkdir_with_parents (new_path, 0755) < 0)
+    {
+      int saved_errno = errno;
+
+      g_warning ("Unable to create '%s': %s", new_path, g_strerror (saved_errno));
+
+      g_free (new_path);
+      g_free (buf);
+
+      return FALSE;
+    }
+
+  g_free (new_path);
+
+  new_path = g_build_filename (g_get_user_data_dir (), "applications", shell_app_get_id (app), NULL);
+
+  g_file_set_contents (new_path, buf, len, &internal_error);
+  if (internal_error != NULL)
+    {
+      g_warning ("Unable to write desktop file '%s': %s", new_path, internal_error->message);
+
+      g_error_free (internal_error);
+      g_free (new_path);
+      g_free (buf);
+
+      return FALSE;
+    }
+
+  g_free (new_path);
+  g_free (buf);
+
+  return TRUE;
 }
 
 static void

--- a/src/shell-app.c
+++ b/src/shell-app.c
@@ -466,14 +466,16 @@ shell_app_update_window_actions (ShellApp *app, MetaWindow *window)
 /**
  * shell_app_activate:
  * @app: a #ShellApp
+ * @error: a #GError
  *
  * Like shell_app_activate_full(), but using the default workspace and
  * event timestamp.
  */
 void
-shell_app_activate (ShellApp      *app)
+shell_app_activate (ShellApp      *app,
+                    GError       **error)
 {
-  return shell_app_activate_full (app, -1, 0);
+  return shell_app_activate_full (app, -1, 0, error);
 }
 
 /**
@@ -482,6 +484,7 @@ shell_app_activate (ShellApp      *app)
  * @workspace: launch on this workspace, or -1 for default. Ignored if
  *   activating an existing window
  * @timestamp: Event timestamp
+ * @error: a #GError
  *
  * Perform an appropriate default action for operating on this application,
  * dependent on its current state.  For example, if the application is not
@@ -492,7 +495,8 @@ shell_app_activate (ShellApp      *app)
 void
 shell_app_activate_full (ShellApp      *app,
                          int            workspace,
-                         guint32        timestamp)
+                         guint32        timestamp,
+                         GError       **error)
 {
   ShellGlobal *global;
 
@@ -505,16 +509,16 @@ shell_app_activate_full (ShellApp      *app,
     {
       case SHELL_APP_STATE_STOPPED:
         {
-          GError *error = NULL;
-          if (!shell_app_launch (app, timestamp, workspace, &error))
+          GError *my_error = NULL;
+          if (!shell_app_launch (app, timestamp, workspace, &my_error))
             {
               char *msg;
               msg = g_strdup_printf (_("Failed to launch “%s”"), shell_app_get_name (app));
               shell_global_notify_error (global,
                                          msg,
-                                         error->message);
+                                         my_error->message);
               g_free (msg);
-              g_clear_error (&error);
+              g_propagate_error (error, my_error);
             }
         }
         break;

--- a/src/shell-app.h
+++ b/src/shell-app.h
@@ -29,11 +29,13 @@ gboolean shell_app_is_window_backed (ShellApp *app);
 
 void shell_app_activate_window (ShellApp *app, MetaWindow *window, guint32 timestamp);
 
-void shell_app_activate (ShellApp      *app);
+void shell_app_activate (ShellApp      *app,
+                         GError       **error);
 
 void shell_app_activate_full (ShellApp      *app,
                               int            workspace,
-                              guint32        timestamp);
+                              guint32        timestamp,
+                              GError       **error);
 
 void shell_app_open_new_window (ShellApp *app,
                                 int       workspace);

--- a/src/shell-app.h
+++ b/src/shell-app.h
@@ -72,6 +72,8 @@ void shell_app_update_app_menu       (ShellApp *app, MetaWindow *window);
 
 gboolean shell_app_get_busy          (ShellApp *app);
 
+gboolean shell_app_create_custom_launcher_with_name (ShellApp *app, const char *label);
+
 G_END_DECLS
 
 #endif /* __SHELL_APP_H__ */

--- a/src/shell-desktop-dir-info.c
+++ b/src/shell-desktop-dir-info.c
@@ -1,0 +1,1034 @@
+/* EOS Shell desktop directory information
+ *
+ * Copyright © 2013 Endless Mobile, Inc.
+ *
+ * Based on https://git.gnome.org/browse/glib/tree/gio/gdesktopappinfo.c
+ * Copyright (C) 2006-2007 Red Hat, Inc.
+ * Copyright © 2007 Ryan Lortie
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General
+ * Public License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place, Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+#include "config.h"
+
+#include <errno.h>
+#include <string.h>
+#include <unistd.h>
+
+#ifdef HAVE_CRT_EXTERNS_H
+#include <crt_externs.h>
+#endif
+
+#include "shell-desktop-dir-info.h"
+#include "shell-dir-info.h"
+
+#include <glib.h>
+#include <glib/gi18n.h>
+#include <glib/gstdio.h>
+
+/**
+ * SECTION:shelldesktopdirinfo
+ * @title: ShellDesktopDirInfo
+ * @short_description: Directory information from desktop files
+ * @include: shell-desktop-dir-info.h
+ *
+ * #ShellDesktopDirInfo is an implementation of #ShellDirInfo based on
+ * desktop files.
+ */
+
+#define GENERIC_NAME_KEY            "GenericName"
+#define FULL_NAME_KEY               "X-GNOME-FullName"
+
+enum {
+  PROP_0,
+  PROP_FILENAME
+};
+
+static void     shell_desktop_dir_info_iface_init         (ShellDirInfoIface    *iface);
+
+/**
+ * ShellDesktopDirInfo:
+ * 
+ * Information about a desktop directory from a desktop file.
+ */
+struct _ShellDesktopDirInfo
+{
+  GObject parent_instance;
+
+  char *desktop_id;
+  char *filename;
+
+  GKeyFile *keyfile;
+
+  char *name;
+  char *generic_name;
+  char *fullname;
+  char *comment;
+  char *icon_name;
+  GIcon *icon;
+  char **only_show_in;
+  char **not_show_in;
+
+  guint nodisplay       : 1;
+  guint hidden          : 1;
+};
+
+G_DEFINE_TYPE_WITH_CODE (ShellDesktopDirInfo, shell_desktop_dir_info, G_TYPE_OBJECT,
+                         G_IMPLEMENT_INTERFACE (SHELL_TYPE_DIR_INFO,
+                                                shell_desktop_dir_info_iface_init))
+
+G_LOCK_DEFINE_STATIC (shell_desktop_env);
+static gchar *shell_desktop_env = NULL;
+
+static gpointer
+search_path_init (gpointer data)
+{
+  char **args = NULL;
+  const char * const *data_dirs;
+  const char *user_data_dir;
+  int i, length, j;
+
+  data_dirs = g_get_system_data_dirs ();
+  length = g_strv_length ((char **) data_dirs);
+  
+  args = g_new (char *, length + 2);
+  
+  j = 0;
+  user_data_dir = g_get_user_data_dir ();
+  args[j++] = g_build_filename (user_data_dir, "desktop-directories", NULL);
+  for (i = 0; i < length; i++)
+    args[j++] = g_build_filename (data_dirs[i],
+                                  "desktop-directories", NULL);
+  args[j++] = NULL;
+  
+  return args;
+}
+  
+static const char * const *
+get_directories_search_path (void)
+{
+  static GOnce once_init = G_ONCE_INIT;
+  return g_once (&once_init, search_path_init, NULL);
+}
+
+static void
+shell_desktop_dir_info_finalize (GObject *object)
+{
+  ShellDesktopDirInfo *info;
+
+  info = SHELL_DESKTOP_DIR_INFO (object);
+
+  g_free (info->desktop_id);
+  g_free (info->filename);
+
+  if (info->keyfile)
+    g_key_file_unref (info->keyfile);
+
+  g_free (info->name);
+  g_free (info->generic_name);
+  g_free (info->fullname);
+  g_free (info->comment);
+  g_free (info->icon_name);
+  if (info->icon)
+    g_object_unref (info->icon);
+  g_strfreev (info->only_show_in);
+  g_strfreev (info->not_show_in);
+  
+  G_OBJECT_CLASS (shell_desktop_dir_info_parent_class)->finalize (object);
+}
+
+static void
+shell_desktop_dir_info_set_property(GObject         *object,
+                                    guint            prop_id,
+                                    const GValue    *value,
+                                    GParamSpec      *pspec)
+{
+  ShellDesktopDirInfo *self = SHELL_DESKTOP_DIR_INFO (object);
+
+  switch (prop_id)
+    {
+    case PROP_FILENAME:
+      self->filename = g_value_dup_string (value);
+      break;
+
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+      break;
+    }
+}
+
+static void
+shell_desktop_dir_info_get_property (GObject    *object,
+                                     guint       prop_id,
+                                     GValue     *value,
+                                     GParamSpec *pspec)
+{
+  ShellDesktopDirInfo *self = SHELL_DESKTOP_DIR_INFO (object);
+
+  switch (prop_id)
+    {
+    case PROP_FILENAME:
+      g_value_set_string (value, self->filename);
+      break;
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+      break;
+    }
+}
+
+static void
+shell_desktop_dir_info_class_init (ShellDesktopDirInfoClass *klass)
+{
+  GObjectClass *gobject_class = G_OBJECT_CLASS (klass);
+  
+  gobject_class->get_property = shell_desktop_dir_info_get_property;
+  gobject_class->set_property = shell_desktop_dir_info_set_property;
+  gobject_class->finalize = shell_desktop_dir_info_finalize;
+
+  /**
+   * ShellDesktopDirInfo:filename:
+   *
+   * The origin filename of this #ShellDesktopDirInfo
+   */
+  g_object_class_install_property (gobject_class,
+                                   PROP_FILENAME,
+                                   g_param_spec_string ("filename", "Filename", "",
+                                                        NULL,
+                                                        G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+}
+
+static void
+shell_desktop_dir_info_init (ShellDesktopDirInfo *local)
+{
+}
+
+static gboolean
+shell_desktop_dir_info_load_from_keyfile (ShellDesktopDirInfo *info, 
+                                          GKeyFile        *key_file)
+{
+  char *start_group;
+  char *type;
+
+  start_group = g_key_file_get_start_group (key_file);
+  if (start_group == NULL || strcmp (start_group, G_KEY_FILE_DESKTOP_GROUP) != 0)
+    {
+      g_free (start_group);
+      return FALSE;
+    }
+  g_free (start_group);
+
+  type = g_key_file_get_string (key_file,
+                                G_KEY_FILE_DESKTOP_GROUP,
+                                G_KEY_FILE_DESKTOP_KEY_TYPE,
+                                NULL);
+  if (type == NULL || strcmp (type, G_KEY_FILE_DESKTOP_TYPE_DIRECTORY) != 0)
+    {
+      g_free (type);
+      return FALSE;
+    }
+  g_free (type);
+
+  info->name = g_key_file_get_locale_string (key_file, G_KEY_FILE_DESKTOP_GROUP, G_KEY_FILE_DESKTOP_KEY_NAME, NULL, NULL);
+  info->generic_name = g_key_file_get_locale_string (key_file, G_KEY_FILE_DESKTOP_GROUP, GENERIC_NAME_KEY, NULL, NULL);
+  info->fullname = g_key_file_get_locale_string (key_file, G_KEY_FILE_DESKTOP_GROUP, FULL_NAME_KEY, NULL, NULL);
+  info->comment = g_key_file_get_locale_string (key_file, G_KEY_FILE_DESKTOP_GROUP, G_KEY_FILE_DESKTOP_KEY_COMMENT, NULL, NULL);
+  info->nodisplay = g_key_file_get_boolean (key_file, G_KEY_FILE_DESKTOP_GROUP, G_KEY_FILE_DESKTOP_KEY_NO_DISPLAY, NULL) != FALSE;
+  info->icon_name =  g_key_file_get_locale_string (key_file, G_KEY_FILE_DESKTOP_GROUP, G_KEY_FILE_DESKTOP_KEY_ICON, NULL, NULL);
+  info->only_show_in = g_key_file_get_string_list (key_file, G_KEY_FILE_DESKTOP_GROUP, G_KEY_FILE_DESKTOP_KEY_ONLY_SHOW_IN, NULL, NULL);
+  info->not_show_in = g_key_file_get_string_list (key_file, G_KEY_FILE_DESKTOP_GROUP, G_KEY_FILE_DESKTOP_KEY_NOT_SHOW_IN, NULL, NULL);
+  info->hidden = g_key_file_get_boolean (key_file, G_KEY_FILE_DESKTOP_GROUP, G_KEY_FILE_DESKTOP_KEY_HIDDEN, NULL) != FALSE;
+  
+  info->icon = NULL;
+  if (info->icon_name)
+    {
+      if (g_path_is_absolute (info->icon_name))
+        {
+          GFile *file;
+          
+          file = g_file_new_for_path (info->icon_name);
+          info->icon = g_file_icon_new (file);
+          g_object_unref (file);
+        }
+      else
+        {
+          char *p;
+
+          /* Work around a common mistake in desktop files */    
+          if ((p = strrchr (info->icon_name, '.')) != NULL &&
+              (strcmp (p, ".png") == 0 ||
+               strcmp (p, ".xpm") == 0 ||
+               strcmp (p, ".svg") == 0)) 
+            *p = 0;
+
+          info->icon = g_themed_icon_new (info->icon_name);
+        }
+    }
+  
+  info->keyfile = g_key_file_ref (key_file);
+
+  return TRUE;
+}
+
+static gboolean
+shell_desktop_dir_info_load_file (ShellDesktopDirInfo *self)
+{
+  GKeyFile *key_file;
+  gboolean retval = FALSE;
+
+  g_return_val_if_fail (self->filename != NULL, FALSE);
+
+  self->desktop_id = g_path_get_basename (self->filename);
+
+  key_file = g_key_file_new ();
+
+  if (g_key_file_load_from_file (key_file,
+                                 self->filename,
+                                 G_KEY_FILE_NONE,
+                                 NULL))
+    {
+      retval = shell_desktop_dir_info_load_from_keyfile (self, key_file);
+    }
+
+  g_key_file_unref (key_file);
+  return retval;
+}
+
+/**
+ * shell_desktop_dir_info_new_from_keyfile:
+ * @key_file: an opened #GKeyFile
+ *
+ * Creates a new #ShellDesktopDirInfo.
+ *
+ * Returns: a new #ShellDesktopDirInfo or %NULL on error.
+ **/
+ShellDesktopDirInfo *
+shell_desktop_dir_info_new_from_keyfile (GKeyFile *key_file)
+{
+  ShellDesktopDirInfo *info;
+
+  info = g_object_new (SHELL_TYPE_DESKTOP_DIR_INFO, NULL);
+  info->filename = NULL;
+  if (!shell_desktop_dir_info_load_from_keyfile (info, key_file))
+    {
+      g_object_unref (info);
+      return NULL;
+    }
+  return info;
+}
+
+/**
+ * shell_desktop_dir_info_new_from_filename:
+ * @filename: the path of a desktop file, in the GLib filename encoding
+ * 
+ * Creates a new #ShellDesktopDirInfo.
+ *
+ * Returns: a new #ShellDesktopDirInfo or %NULL on error.
+ **/
+ShellDesktopDirInfo *
+shell_desktop_dir_info_new_from_filename (const char *filename)
+{
+  ShellDesktopDirInfo *info = NULL;
+
+  info = g_object_new (SHELL_TYPE_DESKTOP_DIR_INFO, "filename", filename, NULL);
+  if (!shell_desktop_dir_info_load_file (info))
+    {
+      g_object_unref (info);
+      return NULL;
+    }
+  return info;
+}
+
+/**
+ * shell_desktop_dir_info_new:
+ * @desktop_id: the desktop file id
+ * 
+ * Creates a new #ShellDesktopDirInfo based on a desktop file id. 
+ *
+ * A desktop file id is the basename of the desktop file, including the 
+ * .directory extension. GIO is looking for a desktop file with this name 
+ * in the <filename>desktop-directories</filename> subdirectories of the XDG data
+ * directories (i.e. the directories specified in the 
+ * <envar>XDG_DATA_HOME</envar> and <envar>XDG_DATA_DIRS</envar> environment 
+ * variables). GIO also supports the prefix-to-subdirectory mapping that is
+ * described in the <ulink url="http://standards.freedesktop.org/menu-spec/latest/">Menu Spec</ulink> 
+ * (i.e. a desktop id of kde-foo.directory will match
+ * <filename>/usr/share/desktop-directories/kde/foo.directory</filename>).
+ * 
+ * Returns: a new #ShellDesktopDirInfo, or %NULL if no desktop file with that id
+ */
+ShellDesktopDirInfo *
+shell_desktop_dir_info_new (const char *desktop_id)
+{
+  ShellDesktopDirInfo *dirinfo;
+  const char * const *dirs;
+  char *basename;
+  int i;
+
+  dirs = get_directories_search_path ();
+
+  basename = g_strdup (desktop_id);
+  
+  for (i = 0; dirs[i] != NULL; i++)
+    {
+      char *filename;
+      char *p;
+
+      filename = g_build_filename (dirs[i], desktop_id, NULL);
+      dirinfo = shell_desktop_dir_info_new_from_filename (filename);
+      g_free (filename);
+      if (dirinfo != NULL)
+        goto found;
+
+      p = basename;
+      while ((p = strchr (p, '-')) != NULL)
+        {
+          *p = '/';
+
+          filename = g_build_filename (dirs[i], basename, NULL);
+          dirinfo = shell_desktop_dir_info_new_from_filename (filename);
+          g_free (filename);
+          if (dirinfo != NULL)
+            goto found;
+          *p = '-';
+          p++;
+        }
+    }
+
+  g_free (basename);
+  return NULL;
+
+ found:
+  g_free (basename);
+  
+  g_free (dirinfo->desktop_id);
+  dirinfo->desktop_id = g_strdup (desktop_id);
+
+  if (shell_desktop_dir_info_get_is_hidden (dirinfo))
+    {
+      g_object_unref (dirinfo);
+      dirinfo = NULL;
+    }
+  
+  return dirinfo;
+}
+
+static ShellDirInfo *
+shell_desktop_dir_info_dup (ShellDirInfo *dirinfo)
+{
+  ShellDesktopDirInfo *info = SHELL_DESKTOP_DIR_INFO (dirinfo);
+  ShellDesktopDirInfo *new_info;
+  
+  new_info = g_object_new (SHELL_TYPE_DESKTOP_DIR_INFO, NULL);
+
+  new_info->filename = g_strdup (info->filename);
+  new_info->desktop_id = g_strdup (info->desktop_id);
+
+  if (info->keyfile)
+    new_info->keyfile = g_key_file_ref (info->keyfile);
+
+  new_info->name = g_strdup (info->name);
+  new_info->generic_name = g_strdup (info->generic_name);
+  new_info->fullname = g_strdup (info->fullname);
+  new_info->comment = g_strdup (info->comment);
+  new_info->nodisplay = info->nodisplay;
+  new_info->icon_name = g_strdup (info->icon_name);
+  if (info->icon)
+    new_info->icon = g_object_ref (info->icon);
+  new_info->only_show_in = g_strdupv (info->only_show_in);
+  new_info->not_show_in = g_strdupv (info->not_show_in);
+  new_info->hidden = info->hidden;
+  
+  return SHELL_DIR_INFO (new_info);
+}
+
+static gboolean
+shell_desktop_dir_info_equal (ShellDirInfo *dirinfo1,
+                              ShellDirInfo *dirinfo2)
+{
+  ShellDesktopDirInfo *info1 = SHELL_DESKTOP_DIR_INFO (dirinfo1);
+  ShellDesktopDirInfo *info2 = SHELL_DESKTOP_DIR_INFO (dirinfo2);
+
+  if (info1->desktop_id == NULL ||
+      info2->desktop_id == NULL)
+    return info1 == info2;
+
+  return strcmp (info1->desktop_id, info2->desktop_id) == 0;
+}
+
+static const char *
+shell_desktop_dir_info_get_id (ShellDirInfo *dirinfo)
+{
+  ShellDesktopDirInfo *info = SHELL_DESKTOP_DIR_INFO (dirinfo);
+
+  return info->desktop_id;
+}
+
+static const char *
+shell_desktop_dir_info_get_name (ShellDirInfo *dirinfo)
+{
+  ShellDesktopDirInfo *info = SHELL_DESKTOP_DIR_INFO (dirinfo);
+
+  if (info->name == NULL)
+    return _("Unnamed");
+  return info->name;
+}
+
+static const char *
+shell_desktop_dir_info_get_display_name (ShellDirInfo *dirinfo)
+{
+  ShellDesktopDirInfo *info = SHELL_DESKTOP_DIR_INFO (dirinfo);
+
+  if (info->fullname == NULL)
+    return shell_desktop_dir_info_get_name (dirinfo);
+  return info->fullname;
+}
+
+/**
+ * shell_desktop_dir_info_get_is_hidden:
+ * @info: a #ShellDesktopDirInfo.
+ *
+ * A desktop file is hidden if the Hidden key in it is
+ * set to True.
+ *
+ * Returns: %TRUE if hidden, %FALSE otherwise. 
+ **/
+gboolean
+shell_desktop_dir_info_get_is_hidden (ShellDesktopDirInfo *info)
+{
+  return info->hidden;
+}
+
+/**
+ * shell_desktop_dir_info_get_filename:
+ * @info: a #ShellDesktopDirInfo
+ *
+ * When @info was created from a known filename, return it.  In some
+ * situations such as the #ShellDesktopDirInfo returned from
+ * shell_desktop_dir_info_new_from_keyfile(), this function will return %NULL.
+ *
+ * Returns: The full path to the file for @info, or %NULL if not known.
+ */
+const char *
+shell_desktop_dir_info_get_filename (ShellDesktopDirInfo *info)
+{
+  return info->filename;
+}
+
+static const char *
+shell_desktop_dir_info_get_description (ShellDirInfo *dirinfo)
+{
+  ShellDesktopDirInfo *info = SHELL_DESKTOP_DIR_INFO (dirinfo);
+  
+  return info->comment;
+}
+
+static GIcon *
+shell_desktop_dir_info_get_icon (ShellDirInfo *dirinfo)
+{
+  ShellDesktopDirInfo *info = SHELL_DESKTOP_DIR_INFO (dirinfo);
+
+  return info->icon;
+}
+
+/**
+ * shell_desktop_dir_info_get_generic_name:
+ * @info: a #ShellDesktopDirInfo
+ *
+ * Gets the generic name from the destkop file.
+ *
+ * Returns: The value of the GenericName key
+ */
+const char *
+shell_desktop_dir_info_get_generic_name (ShellDesktopDirInfo *info)
+{
+  return info->generic_name;
+}
+
+/**
+ * shell_desktop_dir_info_get_nodisplay:
+ * @info: a #ShellDesktopDirInfo
+ *
+ * Gets the value of the NoDisplay key, which helps determine if the
+ * directory info should be shown in menus. See
+ * #G_KEY_FILE_DESKTOP_KEY_NO_DISPLAY and shell_dir_info_should_show().
+ *
+ * Returns: The value of the NoDisplay key
+ */
+gboolean
+shell_desktop_dir_info_get_nodisplay (ShellDesktopDirInfo *info)
+{
+  return info->nodisplay;
+}
+
+/**
+ * shell_desktop_dir_info_get_show_in:
+ * @info: a #ShellDesktopDirInfo
+ * @desktop_env: a string specifying a desktop name
+ *
+ * Checks if the directory info should be shown in menus that list available
+ * directories for a specific name of the desktop, based on the
+ * <literal>OnlyShowIn</literal> and <literal>NotShowIn</literal> keys.
+ *
+ * If @desktop_env is %NULL, then the name of the desktop set with
+ * shell_desktop_dir_info_set_desktop_env() is used.
+ *
+ * Note that shell_dir_info_should_show() for @info will include this check (with
+ * %NULL for @desktop_env) as well as additional checks.
+ *
+ * Returns: %TRUE if the @info should be shown in @desktop_env according to the
+ * <literal>OnlyShowIn</literal> and <literal>NotShowIn</literal> keys, %FALSE
+ * otherwise.
+ */
+gboolean
+shell_desktop_dir_info_get_show_in (ShellDesktopDirInfo *info,
+                                    const gchar         *desktop_env)
+{
+  gboolean found;
+  int i;
+
+  g_return_val_if_fail (SHELL_IS_DESKTOP_DIR_INFO (info), FALSE);
+
+  if (!desktop_env  ) {
+    G_LOCK (shell_desktop_env);
+    desktop_env = shell_desktop_env;
+    G_UNLOCK (shell_desktop_env);
+  }
+
+  if (info->only_show_in)
+    {
+      if (desktop_env == NULL)
+        return FALSE;
+
+      found = FALSE;
+      for (i = 0; info->only_show_in[i] != NULL; i++)
+        {
+          if (strcmp (info->only_show_in[i], desktop_env) == 0)
+            {
+              found = TRUE;
+              break;
+            }
+        }
+      if (!found)
+        return FALSE;
+    }
+
+  if (info->not_show_in && desktop_env)
+    {
+      for (i = 0; info->not_show_in[i] != NULL; i++)
+        {
+          if (strcmp (info->not_show_in[i], desktop_env) == 0)
+            return FALSE;
+        }
+    }
+
+  return TRUE;
+}
+
+/**
+ * shell_desktop_dir_info_set_desktop_env:
+ * @desktop_env: a string specifying what desktop this is
+ *
+ * Sets the name of the desktop that the application is running in.
+ * This is used by shell_dir_info_should_show() and
+ * shell_desktop_dir_info_get_show_in() to evaluate the
+ * <literal>OnlyShowIn</literal> and <literal>NotShowIn</literal>
+ * desktop entry fields.
+ *
+ * The <ulink url="http://standards.freedesktop.org/menu-spec/latest/">Desktop
+ * Menu specification</ulink> recognizes the following:
+ * <simplelist>
+ *   <member>GNOME</member>
+ *   <member>KDE</member>
+ *   <member>ROX</member>
+ *   <member>XFCE</member>
+ *   <member>LXDE</member>
+ *   <member>Unity</member>
+ *   <member>Old</member>
+ * </simplelist>
+ *
+ * Should be called only once; subsequent calls are ignored.
+ */
+void
+shell_desktop_dir_info_set_desktop_env (const gchar *desktop_env)
+{
+  G_LOCK (shell_desktop_env);
+  if (!shell_desktop_env)
+    shell_desktop_env = g_strdup (desktop_env);
+  G_UNLOCK (shell_desktop_env);
+}
+
+static gboolean
+shell_desktop_dir_info_should_show (ShellDirInfo *dirinfo)
+{
+  ShellDesktopDirInfo *info = SHELL_DESKTOP_DIR_INFO (dirinfo);
+
+  if (info->nodisplay)
+    return FALSE;
+
+  return shell_desktop_dir_info_get_show_in (info, NULL);
+}
+
+static gboolean
+shell_desktop_dir_info_can_delete (ShellDirInfo *dirinfo)
+{
+  ShellDesktopDirInfo *info = SHELL_DESKTOP_DIR_INFO (dirinfo);
+
+  if (info->filename)
+    {
+      if (strstr (info->filename, "/userdir-"))
+        return g_access (info->filename, W_OK) == 0;
+    }
+
+  return FALSE;
+}
+
+static gboolean
+shell_desktop_dir_info_delete (ShellDirInfo *dirinfo)
+{
+  ShellDesktopDirInfo *info = SHELL_DESKTOP_DIR_INFO (dirinfo);
+  
+  if (info->filename)
+    { 
+      if (g_remove (info->filename) == 0)
+        {
+          g_free (info->filename);
+          info->filename = NULL;
+          g_free (info->desktop_id);
+          info->desktop_id = NULL;
+
+          return TRUE;
+        }
+    }
+
+  return FALSE;
+}
+
+/**
+ * shell_dir_info_create_from_directory_name:
+ * @directory_name: the directory name
+ * @error: a #GError location to store the error occurring, %NULL to ignore.
+ *
+ * Creates a new #ShellDirInfo from the given information.
+ *
+ * Returns: (transfer full): new #ShellDirInfo for given directory name.
+ **/
+ShellDirInfo *
+shell_dir_info_create_from_directory_name (const char           *directory_name,
+                                           GError              **error)
+{
+  ShellDesktopDirInfo *info;
+
+  g_return_val_if_fail (directory_name, NULL);
+
+  info = g_object_new (SHELL_TYPE_DESKTOP_DIR_INFO, NULL);
+
+  info->filename = NULL;
+  info->desktop_id = NULL;
+  
+  info->hidden = FALSE;
+  info->nodisplay = TRUE;
+  
+  info->name = g_strdup (directory_name);
+  info->comment = g_strdup_printf (_("Custom definition for %s"), info->name);
+  
+  return SHELL_DIR_INFO (info);
+}
+
+static void
+shell_desktop_dir_info_iface_init (ShellDirInfoIface *iface)
+{
+  iface->dup = shell_desktop_dir_info_dup;
+  iface->equal = shell_desktop_dir_info_equal;
+  iface->get_id = shell_desktop_dir_info_get_id;
+  iface->get_name = shell_desktop_dir_info_get_name;
+  iface->get_description = shell_desktop_dir_info_get_description;
+  iface->get_icon = shell_desktop_dir_info_get_icon;
+  iface->should_show = shell_desktop_dir_info_should_show;
+  iface->can_delete = shell_desktop_dir_info_can_delete;
+  iface->do_delete = shell_desktop_dir_info_delete;
+  iface->get_display_name = shell_desktop_dir_info_get_display_name;
+}
+
+static void
+get_entries_from_dir (GHashTable *entries, 
+                      const char *dirname, 
+                      const char *prefix)
+{
+  GDir *dir;
+  const char *basename;
+  char *filename, *subprefix, *desktop_id;
+  gboolean hidden;
+  ShellDesktopDirInfo *dirinfo;
+  
+  dir = g_dir_open (dirname, 0, NULL);
+  if (dir)
+    {
+      while ((basename = g_dir_read_name (dir)) != NULL)
+        {
+          filename = g_build_filename (dirname, basename, NULL);
+          if (g_str_has_suffix (basename, ".directory"))
+            {
+              desktop_id = g_strconcat (prefix, basename, NULL);
+
+              /* Use _extended so we catch NULLs too (hidden) */
+              if (!g_hash_table_lookup_extended (entries, desktop_id, NULL, NULL))
+                {
+                  dirinfo = shell_desktop_dir_info_new_from_filename (filename);
+                  hidden = FALSE;
+
+                  if (dirinfo && shell_desktop_dir_info_get_is_hidden (dirinfo))
+                    {
+                      g_object_unref (dirinfo);
+                      dirinfo = NULL;
+                      hidden = TRUE;
+                    }
+                                      
+                  if (dirinfo || hidden)
+                    {
+                      g_hash_table_insert (entries, g_strdup (desktop_id), dirinfo);
+
+                      if (dirinfo)
+                        {
+                          /* Reuse instead of strdup here */
+                          dirinfo->desktop_id = desktop_id;
+                          desktop_id = NULL;
+                        }
+                    }
+                }
+              g_free (desktop_id);
+            }
+          else
+            {
+              if (g_file_test (filename, G_FILE_TEST_IS_DIR))
+                {
+                  subprefix = g_strconcat (prefix, basename, "-", NULL);
+                  get_entries_from_dir (entries, filename, subprefix);
+                  g_free (subprefix);
+                }
+            }
+          g_free (filename);
+        }
+      g_dir_close (dir);
+    }
+}
+
+
+/**
+ * shell_dir_info_get_all:
+ *
+ * Gets a list of all of the desktop directories currently registered 
+ * on this system.
+ * 
+ * For desktop files, this includes directories that have 
+ * <literal>NoDisplay=true</literal> set or are excluded from 
+ * display by means of <literal>OnlyShowIn</literal> or
+ * <literal>NotShowIn</literal>. See shell_dir_info_should_show().
+ * The returned list does not include directories which have
+ * the <literal>Hidden</literal> key set. 
+ * 
+ * Returns: (element-type ShellDirInfo) (transfer full): a newly allocated #GList of references to #ShellDirInfo<!---->s.
+ **/
+GList *
+shell_dir_info_get_all (void)
+{
+  const char * const *dirs;
+  GHashTable *entries;
+  GHashTableIter iter;
+  gpointer value;
+  int i;
+  GList *infos;
+
+  dirs = get_directories_search_path ();
+
+  entries = g_hash_table_new_full (g_str_hash, g_str_equal,
+                                   g_free, NULL);
+
+  
+  for (i = 0; dirs[i] != NULL; i++)
+    get_entries_from_dir (entries, dirs[i], "");
+
+
+  infos = NULL;
+  g_hash_table_iter_init (&iter, entries);
+  while (g_hash_table_iter_next (&iter, NULL, &value))
+    {
+      if (value)
+        infos = g_list_prepend (infos, value);
+    }
+
+  g_hash_table_destroy (entries);
+
+  return g_list_reverse (infos);
+}
+
+/**
+ * shell_desktop_dir_info_get_string:
+ * @info: a #ShellDesktopDirInfo
+ * @key: the key to look up
+ *
+ * Looks up a string value in the keyfile backing @info.
+ *
+ * The @key is looked up in the "Desktop Entry" group.
+ *
+ * Returns: a newly allocated string, or %NULL if the key
+ *     is not found
+ */
+char *
+shell_desktop_dir_info_get_string (ShellDesktopDirInfo *info,
+                                   const char      *key)
+{
+  g_return_val_if_fail (SHELL_IS_DESKTOP_DIR_INFO (info), NULL);
+
+  return g_key_file_get_string (info->keyfile,
+                                G_KEY_FILE_DESKTOP_GROUP, key, NULL);
+}
+
+/**
+ * shell_desktop_dir_info_get_boolean:
+ * @info: a #ShellDesktopDirInfo
+ * @key: the key to look up
+ *
+ * Looks up a boolean value in the keyfile backing @info.
+ *
+ * The @key is looked up in the "Desktop Entry" group.
+ *
+ * Returns: the boolean value, or %FALSE if the key
+ *     is not found
+ */
+gboolean
+shell_desktop_dir_info_get_boolean (ShellDesktopDirInfo *info,
+                                    const char      *key)
+{
+  g_return_val_if_fail (SHELL_IS_DESKTOP_DIR_INFO (info), FALSE);
+
+  return g_key_file_get_boolean (info->keyfile,
+                                 G_KEY_FILE_DESKTOP_GROUP, key, NULL);
+}
+
+/**
+ * shell_desktop_dir_info_has_key:
+ * @info: a #ShellDesktopDirInfo
+ * @key: the key to look up
+ *
+ * Returns whether @key exists in the "Desktop Entry" group
+ * of the keyfile backing @info.
+ *
+ * Returns: %TRUE if the @key exists
+ */
+gboolean
+shell_desktop_dir_info_has_key (ShellDesktopDirInfo *info,
+                                const char      *key)
+{
+  g_return_val_if_fail (SHELL_IS_DESKTOP_DIR_INFO (info), FALSE);
+
+  return g_key_file_has_key (info->keyfile,
+                             G_KEY_FILE_DESKTOP_GROUP, key, NULL);
+}
+
+gboolean
+shell_desktop_dir_info_create_custom_with_name (ShellDesktopDirInfo *info,
+                                                const char          *name,
+                                                GError             **error)
+{
+  GError *internal_error = NULL;
+  char *user_path, *buf;
+  gsize len;
+  char **keys;
+  gsize i;
+
+  g_free (info->name);
+  info->name = g_strdup (name);
+
+  /* no keyfile, we just store it in the DirInfo */
+  if (info->keyfile == NULL)
+    return TRUE;
+
+  /* remove all translated 'Name' keys */
+  keys = g_key_file_get_keys (info->keyfile,
+                              G_KEY_FILE_DESKTOP_GROUP,
+                              &len,
+                              NULL);
+  for (i = 0; i < len; i++)
+    {
+      if (strncmp (keys[i], G_KEY_FILE_DESKTOP_KEY_NAME,
+                   strlen(G_KEY_FILE_DESKTOP_KEY_NAME)) == 0)
+        {
+          g_key_file_remove_key (info->keyfile,
+                                 G_KEY_FILE_DESKTOP_GROUP,
+                                 keys[i],
+                                 NULL);
+        }
+    }
+
+  /* create a new 'Name' key with the new name */
+  g_key_file_set_string (info->keyfile,
+                         G_KEY_FILE_DESKTOP_GROUP,
+                         G_KEY_FILE_DESKTOP_KEY_NAME,
+                         name);
+
+  buf = g_key_file_to_data (info->keyfile, &len, &internal_error);
+  if (internal_error != NULL)
+    {
+      g_propagate_error (error, internal_error);
+      return FALSE;
+    }
+
+  user_path = g_build_filename (g_get_user_data_dir (),
+                                "desktop-directories",
+                                NULL);
+
+  if (g_mkdir_with_parents (user_path, 0755) < 0)
+    {
+      int saved_errno = errno;
+
+      g_set_error (error, G_FILE_ERROR,
+                   G_FILE_ERROR_FAILED,
+                   "Unable to create '%s': %s",
+                   user_path,
+                   g_strerror (saved_errno));
+
+      g_free (user_path);
+      g_free (buf);
+
+      return FALSE;
+    }
+
+  g_free (user_path);
+
+  /* store the keyfile in the user's data directory; it will take
+   * precedence over the system one when we reload the list of
+   * folders
+   */
+  user_path = g_build_filename (g_get_user_data_dir (),
+                                "desktop-directories",
+                                info->desktop_id,
+                                NULL);
+
+  g_file_set_contents (user_path, buf, len, &internal_error);
+  if (internal_error != NULL)
+    {
+      g_propagate_error (error, internal_error);
+      g_free (user_path);
+      g_free (buf);
+
+      return FALSE;
+    }
+
+  g_free (user_path);
+  g_free (buf);
+
+  return TRUE;
+}

--- a/src/shell-desktop-dir-info.h
+++ b/src/shell-desktop-dir-info.h
@@ -1,0 +1,83 @@
+/* EOS Shell desktop directory information
+ *
+ * Copyright © 2013 Endless Mobile, Inc.
+ *
+ * Based on https://git.gnome.org/browse/glib/tree/gio/gdesktopappinfo.h
+ * Copyright (C) 2006-2007 Red Hat, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General
+ * Public License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place, Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+#ifndef __SHELL_DESKTOP_DIR_INFO_H__
+#define __SHELL_DESKTOP_DIR_INFO_H__
+
+#include <gio/gio.h>
+
+G_BEGIN_DECLS
+
+typedef struct _ShellDesktopDirInfo        ShellDesktopDirInfo;
+typedef struct _ShellDesktopDirInfoClass   ShellDesktopDirInfoClass;
+
+#define SHELL_TYPE_DESKTOP_DIR_INFO         (shell_desktop_dir_info_get_type ())
+#define SHELL_DESKTOP_DIR_INFO(o)           (G_TYPE_CHECK_INSTANCE_CAST ((o), SHELL_TYPE_DESKTOP_DIR_INFO, ShellDesktopDirInfo))
+#define SHELL_DESKTOP_DIR_INFO_CLASS(k)     (G_TYPE_CHECK_CLASS_CAST((k), SHELL_TYPE_DESKTOP_DIR_INFO, ShellDesktopDirInfoClass))
+#define SHELL_IS_DESKTOP_DIR_INFO(o)        (G_TYPE_CHECK_INSTANCE_TYPE ((o), SHELL_TYPE_DESKTOP_DIR_INFO))
+#define SHELL_IS_DESKTOP_DIR_INFO_CLASS(k)  (G_TYPE_CHECK_CLASS_TYPE ((k), SHELL_TYPE_DESKTOP_DIR_INFO))
+#define SHELL_DESKTOP_DIR_INFO_GET_CLASS(o) (G_TYPE_INSTANCE_GET_CLASS ((o), SHELL_TYPE_DESKTOP_DIR_INFO, ShellDesktopDirInfoClass))
+
+struct _ShellDesktopDirInfoClass
+{
+  GObjectClass parent_class;
+};
+
+
+GType            shell_desktop_dir_info_get_type          (void) G_GNUC_CONST;
+
+ShellDesktopDirInfo *shell_desktop_dir_info_new_from_filename (const char      *filename);
+
+ShellDesktopDirInfo *shell_desktop_dir_info_new_from_keyfile  (GKeyFile        *key_file);
+
+const char *     shell_desktop_dir_info_get_filename      (ShellDesktopDirInfo *info);
+
+const char *     shell_desktop_dir_info_get_generic_name  (ShellDesktopDirInfo *info);
+
+gboolean         shell_desktop_dir_info_get_nodisplay     (ShellDesktopDirInfo *info);
+
+gboolean         shell_desktop_dir_info_get_show_in       (ShellDesktopDirInfo *info,
+                                                           const gchar     *desktop_env);
+
+ShellDesktopDirInfo *shell_desktop_dir_info_new           (const char      *desktop_id);
+
+gboolean         shell_desktop_dir_info_get_is_hidden     (ShellDesktopDirInfo *info);
+
+void             shell_desktop_dir_info_set_desktop_env   (const char      *desktop_env);
+
+gboolean         shell_desktop_dir_info_has_key           (ShellDesktopDirInfo *info,
+                                                           const char      *key);
+
+char *           shell_desktop_dir_info_get_string        (ShellDesktopDirInfo *info,
+                                                           const char      *key);
+
+gboolean         shell_desktop_dir_info_get_boolean       (ShellDesktopDirInfo *info,
+                                                           const char      *key);
+
+gboolean         shell_desktop_dir_info_create_custom_with_name (ShellDesktopDirInfo *info,
+                                                                 const char          *name,
+                                                                 GError             **error);
+
+G_END_DECLS
+
+#endif /* __SHELL_DESKTOP_DIR_INFO_H__ */

--- a/src/shell-dir-info.c
+++ b/src/shell-dir-info.c
@@ -1,0 +1,281 @@
+/* EOS Shell directory information
+ *
+ * Copyright © 2013 Endless Mobile, Inc.
+ *
+ * Based on https://git.gnome.org/browse/glib/tree/gio/gappinfo.c
+ * Copyright (C) 2006-2007 Red Hat, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General
+ * Public License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place, Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+#include "config.h"
+#include "shell-dir-info.h"
+
+#include <gio/gio.h>
+
+
+/**
+ * SECTION:shelldirinfo
+ * @short_description: Desktop directory information
+ * @include: gio/gio.h
+ * 
+ * #ShellDirInfo is used for describing directories on the desktop.
+ *
+ **/
+
+typedef ShellDirInfoIface ShellDirInfoInterface;
+G_DEFINE_INTERFACE (ShellDirInfo, shell_dir_info, G_TYPE_OBJECT)
+
+static void
+shell_dir_info_default_init (ShellDirInfoInterface *iface)
+{
+}
+
+
+/**
+ * shell_dir_info_dup:
+ * @dirinfo: a #ShellDirInfo.
+ * 
+ * Creates a duplicate of a #ShellDirInfo.
+ *
+ * Returns: (transfer full): a duplicate of @dirinfo.
+ **/
+ShellDirInfo *
+shell_dir_info_dup (ShellDirInfo *dirinfo)
+{
+  ShellDirInfoIface *iface;
+
+  g_return_val_if_fail (SHELL_IS_DIR_INFO (dirinfo), NULL);
+
+  iface = SHELL_DIR_INFO_GET_IFACE (dirinfo);
+
+  return (* iface->dup) (dirinfo);
+}
+
+/**
+ * shell_dir_info_equal:
+ * @dirinfo1: the first #ShellDirInfo.
+ * @dirinfo2: the second #ShellDirInfo.
+ *
+ * Checks if two #ShellDirInfo<!-- -->s are equal.
+ *
+ * Returns: %TRUE if @dirinfo1 is equal to @dirinfo2. %FALSE otherwise.
+ **/
+gboolean
+shell_dir_info_equal (ShellDirInfo *dirinfo1,
+                      ShellDirInfo *dirinfo2)
+{
+  ShellDirInfoIface *iface;
+
+  g_return_val_if_fail (SHELL_IS_DIR_INFO (dirinfo1), FALSE);
+  g_return_val_if_fail (SHELL_IS_DIR_INFO (dirinfo2), FALSE);
+
+  if (G_TYPE_FROM_INSTANCE (dirinfo1) != G_TYPE_FROM_INSTANCE (dirinfo2))
+    return FALSE;
+  
+  iface = SHELL_DIR_INFO_GET_IFACE (dirinfo1);
+
+  return (* iface->equal) (dirinfo1, dirinfo2);
+}
+
+/**
+ * shell_dir_info_get_id:
+ * @dirinfo: a #ShellDirInfo.
+ * 
+ * Gets the ID of a directory. An id is a string that
+ * identifies the directory. The exact format of the id is
+ * platform dependent. For instance, on Unix this is the
+ * desktop file id from the xdg menu specification.
+ *
+ * Note that the returned ID may be %NULL, depending on how
+ * the @dirinfo has been constructed.
+ *
+ * Returns: a string containing the directory's ID.
+ **/
+const char *
+shell_dir_info_get_id (ShellDirInfo *dirinfo)
+{
+  ShellDirInfoIface *iface;
+  
+  g_return_val_if_fail (SHELL_IS_DIR_INFO (dirinfo), NULL);
+
+  iface = SHELL_DIR_INFO_GET_IFACE (dirinfo);
+
+  return (* iface->get_id) (dirinfo);
+}
+
+/**
+ * shell_dir_info_get_name:
+ * @dirinfo: a #ShellDirInfo.
+ * 
+ * Gets the name of the directory. 
+ *
+ * Returns: the name of the directory for @dirinfo.
+ **/
+const char *
+shell_dir_info_get_name (ShellDirInfo *dirinfo)
+{
+  ShellDirInfoIface *iface;
+  
+  g_return_val_if_fail (SHELL_IS_DIR_INFO (dirinfo), NULL);
+
+  iface = SHELL_DIR_INFO_GET_IFACE (dirinfo);
+
+  return (* iface->get_name) (dirinfo);
+}
+
+/**
+ * shell_dir_info_get_display_name:
+ * @dirinfo: a #ShellDirInfo.
+ *
+ * Gets the display name of the directory. The display name is often more
+ * descriptive to the user than the name itself.
+ *
+ * Returns: the display name of the directory for @dirinfo, or the name if
+ * no display name is available.
+ **/
+const char *
+shell_dir_info_get_display_name (ShellDirInfo *dirinfo)
+{
+  ShellDirInfoIface *iface;
+
+  g_return_val_if_fail (SHELL_IS_DIR_INFO (dirinfo), NULL);
+
+  iface = SHELL_DIR_INFO_GET_IFACE (dirinfo);
+
+  if (iface->get_display_name == NULL)
+    return (* iface->get_name) (dirinfo);
+
+  return (* iface->get_display_name) (dirinfo);
+}
+
+/**
+ * shell_dir_info_get_description:
+ * @dirinfo: a #ShellDirInfo.
+ * 
+ * Gets a human-readable description of a directory.
+ *
+ * Returns: a string containing a description of the 
+ * directory @dirinfo, or %NULL if none. 
+ **/
+const char *
+shell_dir_info_get_description (ShellDirInfo *dirinfo)
+{
+  ShellDirInfoIface *iface;
+  
+  g_return_val_if_fail (SHELL_IS_DIR_INFO (dirinfo), NULL);
+
+  iface = SHELL_DIR_INFO_GET_IFACE (dirinfo);
+
+  return (* iface->get_description) (dirinfo);
+}
+
+
+/**
+ * shell_dir_info_get_icon:
+ * @dirinfo: a #ShellDirInfo.
+ * 
+ * Gets the icon for the directory.
+ *
+ * Returns: (transfer none): the default #GIcon for @dirinfo or %NULL
+ * if there is no default icon.
+ **/
+GIcon *
+shell_dir_info_get_icon (ShellDirInfo *dirinfo)
+{
+  ShellDirInfoIface *iface;
+  
+  g_return_val_if_fail (SHELL_IS_DIR_INFO (dirinfo), NULL);
+
+  iface = SHELL_DIR_INFO_GET_IFACE (dirinfo);
+
+  return (* iface->get_icon) (dirinfo);
+}
+
+
+/**
+ * shell_dir_info_should_show:
+ * @dirinfo: a #ShellDirInfo.
+ *
+ * Checks if the directory info should be shown in menus that 
+ * list available directories.
+ * 
+ * Returns: %TRUE if the @dirinfo should be shown, %FALSE otherwise.
+ **/
+gboolean
+shell_dir_info_should_show (ShellDirInfo *dirinfo)
+{
+  ShellDirInfoIface *iface;
+  
+  g_return_val_if_fail (SHELL_IS_DIR_INFO (dirinfo), FALSE);
+
+  iface = SHELL_DIR_INFO_GET_IFACE (dirinfo);
+
+  return (* iface->should_show) (dirinfo);
+}
+
+
+/**
+ * shell_dir_info_can_delete:
+ * @dirinfo: a #ShellDirInfo
+ *
+ * Obtains the information whether the #ShellDirInfo can be deleted.
+ * See shell_dir_info_delete().
+ *
+ * Returns: %TRUE if @dirinfo can be deleted
+ */
+gboolean
+shell_dir_info_can_delete (ShellDirInfo *dirinfo)
+{
+  ShellDirInfoIface *iface;
+  
+  g_return_val_if_fail (SHELL_IS_DIR_INFO (dirinfo), FALSE);
+
+  iface = SHELL_DIR_INFO_GET_IFACE (dirinfo);
+
+  if (iface->can_delete)
+    return (* iface->can_delete) (dirinfo);
+ 
+  return FALSE; 
+}
+
+
+/**
+ * shell_dir_info_delete: (virtual do_delete)
+ * @dirinfo: a #ShellDirInfo
+ *
+ * Tries to delete a #ShellDirInfo.
+ *
+ * On some platforms, there may be a difference between user-defined
+ * #ShellDirInfo<!-- -->s which can be deleted, and system-wide ones which
+ * cannot. See shell_dir_info_can_delete().
+ *
+ * Returns: %TRUE if @dirinfo has been deleted
+ */
+gboolean
+shell_dir_info_delete (ShellDirInfo *dirinfo)
+{
+  ShellDirInfoIface *iface;
+  
+  g_return_val_if_fail (SHELL_IS_DIR_INFO (dirinfo), FALSE);
+
+  iface = SHELL_DIR_INFO_GET_IFACE (dirinfo);
+
+  if (iface->do_delete)
+    return (* iface->do_delete) (dirinfo);
+ 
+  return FALSE; 
+}

--- a/src/shell-dir-info.h
+++ b/src/shell-dir-info.h
@@ -1,0 +1,113 @@
+/* EOS Shell directory information
+ *
+ * Copyright © 2013 Endless Mobile, Inc.
+ *
+ * Based on https://git.gnome.org/browse/glib/tree/gio/gappinfo.h
+ * Copyright (C) 2006-2007 Red Hat, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General
+ * Public License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place, Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+#ifndef __SHELL_DIR_INFO_H__
+#define __SHELL_DIR_INFO_H__
+
+#include <gio/gio.h>
+
+G_BEGIN_DECLS
+
+typedef struct _ShellDirInfo ShellDirInfo;
+
+#define SHELL_TYPE_DIR_INFO            (shell_dir_info_get_type ())
+#define SHELL_DIR_INFO(obj)            (G_TYPE_CHECK_INSTANCE_CAST ((obj), SHELL_TYPE_DIR_INFO, ShellDirInfo))
+#define SHELL_IS_DIR_INFO(obj)         (G_TYPE_CHECK_INSTANCE_TYPE ((obj), SHELL_TYPE_DIR_INFO))
+#define SHELL_DIR_INFO_GET_IFACE(obj)  (G_TYPE_INSTANCE_GET_INTERFACE ((obj), SHELL_TYPE_DIR_INFO, ShellDirInfoIface))
+
+
+/**
+ * ShellDirInfo:
+ *
+ * Information about a desktop directory.
+ */
+
+/**
+ * ShellDirInfoIface:
+ * @g_iface: The parent interface.
+ * @dup: Copies a #ShellDirInfo.
+ * @equal: Checks two #ShellDirInfo<!-- -->s for equality.
+ * @get_id: Gets a string identifier for a #ShellDirInfo.
+ * @get_name: Gets the name of the directory for a #ShellDirInfo.
+ * @get_description: Gets a short description for the directory described by the #ShellDirInfo.
+ * @get_icon: Gets the #GIcon for the #ShellDirInfo.
+ * @should_show: Returns whether a directory should be shown (e.g. when getting a list of desktop directories).
+ * @can_delete: Checks if a #ShellDirInfo can be deleted.
+ * @do_delete: Deletes a #ShellDirInfo.
+ * @get_display_name: Gets the display name for the #ShellDirInfo.
+ *
+ * Directory Information interface, for operating system portability.
+ */
+typedef struct _ShellDirInfoIface    ShellDirInfoIface;
+
+struct _ShellDirInfoIface
+{
+  GTypeInterface g_iface;
+
+  /* Virtual Table */
+
+  ShellDirInfo *   (* dup)                      (ShellDirInfo   *dirinfo);
+  gboolean     (* equal)                        (ShellDirInfo   *dirinfo1,
+                                                 ShellDirInfo   *dirinfo2);
+  const char * (* get_id)                       (ShellDirInfo   *dirinfo);
+  const char * (* get_name)                     (ShellDirInfo   *dirinfo);
+  const char * (* get_description)              (ShellDirInfo   *dirinfo);
+  GIcon *      (* get_icon)                     (ShellDirInfo   *dirinfo);
+  gboolean     (* should_show)                  (ShellDirInfo   *dirinfo);
+  gboolean     (* can_delete)                   (ShellDirInfo   *dirinfo);
+  gboolean     (* do_delete)                    (ShellDirInfo   *dirinfo);
+  const char * (* get_display_name)             (ShellDirInfo   *dirinfo);
+};
+
+GType       shell_dir_info_get_type             (void) G_GNUC_CONST;
+
+ShellDirInfo *  shell_dir_info_create_from_directory_name
+                                                (const char     *directory_name,
+                                                 GError        **error);
+
+ShellDirInfo *  shell_dir_info_dup              (ShellDirInfo   *dirinfo);
+
+gboolean    shell_dir_info_equal                (ShellDirInfo   *dirinfo1,
+                                                 ShellDirInfo   *dirinfo2);
+
+const char *shell_dir_info_get_id               (ShellDirInfo   *dirinfo);
+
+const char *shell_dir_info_get_name             (ShellDirInfo   *dirinfo);
+
+const char *shell_dir_info_get_display_name     (ShellDirInfo   *dirinfo);
+
+const char *shell_dir_info_get_description      (ShellDirInfo   *dirinfo);
+
+GIcon *     shell_dir_info_get_icon             (ShellDirInfo   *dirinfo);
+
+gboolean    shell_dir_info_should_show          (ShellDirInfo   *dirinfo);
+
+gboolean    shell_dir_info_can_delete           (ShellDirInfo   *dirinfo);
+
+gboolean    shell_dir_info_delete               (ShellDirInfo   *dirinfo);
+
+GList *     shell_dir_info_get_all              (void);
+
+G_END_DECLS
+
+#endif /* __SHELL_DIR_INFO_H__ */

--- a/src/shell-grid-desaturate-effect.c
+++ b/src/shell-grid-desaturate-effect.c
@@ -1,0 +1,483 @@
+/*
+ * Clutter.
+ *
+ * An OpenGL based 'interactive canvas' library.
+ *
+ * Copyright (C) 2010  Intel Corporation.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Author:
+ *   Emmanuele Bassi <ebassi@linux.intel.com>
+ */
+
+/**
+ * SECTION:clutter-desaturate-effect
+ * @short_description: A desaturation effect
+ * @see_also: #ClutterEffect, #ClutterOffscreenEffect
+ *
+ * #ShellGridDesaturateEffect is a sub-class of #ClutterEffect that
+ * desaturates the color of an actor and its contents. The strenght
+ * of the desaturation effect is controllable and animatable through
+ * the #ShellGridDesaturateEffect:factor property.
+ *
+ * #ShellGridDesaturateEffect is available since Clutter 1.4
+ */
+
+#define SHELL_GRID_DESATURATE_EFFECT_CLASS(klass)        (G_TYPE_CHECK_CLASS_CAST ((klass), SHELL_TYPE_GRID_DESATURATE_EFFECT, ShellGridDesaturateEffectClass))
+#define SHELL_IS_GRID_DESATURATE_EFFECT_CLASS(klass)     (G_TYPE_CHECK_CLASS_TYPE ((klass), SHELL_TYPE_GRID_DESATURATE_EFFECT))
+#define SHELL_GRID_DESATURATE_EFFECT_GET_CLASS(obj)      (G_TYPE_INSTANCE_GET_CLASS ((obj), SHELL_TYPE_GRID_DESATURATE_EFFECT, ShellGridDesaturateEffectClass))
+
+#include <math.h>
+
+#include "shell-grid-desaturate-effect.h"
+
+#include <cogl/cogl.h>
+
+struct _ShellGridDesaturateEffect
+{
+  ClutterOffscreenEffect parent_instance;
+
+  /* the desaturation factor, also known as "strength" */
+  gdouble factor;
+
+  /* an area not to be shaded */
+  ClutterRect *unshaded_rect;
+
+  gint factor_uniform;
+  gint unshaded_uniform;
+
+  gint tex_width;
+  gint tex_height;
+
+  gboolean unshaded_uniform_dirty;
+
+  CoglPipeline *pipeline;
+};
+
+struct _ShellGridDesaturateEffectClass
+{
+  ClutterOffscreenEffectClass parent_class;
+
+  CoglPipeline *base_pipeline;
+};
+
+/* the magic gray vec3 has been taken from the NTSC conversion weights
+ * as defined by:
+ *
+ *   "OpenGL Superbible, 4th edition"
+ *   -- Richard S. Wright Jr, Benjamin Lipchak, Nicholas Haemel
+ *   Addison-Wesley
+ */
+static const gchar *desaturate_glsl_declarations =
+  "uniform float factor;\n"
+  "uniform vec4 unshaded;\n"
+  "\n"
+  "vec3 desaturate (const vec3 color, const float desaturation)\n"
+  "{\n"
+  "  if ((cogl_tex_coord0_in[0] > unshaded[0]) && (cogl_tex_coord0_in[0] < unshaded[2]) &&\n"
+  "      (cogl_tex_coord0_in[1] > unshaded[1]) && (cogl_tex_coord0_in[1] < unshaded[3]))\n"
+  "    return color;\n"
+  "  const vec3 gray_conv = vec3 (0.299, 0.587, 0.114);\n"
+  "  vec3 gray = vec3 (dot (gray_conv, color));\n"
+  "  return vec3 (mix (color.rgb, gray, desaturation));\n"
+  "}\n";
+
+static const gchar *desaturate_glsl_source =
+  "  cogl_color_out.rgb = desaturate (cogl_color_out.rgb, factor);\n";
+
+enum
+{
+  PROP_0,
+
+  PROP_FACTOR,
+  PROP_UNSHADED_RECT,
+
+  PROP_LAST
+};
+
+static GParamSpec *obj_props[PROP_LAST];
+
+G_DEFINE_TYPE (ShellGridDesaturateEffect,
+               shell_grid_desaturate_effect,
+               CLUTTER_TYPE_OFFSCREEN_EFFECT);
+
+static void update_unshaded_uniform (ShellGridDesaturateEffect *self);
+
+static gboolean
+shell_grid_desaturate_effect_pre_paint (ClutterEffect *effect)
+{
+  ShellGridDesaturateEffect *self = SHELL_GRID_DESATURATE_EFFECT (effect);
+  ClutterEffectClass *parent_class;
+
+  if (!clutter_actor_meta_get_enabled (CLUTTER_ACTOR_META (effect)))
+    return FALSE;
+
+  if (!clutter_feature_available (CLUTTER_FEATURE_SHADERS_GLSL))
+    {
+      /* if we don't have support for GLSL shaders then we
+       * forcibly disable the ActorMeta
+       */
+      g_warning ("Unable to use the ShaderEffect: the graphics hardware "
+                 "or the current GL driver does not implement support "
+                 "for the GLSL shading language.");
+      clutter_actor_meta_set_enabled (CLUTTER_ACTOR_META (effect), FALSE);
+      return FALSE;
+    }
+
+  parent_class = CLUTTER_EFFECT_CLASS (shell_grid_desaturate_effect_parent_class);
+  if (parent_class->pre_paint (effect))
+    {
+      ClutterOffscreenEffect *offscreen_effect =
+        CLUTTER_OFFSCREEN_EFFECT (effect);
+      CoglHandle texture;
+
+      texture = clutter_offscreen_effect_get_texture (offscreen_effect);
+      self->tex_width = cogl_texture_get_width (texture);
+      self->tex_height = cogl_texture_get_height (texture);
+
+      if (self->unshaded_uniform_dirty)
+        update_unshaded_uniform (self);
+
+      cogl_pipeline_set_layer_texture (self->pipeline, 0, texture);
+
+      return TRUE;
+    }
+  else
+    return FALSE;
+}
+
+static void
+shell_grid_desaturate_effect_paint_target (ClutterOffscreenEffect *effect)
+{
+  ShellGridDesaturateEffect *self = SHELL_GRID_DESATURATE_EFFECT (effect);
+  ClutterActor *actor;
+  CoglHandle texture;
+  guint8 paint_opacity;
+
+  texture = clutter_offscreen_effect_get_texture (effect);
+  cogl_pipeline_set_layer_texture (self->pipeline, 0, texture);
+
+  actor = clutter_actor_meta_get_actor (CLUTTER_ACTOR_META (effect));
+  paint_opacity = clutter_actor_get_paint_opacity (actor);
+
+  cogl_pipeline_set_color4ub (self->pipeline,
+                              paint_opacity,
+                              paint_opacity,
+                              paint_opacity,
+                              paint_opacity);
+  cogl_push_source (self->pipeline);
+
+  cogl_rectangle (0, 0,
+                  cogl_texture_get_width (texture),
+                  cogl_texture_get_height (texture));
+
+  cogl_pop_source ();
+}
+
+static void
+shell_grid_desaturate_effect_dispose (GObject *gobject)
+{
+  ShellGridDesaturateEffect *self = SHELL_GRID_DESATURATE_EFFECT (gobject);
+
+  if (self->pipeline != NULL)
+    {
+      cogl_object_unref (self->pipeline);
+      self->pipeline = NULL;
+    }
+
+  clutter_rect_free (self->unshaded_rect);
+  self->unshaded_rect = NULL;
+
+  G_OBJECT_CLASS (shell_grid_desaturate_effect_parent_class)->dispose (gobject);
+}
+
+static void
+shell_grid_desaturate_effect_set_property (GObject      *gobject,
+                                           guint         prop_id,
+                                           const GValue *value,
+                                           GParamSpec   *pspec)
+{
+  ShellGridDesaturateEffect *effect = SHELL_GRID_DESATURATE_EFFECT (gobject);
+
+  switch (prop_id)
+    {
+    case PROP_FACTOR:
+      shell_grid_desaturate_effect_set_factor (effect,
+                                               g_value_get_double (value));
+      break;
+
+    case PROP_UNSHADED_RECT:
+      shell_grid_desaturate_effect_set_unshaded_rect (effect,
+                                                      g_value_get_boxed (value));
+      break;
+
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (gobject, prop_id, pspec);
+      break;
+    }
+}
+
+static void
+shell_grid_desaturate_effect_get_property (GObject    *gobject,
+                                           guint       prop_id,
+                                           GValue     *value,
+                                           GParamSpec *pspec)
+{
+  ShellGridDesaturateEffect *effect = SHELL_GRID_DESATURATE_EFFECT (gobject);
+
+  switch (prop_id)
+    {
+    case PROP_FACTOR:
+      g_value_set_double (value, effect->factor);
+      break;
+
+    case PROP_UNSHADED_RECT:
+      g_value_set_boxed (value, effect->unshaded_rect);
+      break;
+
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (gobject, prop_id, pspec);
+      break;
+    }
+}
+
+static void
+update_factor_uniform (ShellGridDesaturateEffect *self)
+{
+  if (self->factor_uniform > -1)
+    cogl_pipeline_set_uniform_1f (self->pipeline,
+                                  self->factor_uniform,
+                                  self->factor);
+}
+
+static void
+update_unshaded_uniform (ShellGridDesaturateEffect *self)
+{
+  float values[4] = { 0., 0., 0., 0.};
+  ClutterOffscreenEffect *offscreen_effect = CLUTTER_OFFSCREEN_EFFECT (self);
+  CoglHandle texture;
+  float width, height;
+
+  if (self->unshaded_uniform == -1)
+    return;
+
+  texture = clutter_offscreen_effect_get_texture (offscreen_effect);
+  if (texture == COGL_INVALID_HANDLE)
+    goto out;
+
+  width = cogl_texture_get_width (texture);
+  height = cogl_texture_get_height (texture);
+
+  values[0] = MIN (1.0, self->unshaded_rect->origin.x / width);
+  values[1] = MIN (1.0, self->unshaded_rect->origin.y / height);
+  values[2] = MIN (1.0, (self->unshaded_rect->origin.x + self->unshaded_rect->size.width) / width);
+  values[3] = MIN (1.0, (self->unshaded_rect->origin.y + self->unshaded_rect->size.height) / height);
+
+  self->unshaded_uniform_dirty = FALSE;
+
+ out:
+  cogl_pipeline_set_uniform_float (self->pipeline,
+                                   self->unshaded_uniform,
+                                   4, 1,
+                                   values);
+}
+
+static void
+shell_grid_desaturate_effect_class_init (ShellGridDesaturateEffectClass *klass)
+{
+  ClutterEffectClass *effect_class = CLUTTER_EFFECT_CLASS (klass);
+  GObjectClass *gobject_class = G_OBJECT_CLASS (klass);
+  ClutterOffscreenEffectClass *offscreen_class;
+
+  offscreen_class = CLUTTER_OFFSCREEN_EFFECT_CLASS (klass);
+  offscreen_class->paint_target = shell_grid_desaturate_effect_paint_target;
+
+  effect_class->pre_paint = shell_grid_desaturate_effect_pre_paint;
+
+  /**
+   * ShellGridDesaturateEffect:factor:
+   *
+   * The desaturation factor, between 0.0 (no desaturation) and 1.0 (full
+   * desaturation).
+   */
+  obj_props[PROP_FACTOR] =
+    g_param_spec_double ("factor",
+                         "Factor",
+                         "The desaturation factor",
+                         0.0, 1.0,
+                         1.0,
+                         G_PARAM_READWRITE);
+
+  /**
+   * ShellGridDesaturateEffect:unshaded-rect:
+   *
+   * The unshaded rectangle.
+   */
+  obj_props[PROP_UNSHADED_RECT] =
+    g_param_spec_boxed ("unshaded-rect",
+                        "Unshaded rect",
+                        "The unshaded rectangle",
+                        CLUTTER_TYPE_RECT,
+                        G_PARAM_READWRITE);
+
+  gobject_class->dispose = shell_grid_desaturate_effect_dispose;
+  gobject_class->set_property = shell_grid_desaturate_effect_set_property;
+  gobject_class->get_property = shell_grid_desaturate_effect_get_property;
+
+  g_object_class_install_properties (gobject_class, PROP_LAST, obj_props);
+}
+
+static void
+shell_grid_desaturate_effect_init (ShellGridDesaturateEffect *self)
+{
+  ShellGridDesaturateEffectClass *klass = SHELL_GRID_DESATURATE_EFFECT_GET_CLASS (self);
+
+  if (G_UNLIKELY (klass->base_pipeline == NULL))
+    {
+      CoglContext *ctx =
+        clutter_backend_get_cogl_context (clutter_get_default_backend ());
+      CoglSnippet *snippet;
+
+      klass->base_pipeline = cogl_pipeline_new (ctx);
+
+      snippet = cogl_snippet_new (COGL_SNIPPET_HOOK_FRAGMENT,
+                                  desaturate_glsl_declarations,
+                                  desaturate_glsl_source);
+      cogl_pipeline_add_snippet (klass->base_pipeline, snippet);
+      cogl_object_unref (snippet);
+
+      cogl_pipeline_set_layer_null_texture (klass->base_pipeline,
+                                            0, /* layer number */
+                                            COGL_TEXTURE_TYPE_2D);
+    }
+
+  self->pipeline = cogl_pipeline_copy (klass->base_pipeline);
+
+  self->factor_uniform =
+    cogl_pipeline_get_uniform_location (self->pipeline, "factor");
+
+  self->factor = 1.0;
+
+  update_factor_uniform (self);
+
+  self->unshaded_rect = (ClutterRect *) clutter_rect_zero ();
+
+  self->unshaded_uniform =
+    cogl_pipeline_get_uniform_location (self->pipeline, "unshaded");
+
+  update_unshaded_uniform (self);
+}
+
+/**
+ * shell_grid_desaturate_effect_new:
+ * @factor: the desaturation factor, between 0.0 and 1.0
+ *
+ * Creates a new #ShellGridDesaturateEffect to be used with
+ * clutter_actor_add_effect()
+ *
+ * Return value: the newly created #ShellGridDesaturateEffect or %NULL
+ */
+ClutterEffect *
+shell_grid_desaturate_effect_new (gdouble factor)
+{
+  g_return_val_if_fail (factor >= 0.0 && factor <= 1.0, NULL);
+
+  return g_object_new (CLUTTER_TYPE_DESATURATE_EFFECT,
+                       "factor", factor,
+                       NULL);
+}
+
+/**
+ * shell_grid_desaturate_effect_set_factor:
+ * @effect: a #ShellGridDesaturateEffect
+ * @factor: the desaturation factor, between 0.0 and 1.0
+ *
+ * Sets the desaturation factor for @effect, with 0.0 being "do not desaturate"
+ * and 1.0 being "fully desaturate"
+ */
+void
+shell_grid_desaturate_effect_set_factor (ShellGridDesaturateEffect *effect,
+                                         gdouble                    factor)
+{
+  g_return_if_fail (SHELL_IS_GRID_DESATURATE_EFFECT (effect));
+  g_return_if_fail (factor >= 0.0 && factor <= 1.0);
+
+  if (fabsf (effect->factor - factor) >= 0.00001)
+    {
+      effect->factor = factor;
+      update_factor_uniform (effect);
+
+      clutter_effect_queue_repaint (CLUTTER_EFFECT (effect));
+
+      g_object_notify_by_pspec (G_OBJECT (effect), obj_props[PROP_FACTOR]);
+    }
+}
+
+/**
+ * shell_grid_desaturate_effect_get_unshaded_rect:
+ * @effect: a #ShellGridDesaturateEffect
+ *
+ * Retrieves the unshaded area of @effect
+ *
+ * Return value: (transfer none): the unshaded area
+ */
+ClutterRect *
+shell_grid_desaturate_effect_get_unshaded_rect (ShellGridDesaturateEffect *effect)
+{
+  g_return_val_if_fail (SHELL_IS_GRID_DESATURATE_EFFECT (effect), NULL);
+
+  return effect->unshaded_rect;
+}
+
+/**
+ * shell_grid_desaturate_effect_set_unshaded_rect:
+ * @effect: a #ShellGridDesaturateEffect
+ * @rect: (allow-none): the unshaded area
+ *
+ * Sets an unshaded area to the effect
+ */
+void
+shell_grid_desaturate_effect_set_unshaded_rect (ShellGridDesaturateEffect *effect,
+                                                ClutterRect               *rect)
+{
+  g_return_if_fail (SHELL_IS_GRID_DESATURATE_EFFECT (effect));
+
+  if (!clutter_rect_equals (rect, effect->unshaded_rect))
+    {
+      clutter_rect_free (effect->unshaded_rect);
+      effect->unshaded_rect = clutter_rect_copy (rect);
+      effect->unshaded_uniform_dirty = TRUE;
+
+      clutter_effect_queue_repaint (CLUTTER_EFFECT (effect));
+
+      g_object_notify_by_pspec (G_OBJECT (effect), obj_props[PROP_UNSHADED_RECT]);
+    }
+}
+
+/**
+ * shell_grid_desaturate_effect_get_factor:
+ * @effect: a #ShellGridDesaturateEffect
+ *
+ * Retrieves the desaturation factor of @effect
+ *
+ * Return value: the desaturation factor
+ */
+gdouble
+shell_grid_desaturate_effect_get_factor (ShellGridDesaturateEffect *effect)
+{
+  g_return_val_if_fail (SHELL_IS_GRID_DESATURATE_EFFECT (effect), 0.0);
+
+  return effect->factor;
+}

--- a/src/shell-grid-desaturate-effect.h
+++ b/src/shell-grid-desaturate-effect.h
@@ -1,0 +1,62 @@
+/*
+ * Clutter.
+ *
+ * An OpenGL based 'interactive canvas' library.
+ *
+ * Copyright (C) 2010  Intel Corporation.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Author:
+ *   Emmanuele Bassi <ebassi@linux.intel.com>
+ */
+
+#ifndef __SHELL_GRID_DESATURATE_EFFECT_H__
+#define __SHELL_GRID_DESATURATE_EFFECT_H__
+
+#include <clutter/clutter.h>
+
+G_BEGIN_DECLS
+
+#define SHELL_TYPE_GRID_DESATURATE_EFFECT          (shell_grid_desaturate_effect_get_type ())
+#define SHELL_GRID_DESATURATE_EFFECT(obj)          (G_TYPE_CHECK_INSTANCE_CAST ((obj), SHELL_TYPE_GRID_DESATURATE_EFFECT, ShellGridDesaturateEffect))
+#define SHELL_IS_GRID_DESATURATE_EFFECT(obj)       (G_TYPE_CHECK_INSTANCE_TYPE ((obj), SHELL_TYPE_GRID_DESATURATE_EFFECT))
+
+/**
+ * ShellGridDesaturateEffect:
+ *
+ * <structname>ShellGridDesaturateEffect</structname> is an opaque structure
+ * whose members cannot be directly accessed
+ *
+ * Since: 1.4
+ */
+typedef struct _ShellGridDesaturateEffect         ShellGridDesaturateEffect;
+typedef struct _ShellGridDesaturateEffectClass    ShellGridDesaturateEffectClass;
+
+GType shell_grid_desaturate_effect_get_type (void) G_GNUC_CONST;
+
+ClutterEffect *shell_grid_desaturate_effect_new        (gdouble                  factor);
+
+void           shell_grid_desaturate_effect_set_factor (ShellGridDesaturateEffect *effect,
+                                                        gdouble                    factor);
+gdouble        shell_grid_desaturate_effect_get_factor (ShellGridDesaturateEffect *effect);
+
+void           shell_grid_desaturate_effect_set_unshaded_rect (ShellGridDesaturateEffect *effect,
+                                                               ClutterRect               *rect);
+
+ClutterRect *  shell_grid_desaturate_effect_get_unshaded_rect (ShellGridDesaturateEffect *effect);
+
+G_END_DECLS
+
+#endif /* __SHELL_GRID_DESATURATE_EFFECT_H__ */

--- a/src/shell-wm.c
+++ b/src/shell-wm.c
@@ -20,10 +20,12 @@ struct _ShellWM {
 enum
 {
   MINIMIZE,
+  MINIMIZE_COMPLETED,
   UNMINIMIZE,
   SIZE_CHANGE,
   MAP,
   DESTROY,
+  DESTROY_COMPLETED,
   SWITCH_WORKSPACE,
   KILL_SWITCH_WORKSPACE,
   KILL_WINDOW_EFFECTS,
@@ -66,6 +68,14 @@ shell_wm_class_init (ShellWMClass *klass)
                   NULL, NULL, NULL,
                   G_TYPE_NONE, 1,
                   META_TYPE_WINDOW_ACTOR);
+  shell_wm_signals[MINIMIZE_COMPLETED] =
+    g_signal_new ("minimize-completed",
+                  G_TYPE_FROM_CLASS (klass),
+                  G_SIGNAL_RUN_LAST,
+                  0,
+                  NULL, NULL, NULL,
+                  G_TYPE_NONE, 1,
+                  META_TYPE_WINDOW_ACTOR);
   shell_wm_signals[UNMINIMIZE] =
     g_signal_new ("unminimize",
                   G_TYPE_FROM_CLASS (klass),
@@ -92,6 +102,14 @@ shell_wm_class_init (ShellWMClass *klass)
                   META_TYPE_WINDOW_ACTOR);
   shell_wm_signals[DESTROY] =
     g_signal_new ("destroy",
+                  G_TYPE_FROM_CLASS (klass),
+                  G_SIGNAL_RUN_LAST,
+                  0,
+                  NULL, NULL, NULL,
+                  G_TYPE_NONE, 1,
+                  META_TYPE_WINDOW_ACTOR);
+  shell_wm_signals[DESTROY_COMPLETED] =
+    g_signal_new ("destroy-completed",
                   G_TYPE_FROM_CLASS (klass),
                   G_SIGNAL_RUN_LAST,
                   0,
@@ -196,6 +214,7 @@ shell_wm_completed_minimize (ShellWM         *wm,
                              MetaWindowActor *actor)
 {
   meta_plugin_minimize_completed (wm->plugin, actor);
+  g_signal_emit (wm, shell_wm_signals[MINIMIZE_COMPLETED], 0, actor);
 }
 
 /**
@@ -244,6 +263,7 @@ void
 shell_wm_completed_destroy (ShellWM         *wm,
                             MetaWindowActor *actor)
 {
+  g_signal_emit (wm, shell_wm_signals[DESTROY_COMPLETED], 0, actor);
   meta_plugin_destroy_completed (wm->plugin, actor);
 }
 

--- a/src/st/st-entry.c
+++ b/src/st/st-entry.c
@@ -107,6 +107,10 @@ struct _StEntryPrivate
   gboolean      hint_visible;
   gboolean      capslock_warning_shown;
   gboolean      has_ibeam;
+
+  CoglHandle    text_shadow_material;
+  gfloat        shadow_width;
+  gfloat        shadow_height;
 };
 
 static guint entry_signals[LAST_SIGNAL] = { 0, };
@@ -247,6 +251,12 @@ st_entry_dispose (GObject *object)
       priv->entry = NULL;
     }
 
+  if (priv->text_shadow_material != COGL_INVALID_HANDLE)
+    {
+      cogl_handle_unref (priv->text_shadow_material);
+      priv->text_shadow_material = COGL_INVALID_HANDLE;
+    }
+
   keymap = gdk_keymap_get_for_display (gdk_display_get_default ());
   g_signal_handlers_disconnect_by_func (keymap, keymap_state_changed, entry);
 
@@ -308,6 +318,12 @@ st_entry_style_changed (StWidget *self)
   const PangoFontDescription *font;
   gchar *font_string, *font_name;
   gdouble size;
+
+  if (priv->text_shadow_material != COGL_INVALID_HANDLE)
+    {
+      cogl_handle_unref (priv->text_shadow_material);
+      priv->text_shadow_material = COGL_INVALID_HANDLE;
+    }
 
   theme_node = st_widget_get_theme_node (self);
  
@@ -842,6 +858,60 @@ st_entry_leave_event (ClutterActor         *actor,
 }
 
 static void
+st_entry_paint (ClutterActor *actor)
+{
+  StEntryPrivate *priv = ST_ENTRY_PRIV (actor);
+  ClutterText *ctext = CLUTTER_TEXT (priv->entry);
+
+  StThemeNode *theme_node = st_widget_get_theme_node (ST_WIDGET (actor));
+  StShadow *shadow_spec = st_theme_node_get_text_shadow (theme_node);
+  ClutterActorClass *parent_class;
+
+  st_widget_paint_background (ST_WIDGET (actor));
+
+  if (shadow_spec
+      && !clutter_text_get_editable (ctext)
+      && !HAS_FOCUS (actor))
+    {
+      ClutterActorBox allocation;
+      float width, height;
+
+      clutter_actor_get_allocation_box (priv->entry, &allocation);
+      clutter_actor_box_get_size (&allocation, &width, &height);
+
+      if (priv->text_shadow_material == COGL_INVALID_HANDLE ||
+          width != priv->shadow_width ||
+          height != priv->shadow_height)
+        {
+          CoglHandle material;
+
+          if (priv->text_shadow_material != COGL_INVALID_HANDLE)
+            cogl_handle_unref (priv->text_shadow_material);
+
+          material = _st_create_shadow_pipeline_from_actor (shadow_spec,
+                                                            priv->entry);
+
+          priv->shadow_width = width;
+          priv->shadow_height = height;
+          priv->text_shadow_material = material;
+        }
+
+      if (priv->text_shadow_material != COGL_INVALID_HANDLE)
+        _st_paint_shadow_with_opacity (shadow_spec,
+                                       priv->text_shadow_material,
+                                       &allocation,
+                                       clutter_actor_get_paint_opacity (priv->entry));
+    }
+
+  /* Since we paint the background ourselves, chain to the parent class
+   * of StWidget, to avoid painting it twice.
+   * This is needed as we still want to paint children.
+   */
+  parent_class = g_type_class_peek_parent (st_entry_parent_class);
+  parent_class->paint (actor);
+}
+
+static void
 st_entry_unmap (ClutterActor *actor)
 {
   StEntryPrivate *priv = ST_ENTRY_PRIV (actor);
@@ -867,6 +937,7 @@ st_entry_class_init (StEntryClass *klass)
   actor_class->get_preferred_width = st_entry_get_preferred_width;
   actor_class->get_preferred_height = st_entry_get_preferred_height;
   actor_class->allocate = st_entry_allocate;
+  actor_class->paint = st_entry_paint;
   actor_class->unmap = st_entry_unmap;
 
   actor_class->key_press_event = st_entry_key_press_event;
@@ -985,6 +1056,10 @@ st_entry_init (StEntry *entry)
 
   priv->spacing = 6.0f;
 
+  priv->text_shadow_material = COGL_INVALID_HANDLE;
+  priv->shadow_width = -1.;
+  priv->shadow_height = -1.;
+
   clutter_actor_add_child (CLUTTER_ACTOR (entry), priv->entry);
   clutter_actor_set_reactive ((ClutterActor *) entry, TRUE);
 
@@ -1047,10 +1122,21 @@ st_entry_set_text (StEntry     *entry,
                    const gchar *text)
 {
   StEntryPrivate *priv;
+  ClutterText *ctext;
 
   g_return_if_fail (ST_IS_ENTRY (entry));
 
   priv = st_entry_get_instance_private (entry);
+  ctext = CLUTTER_TEXT (priv->entry);
+
+  /* if text changed, force a regen of shadow texture */
+  if (text
+      && g_strcmp0 (clutter_text_get_text (ctext), text) != 0
+      && priv->text_shadow_material != COGL_INVALID_HANDLE)
+    {
+      cogl_handle_unref (priv->text_shadow_material);
+      priv->text_shadow_material = COGL_INVALID_HANDLE;
+    }
 
   /* set a hint if we are blanking the entry */
   if (priv->hint

--- a/src/st/st-entry.c
+++ b/src/st/st-entry.c
@@ -72,6 +72,8 @@ enum
   PROP_0,
 
   PROP_CLUTTER_TEXT,
+  PROP_PRIMARY_ICON,
+  PROP_SECONDARY_ICON,
   PROP_HINT_TEXT,
   PROP_HINT_ACTOR,
   PROP_TEXT,
@@ -129,6 +131,14 @@ st_entry_set_property (GObject      *gobject,
 
   switch (prop_id)
     {
+    case PROP_PRIMARY_ICON:
+      st_entry_set_primary_icon (entry, g_value_get_object (value));
+      break;
+
+    case PROP_SECONDARY_ICON:
+      st_entry_set_secondary_icon (entry, g_value_get_object (value));
+      break;
+
     case PROP_HINT_TEXT:
       st_entry_set_hint_text (entry, g_value_get_string (value));
       break;
@@ -167,6 +177,14 @@ st_entry_get_property (GObject    *gobject,
     {
     case PROP_CLUTTER_TEXT:
       g_value_set_object (value, priv->entry);
+      break;
+
+    case PROP_PRIMARY_ICON:
+      g_value_set_object (value, priv->primary_icon);
+      break;
+
+    case PROP_SECONDARY_ICON:
+      g_value_set_object (value, priv->secondary_icon);
       break;
 
     case PROP_HINT_TEXT:
@@ -957,6 +975,20 @@ st_entry_class_init (StEntryClass *klass)
 			       G_PARAM_READABLE);
   g_object_class_install_property (gobject_class, PROP_CLUTTER_TEXT, pspec);
 
+  pspec = g_param_spec_object ("primary-icon",
+			       "Primary Icon",
+			       "Primary Icon actor",
+			       CLUTTER_TYPE_ACTOR,
+			       G_PARAM_READWRITE);
+  g_object_class_install_property (gobject_class, PROP_PRIMARY_ICON, pspec);
+
+  pspec = g_param_spec_object ("secondary-icon",
+			       "Secondary Icon",
+			       "Secondary Icon actor",
+			       CLUTTER_TYPE_ACTOR,
+			       G_PARAM_READWRITE);
+  g_object_class_install_property (gobject_class, PROP_SECONDARY_ICON, pspec);
+
   pspec = g_param_spec_string ("hint-text",
                                "Hint Text",
                                "Text to display when the entry is not focused "
@@ -1372,6 +1404,23 @@ st_entry_set_primary_icon (StEntry      *entry,
 }
 
 /**
+ * st_entry_get_primary_icon:
+ * @entry: a #StEntry
+ *
+ * Returns: (transfer none): a #ClutterActor
+ */
+ClutterActor *
+st_entry_get_primary_icon (StEntry *entry)
+{
+  StEntryPrivate *priv;
+
+  g_return_val_if_fail (ST_IS_ENTRY (entry), NULL);
+
+  priv = ST_ENTRY_PRIV (entry);
+  return priv->primary_icon;
+}
+
+/**
  * st_entry_set_secondary_icon:
  * @entry: a #StEntry
  * @icon: (nullable): an #ClutterActor
@@ -1389,6 +1438,23 @@ st_entry_set_secondary_icon (StEntry      *entry,
   priv = st_entry_get_instance_private (entry);
 
   _st_entry_set_icon (entry, &priv->secondary_icon, icon);
+}
+
+/**
+ * st_entry_get_secondary_icon:
+ * @entry: a #StEntry
+ *
+ * Returns: (transfer none): a #ClutterActor
+ */
+ClutterActor *
+st_entry_get_secondary_icon (StEntry *entry)
+{
+  StEntryPrivate *priv;
+
+  g_return_val_if_fail (ST_IS_ENTRY (entry), NULL);
+
+  priv = ST_ENTRY_PRIV (entry);
+  return priv->secondary_icon;
 }
 
 /**

--- a/src/st/st-entry.c
+++ b/src/st/st-entry.c
@@ -447,7 +447,7 @@ st_entry_allocate (ClutterActor          *actor,
       clutter_actor_allocate (left_icon, &icon_box, flags);
 
       /* reduce the size for the entry */
-      child_box.x1 += icon_w + priv->spacing;
+      child_box.x1 = MIN (child_box.x2, child_box.x1 + icon_w + priv->spacing);
     }
 
   if (right_icon)

--- a/src/st/st-entry.c
+++ b/src/st/st-entry.c
@@ -73,6 +73,7 @@ enum
 
   PROP_CLUTTER_TEXT,
   PROP_HINT_TEXT,
+  PROP_HINT_ACTOR,
   PROP_TEXT,
   PROP_INPUT_PURPOSE,
   PROP_INPUT_HINTS,
@@ -99,6 +100,8 @@ struct _StEntryPrivate
   ClutterActor *primary_icon;
   ClutterActor *secondary_icon;
 
+  ClutterActor *hint_actor;
+
   gfloat        spacing;
 
   gboolean      hint_visible;
@@ -124,6 +127,10 @@ st_entry_set_property (GObject      *gobject,
     {
     case PROP_HINT_TEXT:
       st_entry_set_hint_text (entry, g_value_get_string (value));
+      break;
+
+    case PROP_HINT_ACTOR:
+      st_entry_set_hint_actor (entry, g_value_get_object (value));
       break;
 
     case PROP_TEXT:
@@ -160,6 +167,10 @@ st_entry_get_property (GObject    *gobject,
 
     case PROP_HINT_TEXT:
       g_value_set_string (value, priv->hint);
+      break;
+
+    case PROP_HINT_ACTOR:
+      g_value_set_object (value, priv->hint_actor);
       break;
 
     case PROP_TEXT:
@@ -254,6 +265,41 @@ st_entry_finalize (GObject *object)
 }
 
 static void
+st_entry_set_hint_visible (StEntry *self,
+                           gboolean visible)
+{
+  StEntryPrivate *priv = ST_ENTRY_PRIV (self);
+
+  if (visible)
+    {
+      priv->hint_visible = TRUE;
+
+      if (priv->hint_actor)
+        {
+          clutter_actor_show (priv->hint_actor);
+          clutter_text_set_text (CLUTTER_TEXT (priv->entry), "");
+        }
+      else
+        {
+          clutter_text_set_text (CLUTTER_TEXT (priv->entry), priv->hint);
+        }
+
+      st_widget_add_style_pseudo_class (ST_WIDGET (self), "indeterminate");
+     }
+  else
+    {
+      priv->hint_visible = FALSE;
+
+      if (priv->hint_actor)
+        clutter_actor_hide (priv->hint_actor);
+      else
+        clutter_text_set_text (CLUTTER_TEXT (priv->entry), "");
+
+      st_widget_remove_style_pseudo_class (ST_WIDGET (self), "indeterminate");
+    }
+}
+
+static void
 st_entry_style_changed (StWidget *self)
 {
   StEntryPrivate *priv = ST_ENTRY_PRIV (self);
@@ -324,13 +370,24 @@ st_entry_get_preferred_width (ClutterActor *actor,
 {
   StEntryPrivate *priv = ST_ENTRY_PRIV (actor);
   StThemeNode *theme_node = st_widget_get_theme_node (ST_WIDGET (actor));
-  gfloat icon_w;
+  gfloat hint_w, icon_w;
 
   st_theme_node_adjust_for_height (theme_node, &for_height);
 
   clutter_actor_get_preferred_width (priv->entry, for_height,
                                      min_width_p,
                                      natural_width_p);
+
+  if (priv->hint_actor)
+    {
+      clutter_actor_get_preferred_width (priv->hint_actor, -1, NULL, &hint_w);
+
+      if (min_width_p && hint_w > *min_width_p)
+        *min_width_p = hint_w;
+
+      if (natural_width_p && hint_w > *natural_width_p)
+        *natural_width_p = hint_w;
+    }
 
   if (priv->primary_icon)
     {
@@ -366,13 +423,25 @@ st_entry_get_preferred_height (ClutterActor *actor,
 {
   StEntryPrivate *priv = ST_ENTRY_PRIV (actor);
   StThemeNode *theme_node = st_widget_get_theme_node (ST_WIDGET (actor));
-  gfloat icon_h;
+  gfloat hint_h, icon_h;
 
   st_theme_node_adjust_for_width (theme_node, &for_width);
 
   clutter_actor_get_preferred_height (priv->entry, for_width,
                                       min_height_p,
                                       natural_height_p);
+
+  if (priv->hint_actor)
+    {
+      clutter_actor_get_preferred_height (priv->hint_actor,
+                                          -1, NULL, &hint_h);
+
+      if (min_height_p && hint_h > *min_height_p)
+        *min_height_p = hint_h;
+
+      if (natural_height_p && hint_h > *natural_height_p)
+        *natural_height_p = hint_h;
+    }
 
   if (priv->primary_icon)
     {
@@ -408,12 +477,16 @@ st_entry_allocate (ClutterActor          *actor,
 {
   StEntryPrivate *priv = ST_ENTRY_PRIV (actor);
   StThemeNode *theme_node = st_widget_get_theme_node (ST_WIDGET (actor));
-  ClutterActorBox content_box, child_box, icon_box;
+  ClutterActorBox content_box, child_box, icon_box, hint_box;
   gfloat icon_w, icon_h;
+  gfloat hint_w, hint_h;
   gfloat entry_h, min_h, pref_h, avail_h;
   ClutterActor *left_icon, *right_icon;
+  gboolean is_rtl;
 
-  if (clutter_actor_get_text_direction (actor) == CLUTTER_TEXT_DIRECTION_RTL)
+  is_rtl = clutter_actor_get_text_direction (actor) == CLUTTER_TEXT_DIRECTION_RTL;
+
+  if (is_rtl)
     {
       right_icon = priv->primary_icon;
       left_icon = priv->secondary_icon;
@@ -464,7 +537,29 @@ st_entry_allocate (ClutterActor          *actor,
       clutter_actor_allocate (right_icon, &icon_box, flags);
 
       /* reduce the size for the entry */
-      child_box.x2 -= icon_w + priv->spacing;
+      if (clutter_actor_is_visible (right_icon))
+        child_box.x2 = MAX (child_box.x1, child_box.x2 - icon_w - priv->spacing);
+    }
+
+  if (priv->hint_actor)
+    {
+      /* now allocate the hint actor */
+      hint_box = child_box;
+
+      clutter_actor_get_preferred_height (priv->hint_actor, -1,
+                                          NULL, &hint_h);
+      clutter_actor_get_preferred_width (priv->hint_actor, -1,
+                                         NULL, &hint_w);
+
+      if (is_rtl)
+        hint_box.x1 = hint_box.x2 - hint_w;
+      else
+        hint_box.x2 = hint_box.x1 + hint_w;
+
+      hint_box.y1 = ceil (content_box.y1 + avail_h / 2 - hint_h / 2);
+      hint_box.y2 = hint_box.y1 + hint_h;
+
+      clutter_actor_allocate (priv->hint_actor, &hint_box, flags);
     }
 
   clutter_actor_get_preferred_height (priv->entry, child_box.x2 - child_box.x1,
@@ -488,18 +583,13 @@ clutter_text_focus_in_cb (ClutterText  *text,
 
   /* remove the hint if visible */
   if (priv->hint && priv->hint_visible)
-    {
-      priv->hint_visible = FALSE;
-
-      clutter_text_set_text (text, "");
-    }
+    st_entry_set_hint_visible (entry, FALSE);
 
   keymap = gdk_keymap_get_for_display (gdk_display_get_default ());
   keymap_state_changed (keymap, entry);
   g_signal_connect (keymap, "state-changed",
                     G_CALLBACK (keymap_state_changed), entry);
 
-  st_widget_remove_style_pseudo_class (ST_WIDGET (actor), "indeterminate");
   st_widget_add_style_pseudo_class (ST_WIDGET (actor), "focus");
   clutter_text_set_cursor_visible (text, TRUE);
 }
@@ -516,12 +606,8 @@ clutter_text_focus_out_cb (ClutterText  *text,
 
   /* add a hint if the entry is empty */
   if (priv->hint && !strcmp (clutter_text_get_text (text), ""))
-    {
-      priv->hint_visible = TRUE;
+    st_entry_set_hint_visible (entry, TRUE);
 
-      clutter_text_set_text (text, priv->hint);
-      st_widget_add_style_pseudo_class (ST_WIDGET (actor), "indeterminate");
-    }
   clutter_text_set_cursor_visible (text, FALSE);
   remove_capslock_feedback (entry);
 
@@ -807,6 +893,14 @@ st_entry_class_init (StEntryClass *klass)
                                NULL, G_PARAM_READWRITE);
   g_object_class_install_property (gobject_class, PROP_HINT_TEXT, pspec);
 
+  pspec = g_param_spec_object ("hint-actor",
+                               "Hint Actor",
+                               "An actor to display when the entry is not focused "
+                               "and the text property is empty",
+                               CLUTTER_TYPE_ACTOR,
+                               G_PARAM_READWRITE);
+  g_object_class_install_property (gobject_class, PROP_HINT_ACTOR, pspec);
+
   pspec = g_param_spec_string ("text",
                                "Text",
                                "Text of the entry",
@@ -963,15 +1057,12 @@ st_entry_set_text (StEntry     *entry,
       && text && !strcmp ("", text)
       && !HAS_FOCUS (priv->entry))
     {
-      text = priv->hint;
-      priv->hint_visible = TRUE;
-      st_widget_add_style_pseudo_class (ST_WIDGET (entry), "indeterminate");
+      st_entry_set_hint_visible (entry, TRUE);
     }
   else
     {
-      st_widget_remove_style_pseudo_class (ST_WIDGET (entry), "indeterminate");
-
-      priv->hint_visible = FALSE;
+      st_entry_set_hint_visible (entry, FALSE);
+      clutter_text_set_text (CLUTTER_TEXT (priv->entry), text);
     }
 
   clutter_text_set_text (CLUTTER_TEXT (priv->entry), text);
@@ -1021,12 +1112,7 @@ st_entry_set_hint_text (StEntry     *entry,
 
   if (!strcmp (clutter_text_get_text (CLUTTER_TEXT (priv->entry)), "")
       && !HAS_FOCUS (priv->entry))
-    {
-      priv->hint_visible = TRUE;
-
-      clutter_text_set_text (CLUTTER_TEXT (priv->entry), priv->hint);
-      st_widget_add_style_pseudo_class (ST_WIDGET (entry), "indeterminate");
-    }
+    st_entry_set_hint_visible (entry, TRUE);
 }
 
 /**
@@ -1217,6 +1303,41 @@ st_entry_set_secondary_icon (StEntry      *entry,
   priv = st_entry_get_instance_private (entry);
 
   _st_entry_set_icon (entry, &priv->secondary_icon, icon);
+}
+
+/**
+ * st_entry_set_hint_actor:
+ * @entry: a #StEntry
+ * @hint_actor: (allow-none): a #ClutterActor
+ *
+ * Set the hint actor of the entry to @hint_actor
+ */
+void
+st_entry_set_hint_actor (StEntry      *entry,
+                         ClutterActor *hint_actor)
+{
+  StEntryPrivate *priv;
+
+  g_return_if_fail (ST_IS_ENTRY (entry));
+
+  priv = ST_ENTRY_PRIV (entry);
+
+  if (priv->hint_actor != NULL)
+    {
+      clutter_actor_remove_child (CLUTTER_ACTOR (entry), priv->hint_actor);
+      priv->hint_actor = NULL;
+    }
+
+  if (hint_actor != NULL)
+    {
+      priv->hint_actor = hint_actor;
+      clutter_actor_add_child (CLUTTER_ACTOR (entry), priv->hint_actor);
+
+      /* refresh actor and hint text visibility */
+      st_entry_set_hint_visible (entry, priv->hint_visible);
+    }
+
+  clutter_actor_queue_relayout (CLUTTER_ACTOR (entry));
 }
 
 /******************************************************************************/

--- a/src/st/st-entry.c
+++ b/src/st/st-entry.c
@@ -263,12 +263,6 @@ st_entry_dispose (GObject *object)
   StEntryPrivate *priv = ST_ENTRY_PRIV (entry);
   GdkKeymap *keymap;
 
-  if (priv->entry)
-    {
-      clutter_actor_destroy (priv->entry);
-      priv->entry = NULL;
-    }
-
   if (priv->text_shadow_material != COGL_INVALID_HANDLE)
     {
       cogl_handle_unref (priv->text_shadow_material);

--- a/src/st/st-entry.h
+++ b/src/st/st-entry.h
@@ -61,6 +61,8 @@ void            st_entry_set_primary_icon   (StEntry        *entry,
                                              ClutterActor   *icon);
 void            st_entry_set_secondary_icon (StEntry        *entry,
                                              ClutterActor   *icon);
+void            st_entry_set_hint_actor    (StEntry      *entry,
+                                            ClutterActor *hint_actor);
 
 typedef void (*StEntryCursorFunc) (StEntry *entry, gboolean use_ibeam, gpointer data);
 void            st_entry_set_cursor_func    (StEntryCursorFunc func,

--- a/src/st/st-entry.h
+++ b/src/st/st-entry.h
@@ -57,10 +57,14 @@ void            st_entry_set_input_hints    (StEntry        *entry,
                                              GtkInputHints   hints);
 GtkInputHints   st_entry_get_input_hints    (StEntry        *entry);
 
-void            st_entry_set_primary_icon   (StEntry        *entry,
-                                             ClutterActor   *icon);
-void            st_entry_set_secondary_icon (StEntry        *entry,
-                                             ClutterActor   *icon);
+void            st_entry_set_primary_icon  (StEntry      *entry,
+                                            ClutterActor *icon);
+ClutterActor *  st_entry_get_primary_icon  (StEntry      *entry);
+
+void            st_entry_set_secondary_icon (StEntry      *entry,
+                                             ClutterActor *icon);
+ClutterActor *  st_entry_get_secondary_icon (StEntry      *entry);
+
 void            st_entry_set_hint_actor    (StEntry      *entry,
                                             ClutterActor *hint_actor);
 

--- a/src/st/st-label.c
+++ b/src/st/st-label.c
@@ -180,12 +180,6 @@ st_label_dispose (GObject   *object)
 {
   StLabelPrivate *priv = ST_LABEL (object)->priv;
 
-  if (priv->label)
-    {
-      clutter_actor_destroy (priv->label);
-      priv->label = NULL;
-    }
-
   g_clear_pointer (&priv->text_shadow_pipeline, cogl_object_unref);
 
   G_OBJECT_CLASS (st_label_parent_class)->dispose (object);

--- a/src/st/st-scroll-view.c
+++ b/src/st/st-scroll-view.c
@@ -641,7 +641,7 @@ st_scroll_view_allocate (ClutterActor          *actor,
   else
     {
       child_box.x1 = content_box.x1;
-      child_box.x2 = content_box.x2 - (vscrollbar_visible ? sb_width : 0);
+      child_box.x2 = MAX (content_box.x1, content_box.x2 - (vscrollbar_visible ? sb_width : 0));
     }
   child_box.y1 = content_box.y2 - sb_height;
   child_box.y2 = content_box.y2;

--- a/src/st/st-texture-cache.c
+++ b/src/st/st-texture-cache.c
@@ -31,6 +31,8 @@
 #define CACHE_PREFIX_FILE "file:"
 #define CACHE_PREFIX_FILE_FOR_CAIRO "file-for-cairo:"
 
+#define IMAGE_MISSING_ICON_NAME "image-missing"
+
 struct _StTextureCachePrivate
 {
   GtkIconTheme *icon_theme;
@@ -889,7 +891,12 @@ st_texture_cache_load_gicon (StTextureCache    *cache,
 
   info = gtk_icon_theme_lookup_by_gicon_for_scale (theme, icon, size, scale, lookup_flags);
   if (info == NULL)
-    return NULL;
+    {
+      /* Do not give up without even trying to pick the image-missing fallback icon. */
+      info = gtk_icon_theme_lookup_icon_for_scale (theme, IMAGE_MISSING_ICON_NAME, size, scale,  GTK_ICON_LOOKUP_USE_BUILTIN);
+      if (info == NULL)
+        return NULL;
+    }
 
   gicon_string = g_icon_to_string (icon);
   /* A return value of NULL indicates that the icon can not be serialized,

--- a/src/st/st-theme-node.c
+++ b/src/st/st-theme-node.c
@@ -3198,11 +3198,13 @@ parse_shadow_property (StThemeNode       *node,
                        gdouble           *yoffset,
                        gdouble           *blur,
                        gdouble           *spread,
-                       gboolean          *inset)
+                       gboolean          *inset,
+                       gboolean          *is_none)
 {
   GetFromTermResult result;
   CRTerm *term;
   int n_offsets = 0;
+  *is_none = FALSE;
 
   /* default values */
   color->red = 0x0; color->green = 0x0; color->blue = 0x0; color->alpha = 0xff;
@@ -3224,8 +3226,10 @@ parse_shadow_property (StThemeNode       *node,
   for (term = decl->value; term; term = term->next)
     {
       /* if we found "none", we're all set with the default values */
-      if (term_is_none (term))
+      if (term_is_none (term)) {
+        *is_none = TRUE;
         return VALUE_FOUND;
+      }
 
       if (term->type == TERM_NUMBER)
         {
@@ -3324,7 +3328,8 @@ parse_shadow_property (StThemeNode       *node,
  * See also st_theme_node_get_shadow(), which provides a simpler API.
  *
  * Return value: %TRUE if the property was found in the properties for this
- *  theme node (or in the properties of parent nodes when inheriting.)
+ * theme node (or in the properties of parent nodes when inheriting.), %FALSE
+ * if the property was not found, or was explicitly set to 'none'.
  */
 gboolean
 st_theme_node_lookup_shadow (StThemeNode  *node,
@@ -3338,6 +3343,7 @@ st_theme_node_lookup_shadow (StThemeNode  *node,
   gdouble blur = 0.;
   gdouble spread = 0.;
   gboolean inset = FALSE;
+  gboolean is_none = FALSE;
 
   int i;
 
@@ -3356,9 +3362,13 @@ st_theme_node_lookup_shadow (StThemeNode  *node,
                                                             &yoffset,
                                                             &blur,
                                                             &spread,
-                                                            &inset);
+                                                            &inset,
+                                                            &is_none);
           if (result == VALUE_FOUND)
             {
+              if (is_none)
+                return FALSE;
+
               *shadow = st_shadow_new (&color,
                                        xoffset, yoffset,
                                        blur, spread,


### PR DESCRIPTION
This is a list of commits that I are needed to bring the desktop back to life and that, most of them, will be needed later on to implement further changes that are at the moment living in my WIP branch here: https://github.com/endlessm/gnome-shell/commits/wip/mario/icongrid

The main reason I'm proposing this PR now is because I will be away until June 4th and this way it should be easier for others to either resume the work I have in my WIP branch (where I have a more functional desktop, but still in a very rudimentary state) or to work on other tasks that can also depend on some of the bits contained here (e.g. implementing the "Endless button" requires the commit that adds `workspaceMonitor.js, that's why I put it first in the llist).

The other reasons for me to propose this specific patch set and not to include other commits from my WIP branch is because the commits suggested here should be fairly safe to integrate in master, since the most visible change is the removal of the "Frequent / All" selector in the apps mode in the overview, and the fact that such view now loads the icons & folders from the Endless desktop, instead of the system ones.

@cosimoc: Please review. If you do it before this Monday there's a small chance I can look into addressing comments (no promises though), otherwise feel free to adjust the commits yourself as you see fit. Thanks!

https://phabricator.endlessm.com/T17230