### PR TITLE
theme: Use Endless' font face

### DIFF
--- a/data/theme/gnome-shell.css
+++ b/data/theme/gnome-shell.css
@@ -1852,6 +1852,10 @@ StScrollBar {
 
 /* Endless-specific overrides below this point */
 
+stage {
+  font-family: lato, Sans-Serif;
+}
+
 .force-app-exit-dialog {
     max-height: 500px;
     min-height: 450px;


### PR DESCRIPTION
This patch makes the shell use Endless' Lato fonts instead of
the default Cantarell.

https://phabricator.endlessm.com/T17230