### PR TITLE
project: Add eos-link-feedback back

### DIFF
--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -2,7 +2,7 @@ CLEANFILES =
 NULL =
 
 desktopdir=$(datadir)/applications
-desktop_DATA = org.gnome.Shell.desktop gnome-shell-extension-prefs.desktop eos-launch.desktop
+desktop_DATA = org.gnome.Shell.desktop gnome-shell-extension-prefs.desktop eos-launch.desktop eos-link-feedback.desktop
 
 if HAVE_NETWORKMANAGER
 desktop_DATA += org.gnome.Shell.PortalHelper.desktop
@@ -123,6 +123,7 @@ EXTRA_DIST =						\
 	gnome-shell-theme.gresource.xml 		\
 	$(resource_files)				\
 	eos-launch.desktop.in.in			\
+	eos-link-feedback.desktop.in.in			\
 	$(NULL)
 
 CLEANFILES +=						\
@@ -135,4 +136,5 @@ CLEANFILES +=						\
 	org.gnome.shell.gschema.valid			\
 	gnome-shell-theme.gresource			\
 	eos-launch.desktop.in				\
+	eos-link-feedback.desktop.in			\
 	$(NULL)

--- a/data/eos-link-feedback.desktop.in.in
+++ b/data/eos-link-feedback.desktop.in.in
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Version=1.0
+_Name=Feedback
+_Comment=
+Type=Application
+Exec=chromium-browser chrome-extension://fpmnjlkappdkncfmjefheaidpmbmfdfk/index.html#feedback
+Icon=
+Categories=Utility;
+NoDisplay=true
+X-Endless-LaunchMaximized=false


### PR DESCRIPTION
This desktop file was present in our previous Endless
Shell before the rebase.

This commit brings this desktop file back.

https://phabricator.endlessm.com/T16842