### PR TITLE
watermak: Protect against null background managers

### DIFF
--- a/js/ui/watermark.js
+++ b/js/ui/watermark.js
@@ -216,6 +216,9 @@ const WatermarkManager = new Lang.Class({
 });
 
 function _forEachBackgroundManager(func) {
-    Main.overview._bgManagers.forEach(func);
-    Main.layoutManager._bgManagers.forEach(func);
+    if (Main.overview._bgManagers)
+        Main.overview._bgManagers.forEach(func);
+
+    if (Main.layoutManager._bgManagers)
+        Main.layoutManager._bgManagers.forEach(func);
 }


### PR DESCRIPTION
When running under a GDM session, Shell has no background
manager instances available, and the watermark code would
make it crash.

Fix that by checking if there are background managers.

https://phabricator.endlessm.com/T15839