### PR TITLE
windowManager: Add wobbly windows.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -115,6 +115,7 @@ PKG_CHECK_MODULES(MUTTER, libmutter >= $MUTTER_MIN_VERSION)
 
 PKG_CHECK_MODULES(GNOME_SHELL_JS, gio-2.0 gjs-1.0 >= $GJS_MIN_VERSION)
 PKG_CHECK_MODULES(ST, mutter-clutter-1.0 gtk+-3.0 libcroco-0.6 >= 0.6.8 x11)
+PKG_CHECK_MODULES(EOS_SHELL_FX, mutter-clutter-1.0 >= 1.16 glib-2.0 >= 2.38 gdk-pixbuf-2.0 libwindowfx_wobbly)
 PKG_CHECK_MODULES(SHELL_PERF_HELPER, gtk+-3.0 gio-2.0)
 PKG_CHECK_MODULES(SHELL_HOTPLUG_SNIFFER, gio-2.0 gdk-pixbuf-2.0)
 PKG_CHECK_MODULES(TRAY, mutter-clutter-1.0 gtk+-3.0)

--- a/data/org.gnome.shell.gschema.xml.in
+++ b/data/org.gnome.shell.gschema.xml.in
@@ -165,6 +165,56 @@
         This key specifies the exact order of the icons shown in the applications launcher view.
       </description>
     </key>
+    <key name="wobbly-effect" type="b">
+      <default>false</default>
+      <summary>
+        Whether or not to enable the wobbly effect
+      </summary>
+      <description>
+        WOBBLY!
+      </description>
+    </key>
+    <key name="wobbly-spring-k" type="d">
+      <range min="2.0" max="10.0"/>
+      <default>8.0</default>
+      <summary>
+        Wobbly effect Spring Constant
+      </summary>
+      <description>
+        Springiness of wobbly effect
+      </description>
+    </key>
+    <key name="wobbly-spring-friction" type="d">
+      <range min="2.0" max="10.0"/>
+      <default>3.0</default>
+      <summary>
+        Wobbly effect Friction
+      </summary>
+      <description>
+        Friction of wobbly effect
+      </description>
+    </key>
+    <key name="wobbly-slowdown-factor" type="d">
+      <range min="1.0" max="5.0"/>
+      <default>1.0</default>
+      <summary>
+        Wobbly effect slowdown factor
+      </summary>
+      <description>
+        Slowdown factor of wobbly effect (1.0 being normal speed)
+      </description>
+    </key>
+    <key name="wobbly-object-movement-range" type="d">
+      <range min="10.0" max="500.0"/>
+      <default>100.0</default>
+      <summary>
+        Wobbly effect object movement range
+      </summary>
+      <description>
+        How much objects are allowed to move in the mesh. A higher range
+        allows for a more pronounced effect.
+      </description>
+    </key>
     <child name="keybindings" schema="org.gnome.shell.keybindings"/>
     <child name="keyboard" schema="org.gnome.shell.keyboard"/>
   </schema>

--- a/js/ui/windowManager.js
+++ b/js/ui/windowManager.js
@@ -4,6 +4,8 @@ const Cairo = imports.cairo;
 const Clutter = imports.gi.Clutter;
 const GLib = imports.gi.GLib;
 const Gio = imports.gi.Gio;
+const GObject = imports.gi.GObject;
+const EndlessShellFX = imports.gi.EndlessShellFX;
 const Lang = imports.lang;
 const Mainloop = imports.mainloop;
 const Meta = imports.gi.Meta;
@@ -134,6 +136,58 @@ const DisplayChangeDialog = new Lang.Class({
         this._wm.complete_display_change(true);
         this.close();
     },
+});
+
+const EOSShellWobbly = new Lang.Class({
+    Name: 'EOSShellWobbly',
+    Extends: EndlessShellFX.Wobbly,
+
+    _init: function(params) {
+        this.parent(params);
+
+        let binder = Lang.bind(this, function(key, prop) {
+            global.settings.bind(key, this, prop, Gio.SettingsBindFlags.GET);
+        });
+
+        /* Bind to effect properties */
+        binder('wobbly-spring-k', 'spring-k');
+        binder('wobbly-spring-friction', 'friction');
+        binder('wobbly-slowdown-factor', 'slowdown-factor');
+        binder('wobbly-object-movement-range', 'object-movement-range');
+    },
+
+    grabbedByMouse: function() {
+        if (!global.settings.get_boolean('wobbly-effect'))
+            return;
+
+        let position = global.get_pointer();
+        let actor = this.get_actor();
+        this.grab(position[0], position[1]);
+
+        this._lastPosition = actor.get_position();
+        this._positionChangedId =
+            actor.connect('allocation-changed', Lang.bind(this, function (actor) {
+                let position = actor.get_position();
+                let dx = position[0] - this._lastPosition[0];
+                let dy = position[1] - this._lastPosition[1];
+
+                this.move_by(dx, dy);
+                this._lastPosition = position;
+            }));
+    },
+
+    ungrabbedByMouse: function() {
+        // Only continue if we have an active grab and change notification
+        // on movement
+        if (!this._positionChangedId)
+            return;
+
+        let actor = this.get_actor();
+        this.ungrab();
+
+        actor.disconnect(this._positionChangedId);
+        this._positionChangedId = null;
+    }
 });
 
 const WindowDimmer = new Lang.Class({
@@ -1215,6 +1269,8 @@ const WindowManager = new Lang.Class({
         gesture.connect('activated', Lang.bind(this, this._switchApp));
         global.stage.add_action(gesture);
 
+        global.display.connect('grab-op-begin', Lang.bind(this, this._windowGrabbed));
+        global.display.connect('grab-op-end', Lang.bind(this, this._windowUngrabbed));
     },
 
     _actionSwitchWorkspace: function(action, direction) {
@@ -2435,5 +2491,49 @@ const WindowManager = new Lang.Class({
                 this._resizePopup = null;
             }
         }
+    },
+
+    _windowCanWobble: function(window, op) {
+        if (window.is_override_redirect() ||
+            op != Meta.GrabOp.MOVING)
+            return false;
+
+        return true;
+    },
+
+    _windowGrabbed: function(display, screen, window, op) {
+        // Occassionally, window can be null, in cases where grab-op-begin
+        // was emitted on a window from shell-toolkit. Ignore these grabs.
+        if (!window)
+            return;
+
+        if (!this._windowCanWobble(window, op))
+            return;
+
+        let actor = window.get_compositor_private();
+
+        let effect = actor.get_effect('endless-wobbly');
+        if (!effect) {
+            effect = new EOSShellWobbly();
+            actor.add_effect_with_name('endless-wobbly', effect);
+        }
+
+        effect.grabbedByMouse();
+    },
+
+    _windowUngrabbed: function(display, op, window) {
+        // Occassionally, window can be null, in cases where grab-op-end
+        // was emitted on a window from shell-toolkit. Ignore these grabs.
+        if (!window)
+            return;
+
+        let actor = window.get_compositor_private();
+        let effect = actor.get_effect('endless-wobbly');
+
+        // Lots of different grab ops can end here, so we just let
+        // EOSShellWobbly.ungrabbedByMouse figure out what to do based on its
+        // own state
+        if (effect)
+            effect.ungrabbedByMouse();
     },
 });

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -78,7 +78,7 @@ gnome_shell_cflags =				\
 	-DGNOME_SHELL_PKGLIBDIR=\"$(pkglibdir)\"
 
 privlibdir = $(pkglibdir)
-privlib_LTLIBRARIES = libgnome-shell-menu.la libgnome-shell.la
+privlib_LTLIBRARIES = libgnome-shell-menu.la libgnome-shell.la libeos-shell-fx.la
 noinst_LTLIBRARIES += libgnome-shell-base.la
 
 shell_built_sources = \
@@ -237,6 +237,27 @@ endif
 
 ########################################
 
+# Set up the libeos-shell-fx target
+libeos_shell_fx_la_SOURCES =	\
+	wobbly-effect.cpp	\
+	wobbly-effect.h		\
+	$(NULL)
+
+libeos_shell_fx_la_LIBADD =	\
+	$(EOS_SHELL_FX_LIBS)	\
+	$(NULL)
+
+libeos_shell_fx_la_LDFLAGS =	\
+	-avoid-version		\
+	$(NULL)
+
+libeos_shell_fx_la_CPPFLAGS =	\
+	$(EOS_SHELL_FX_CFLAGS)	\
+	-std=c++11		\
+	$(NULL)
+
+########################################
+
 shell_recorder_sources =        \
 	shell-recorder.c	\
 	shell-recorder.h
@@ -361,3 +382,12 @@ St_1_0_gir_FILES = $(filter-out %-private.h $(st_non_gir_sources), $(addprefix $
 	$(addprefix $(srcdir)/,$(st_source_c))
 INTROSPECTION_GIRS += St-1.0.gir
 CLEANFILES += St-1.0.gir
+
+EndlessShellFX-1.0.gir: libeos-shell-fx.la
+EndlessShellFX_1_0_gir_INCLUDES = Clutter-1.0
+EndlessShellFX_1_0_gir_CFLAGS = $(EOS_SHELL_FX_CFLAGS) -I $(srcdir)
+EndlessShellFX_1_0_gir_LIBS = libeos-shell-fx.la
+EndlessShellFX_1_0_gir_FILES = $(libeos_shell_fx_la_SOURCES)
+EndlessShellFX_1_0_gir_SCANNERFLAGS = --warn-all
+INTROSPECTION_GIRS += EndlessShellFX-1.0.gir
+CLEANFILES += EndlessShellFX-1.0.gir

--- a/src/wobbly-effect.cpp
+++ b/src/wobbly-effect.cpp
@@ -1,0 +1,572 @@
+/*
+ * wobbly-effect.cpp
+ *
+ * Copyright © 2013-2016 Endless Mobile, Inc.
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * licence or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authors: Sam Spilsbury <sam@endlessm.com>
+ */
+
+#include <array>
+#include <boost/noncopyable.hpp>
+
+#include <glib-object.h>
+#include <gio/gio.h>
+#include <clutter/clutter.h>
+
+#include <windowfx/wobbly/wobbly.h>
+
+#include "wobbly-effect.h"
+
+namespace bg = boost::geometry;
+
+typedef struct _EndlessShellFXWobblyPrivate
+{
+  float      slowdown_factor;
+
+  wobbly::Model  *model;
+  wobbly::Anchor *anchor;
+  gint64     last_msecs;
+  guint      timeout_id;
+  guint      width_changed_signal;
+  guint      height_changed_signal;
+
+  /* We'll be touching this seldomly, so put
+   * it down here for now */
+  wobbly::Model::Settings model_settings;
+
+  /* Single bit at the end of the struct */
+  bool      ungrab_pending : 1;
+} EndlessShellFXWobblyPrivate;
+
+enum
+{
+  PROP_0,
+
+  PROP_SPRING_K,
+  PROP_FRICTION,
+  PROP_SLOWDOWN_FACTOR,
+  PROP_OBJECT_MOVEMENT_RANGE,
+
+  PROP_LAST
+};
+
+static GParamSpec *object_properties[PROP_LAST];
+
+G_DEFINE_TYPE_WITH_PRIVATE (EndlessShellFXWobbly,
+                            endless_shell_fx_wobbly,
+                            CLUTTER_TYPE_DEFORM_EFFECT)
+
+static gboolean
+endless_shell_fx_wobbly_lie_about_paint_volume (ClutterEffect    *effect,
+                                                ClutterPaintVolume *volume)
+{
+  return CLUTTER_EFFECT_CLASS (endless_shell_fx_wobbly_parent_class)->get_paint_volume (effect,
+                                                                                        volume);
+}
+
+static gboolean
+endless_shell_fx_wobbly_get_paint_volume (ClutterEffect    *effect,
+                                          ClutterPaintVolume *volume)
+{
+  EndlessShellFXWobbly *wobbly_effect = ENDLESS_SHELL_FX_WOBBLY (effect);
+  EndlessShellFXWobblyPrivate *priv =
+    reinterpret_cast <EndlessShellFXWobblyPrivate *> (endless_shell_fx_wobbly_get_instance_private (wobbly_effect));
+
+  /* We assume that the parent's get_paint_volume method always returns
+   * TRUE here. */
+  CLUTTER_EFFECT_CLASS (endless_shell_fx_wobbly_parent_class)->get_paint_volume (effect, volume);
+
+  if (priv->model)
+    {
+      std::array <wobbly::Point, 4> const extremes = priv->model->Extremes ();
+
+      float x1 = std::min (bg::get <0> (extremes[0]), bg::get <0> (extremes[2]));
+      float y1 = std::min (bg::get <1> (extremes[0]), bg::get <1> (extremes[1]));
+      float x2 = std::max (bg::get <0> (extremes[1]), bg::get <0> (extremes[3]));
+      float y2 = std::max (bg::get <1> (extremes[2]), bg::get <1> (extremes[3]));
+
+      ClutterActorBox const extremesBox =
+        {
+          static_cast <float> (std::floor (x1)),
+          static_cast <float> (std::floor (y1)),
+          static_cast <float> (std::ceil (x2)),
+          static_cast <float> (std::ceil (y2))
+        };
+
+      clutter_paint_volume_union_box (volume, &extremesBox);
+    }
+
+  return TRUE;
+}
+
+namespace
+{
+  /* Utility class to force the usage of the actor-only paint volume as opposed
+   * to our expanded paint volume from the effect running */
+  class RAIIActorPaintBox :
+    boost::noncopyable
+  {
+    public:
+
+      RAIIActorPaintBox (ClutterEffectClass *effect_class) :
+        effect_class (effect_class)
+      {
+        effect_class->get_paint_volume = endless_shell_fx_wobbly_lie_about_paint_volume;
+      }
+
+      ~RAIIActorPaintBox ()
+      {
+        effect_class->get_paint_volume = endless_shell_fx_wobbly_get_paint_volume;
+      }
+
+    private:
+
+      ClutterEffectClass *effect_class;
+  };
+}
+
+/* ClutterOffscreenEffect calls clutter_actor_get_paint_box in order to
+ * determine the size of the buffer to redirect into. However, we can't
+ * just provide the paint box that we would have used in order for the
+ * wobbly effect because then it will end up creating a slightly larger
+ * framebuffer object to put our texture into. So we have to hook
+ * pre_paint here, replace our function pointer for a bit while we chain
+ * chain up so that we don't get a funky looking paint box and then replace
+ * it with our function to get the *actual* paint volume. */
+static gboolean
+endless_shell_fx_wobbly_pre_paint (ClutterEffect *effect)
+{
+  EndlessShellFXWobbly *wobbly_effect = ENDLESS_SHELL_FX_WOBBLY (effect);
+  EndlessShellFXWobblyClass *klass = ENDLESS_SHELL_FX_WOBBLY_GET_CLASS (wobbly_effect);
+  ClutterEffectClass *effect_class = CLUTTER_EFFECT_CLASS (klass);
+
+  RAIIActorPaintBox forced_client_paint_box (effect_class);
+
+  return CLUTTER_EFFECT_CLASS (endless_shell_fx_wobbly_parent_class)->pre_paint (effect);
+}
+
+static void
+endless_shell_fx_wobbly_deform_vertex (ClutterDeformEffect *effect,
+                                       gfloat                     ,
+                                       gfloat                     ,
+                                       CoglTextureVertex   *vertex)
+{
+  EndlessShellFXWobbly *wobbly_effect = ENDLESS_SHELL_FX_WOBBLY (effect);
+  EndlessShellFXWobblyPrivate *priv =
+    reinterpret_cast <EndlessShellFXWobblyPrivate *> (endless_shell_fx_wobbly_get_instance_private (wobbly_effect));
+
+  wobbly::Point deformed =
+    priv->model->DeformTexcoords (wobbly::Point (vertex->ty,
+                                  vertex->tx));
+  vertex->x = bg::get <0> (deformed);
+  vertex->y = bg::get <1> (deformed);
+}
+
+static void
+remove_anchor_if_pending (EndlessShellFXWobblyPrivate *priv)
+{
+  if (priv->ungrab_pending)
+    {
+      delete priv->anchor;
+      priv->anchor = nullptr;
+      priv->ungrab_pending = false;
+    }
+}
+
+/* It turns out that clutter doesn't contain any mechanism whatsoever
+ * to do timeline-less animations. We're just using a timeout here
+ * to keep performing animations on the actor */
+static gboolean
+endless_shell_fx_wobbly_new_frame (gpointer user_data)
+{
+  EndlessShellFXWobbly *wobbly_effect = ENDLESS_SHELL_FX_WOBBLY (user_data);
+  EndlessShellFXWobblyPrivate *priv =
+    reinterpret_cast <EndlessShellFXWobblyPrivate *> (endless_shell_fx_wobbly_get_instance_private (wobbly_effect));
+  gint64 msecs = g_get_monotonic_time ();
+
+  static const unsigned int ms_to_us = 1000;
+
+  g_assert (priv->model);
+
+  /* Wraparound, priv->last_msecs -= G_MAXINT64.
+   * We make priv->last_msecs negative so that subtracting it
+   * from msecs results in the correct delta */
+  if (G_UNLIKELY (priv->last_msecs > msecs))
+    priv->last_msecs -= G_MAXINT64;
+
+  gint64 msecs_delta = (msecs - priv->last_msecs ) / ms_to_us;
+  priv->last_msecs = msecs;
+
+  /* If there was no time movement, then we can't really step or remove
+   * models in a way that makes sense, so don't do it */
+  if (msecs_delta)
+    {
+      if (priv->model->Step (msecs_delta / priv->slowdown_factor))
+        {
+          clutter_actor_meta_set_enabled (CLUTTER_ACTOR_META (wobbly_effect), TRUE);
+          clutter_deform_effect_invalidate (CLUTTER_DEFORM_EFFECT (wobbly_effect));
+        }
+      else
+        {
+          remove_anchor_if_pending (priv);
+
+          /* Also disable the effect */
+          clutter_actor_meta_set_enabled (CLUTTER_ACTOR_META (wobbly_effect), FALSE);
+
+          /* Finally, return false so that we don't keep animating */
+          priv->timeout_id = 0;
+          return FALSE;
+        }
+    }
+
+  /* We always want to return true even if there was no time delta */
+  return TRUE;
+}
+
+static void
+endless_shell_fx_wobbly_ensure_timeline (EndlessShellFXWobbly *wobbly_effect)
+{
+  EndlessShellFXWobblyPrivate *priv =
+    reinterpret_cast <EndlessShellFXWobblyPrivate *> (endless_shell_fx_wobbly_get_instance_private (wobbly_effect));
+
+  if (!priv->timeout_id)
+    {
+      static const unsigned int frame_length_ms = 16; // 60 / 1000;
+
+      priv->last_msecs = g_get_monotonic_time ();
+      priv->timeout_id = g_timeout_add (frame_length_ms, endless_shell_fx_wobbly_new_frame, wobbly_effect);
+    }
+}
+
+void
+endless_shell_fx_wobbly_grab (EndlessShellFXWobbly *effect,
+                              double               x,
+                              double               y)
+{
+  ClutterActor *actor = clutter_actor_meta_get_actor (CLUTTER_ACTOR_META (effect));
+  EndlessShellFXWobblyPrivate *priv =
+    reinterpret_cast <EndlessShellFXWobblyPrivate *> (endless_shell_fx_wobbly_get_instance_private (effect));
+
+  g_assert (!priv->anchor || priv->ungrab_pending);
+
+  /* Either ungrab here or at the end of the animation */
+  remove_anchor_if_pending (priv);
+
+  if (priv->model)
+    {
+      /* Make sure to move the model to the actor's current position first
+       * as it may have changed in the meantime */
+      priv->model->MoveModelTo (wobbly::Point (0, 0));
+
+      endless_shell_fx_wobbly_ensure_timeline (effect);
+
+      float actor_x, actor_y;
+      clutter_actor_get_position (actor, &actor_x, &actor_y);
+
+      priv->anchor = new wobbly::Anchor (priv->model->GrabAnchor (wobbly::Point (x - actor_x,
+                                                                                 y - actor_y)));
+    }
+}
+
+void
+endless_shell_fx_wobbly_ungrab (EndlessShellFXWobbly *effect)
+{
+  EndlessShellFXWobblyPrivate *priv =
+    reinterpret_cast <EndlessShellFXWobblyPrivate *> (endless_shell_fx_wobbly_get_instance_private (effect));
+
+  g_assert (priv->anchor && !priv->ungrab_pending);
+
+  /* Don't immediately ungrab. We can be a little bit more
+   * clever here and make the ungrab pending on the completion
+   * of the animation */
+  if (priv->timeout_id)
+    {
+      priv->ungrab_pending = true;
+    }
+  else
+    {
+      delete priv->anchor;
+      priv->anchor = nullptr;
+    }
+}
+
+void
+endless_shell_fx_wobbly_move_by (EndlessShellFXWobbly *effect,
+                                 double               dx,
+                                 double               dy)
+{
+  EndlessShellFXWobblyPrivate *priv =
+    reinterpret_cast <EndlessShellFXWobblyPrivate *> (endless_shell_fx_wobbly_get_instance_private (effect));
+
+  if (priv->anchor)
+    {
+      wobbly::Vector delta (dx, dy);
+
+      endless_shell_fx_wobbly_ensure_timeline (effect);
+      priv->anchor->MoveBy (delta);
+
+      wobbly::Vector reverse_delta (delta);
+      bg::multiply_value (reverse_delta, -1);
+
+      /* Now move the entire model back - this ensures that
+       * we stay in sync with the actor's relative position */
+      priv->model->MoveModelBy (reverse_delta);
+    }
+}
+
+static void
+endless_shell_fx_get_actor_only_paint_box_size (EndlessShellFXWobbly *effect,
+                                                ClutterActor         *actor,
+                                                gfloat               *width,
+                                                gfloat               *height)
+{
+  EndlessShellFXWobblyClass *klass = ENDLESS_SHELL_FX_WOBBLY_GET_CLASS (effect);
+  ClutterEffectClass *effect_class = CLUTTER_EFFECT_CLASS (klass);
+
+  /* We want the size of the paint box and not the actor
+   * size, because that's going to be the size of the
+   * texture. However, we only want the size of the
+   * paint box when we're just considering the
+   * actor alone */
+  RAIIActorPaintBox forced_client_paint_box (effect_class);
+  ClutterActorBox   rect;
+
+  /* If clutter_actor_get_paint_box fails
+   * we should fall back to the actor size at this point */
+  if (clutter_actor_get_paint_box (actor, &rect))
+    clutter_actor_box_get_size (&rect, width, height);
+  else
+    clutter_actor_get_size (actor, width, height);
+}
+
+static void
+endless_shell_fx_wobbly_size_changed (GObject    *object,
+                                      GParamSpec *,
+                                      gpointer   user_data)
+{
+  ClutterActor    *actor = CLUTTER_ACTOR (object);
+  EndlessShellFXWobbly *effect = ENDLESS_SHELL_FX_WOBBLY (user_data);
+  EndlessShellFXWobblyPrivate *priv =
+    reinterpret_cast <EndlessShellFXWobblyPrivate *> (endless_shell_fx_wobbly_get_instance_private (effect));
+
+  /* We don't ensure a timeline here because we only want to redistribute
+   * non-anchor points if we're already grabbed, which the wobbly effect will
+   * do internally anyways */
+  if (priv->model)
+    {
+      float actor_width, actor_height;
+      endless_shell_fx_get_actor_only_paint_box_size (effect,
+                                                      actor,
+                                                      &actor_width,
+                                                      &actor_height);
+
+      /* If we have any pending anchors, we should release them now -
+       * the model move and resize code explicitly does not move
+       * anchors around (because that'd put them out of sync with
+       * the cursor) */
+      remove_anchor_if_pending (priv);
+
+      priv->model->ResizeModel (actor_width, actor_height);
+      priv->model->MoveModelTo (wobbly::Point (0, 0));
+    }
+}
+
+static void
+endless_shell_fx_wobbly_set_actor (ClutterActorMeta *actor_meta,
+                                   ClutterActor   *actor)
+{
+  ClutterActor *prev_actor = clutter_actor_meta_get_actor (actor_meta);
+
+  CLUTTER_ACTOR_META_CLASS (endless_shell_fx_wobbly_parent_class)->set_actor (actor_meta, actor);
+
+  EndlessShellFXWobbly *wobbly_effect = ENDLESS_SHELL_FX_WOBBLY (actor_meta);
+  EndlessShellFXWobblyPrivate *priv =
+    reinterpret_cast <EndlessShellFXWobblyPrivate *> (endless_shell_fx_wobbly_get_instance_private (wobbly_effect));
+
+  /* If we're grabbed, we have to immediately get rid of the grab
+   * as the grab depends on objects inside the model */
+  if (priv->anchor)
+    {
+      delete priv->anchor;
+      priv->anchor = nullptr;
+      priv->ungrab_pending = false;
+    }
+
+  if (priv->model)
+    {
+      delete priv->model;
+      priv->model = nullptr;
+    }
+
+  if (priv->timeout_id)
+    {
+      g_source_remove (priv->timeout_id);
+      priv->timeout_id = 0;
+    }
+
+  if (prev_actor)
+    {
+      g_signal_handler_disconnect (prev_actor, priv->width_changed_signal);
+      priv->width_changed_signal = 0;
+
+      g_signal_handler_disconnect (prev_actor, priv->height_changed_signal);
+      priv->height_changed_signal = 0;
+    }
+
+  if (actor)
+    {
+      float actor_width, actor_height;
+      endless_shell_fx_get_actor_only_paint_box_size (wobbly_effect,
+                                                      actor,
+                                                      &actor_width,
+                                                      &actor_height);
+
+      priv->model = new wobbly::Model (wobbly::Point (0, 0),
+                                       actor_width,
+                                       actor_height,
+                                       priv->model_settings);
+
+      priv->width_changed_signal =
+        g_signal_connect_object (actor,
+                                 "notify::width",
+                                 G_CALLBACK (endless_shell_fx_wobbly_size_changed),
+                                 wobbly_effect,
+                                 static_cast <GConnectFlags> (G_CONNECT_AFTER));
+      priv->height_changed_signal =
+        g_signal_connect_object (actor,
+                                 "notify::height",
+                                 G_CALLBACK (endless_shell_fx_wobbly_size_changed),
+                                 wobbly_effect,
+                                 static_cast <GConnectFlags> (G_CONNECT_AFTER));
+    }
+
+  /* Whatever the actor, ensure that the effect is disabled at this point */
+  clutter_actor_meta_set_enabled (actor_meta, FALSE);
+}
+
+static void
+endless_shell_fx_wobbly_set_property (GObject      *object,
+                                      guint        prop_id,
+                                      const GValue *value,
+                                      GParamSpec   *pspec)
+{
+  EndlessShellFXWobbly *wobbly_effect =
+    reinterpret_cast <EndlessShellFXWobbly *> (object);
+  EndlessShellFXWobblyPrivate *priv =
+    reinterpret_cast <EndlessShellFXWobblyPrivate *> (endless_shell_fx_wobbly_get_instance_private (wobbly_effect));
+
+  switch (prop_id)
+    {
+    case PROP_SPRING_K:
+      priv->model_settings.springConstant = g_value_get_double (value);
+      break;
+    case PROP_FRICTION:
+      priv->model_settings.friction = g_value_get_double (value);
+      break;
+    case PROP_SLOWDOWN_FACTOR:
+      priv->slowdown_factor = g_value_get_double (value);
+      break;
+    case PROP_OBJECT_MOVEMENT_RANGE:
+      priv->model_settings.maximumRange = g_value_get_double (value);
+      break;
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+      break;
+    }
+}
+
+static void
+endless_shell_fx_wobbly_finalize (GObject *object)
+{
+  EndlessShellFXWobbly *wobbly_effect =
+    reinterpret_cast <EndlessShellFXWobbly *> (object);
+  EndlessShellFXWobblyPrivate *priv =
+    reinterpret_cast <EndlessShellFXWobblyPrivate *> (endless_shell_fx_wobbly_get_instance_private (wobbly_effect));
+
+  if (priv->model)
+    delete priv->model;
+
+  if (priv->timeout_id)
+    {
+      g_source_remove (priv->timeout_id);
+      priv->timeout_id = 0;
+    }
+
+  G_OBJECT_CLASS (endless_shell_fx_wobbly_parent_class)->finalize (object);
+}
+
+static void
+endless_shell_fx_wobbly_init (EndlessShellFXWobbly *effect)
+{
+  EndlessShellFXWobblyPrivate *priv =
+    reinterpret_cast <EndlessShellFXWobblyPrivate *> (endless_shell_fx_wobbly_get_instance_private (effect));
+
+  /* Everything else is zero-initialised. */
+  priv->model_settings = wobbly::Model::DefaultSettings;
+}
+
+static void
+endless_shell_fx_wobbly_class_init (EndlessShellFXWobblyClass *klass)
+{
+  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+  ClutterActorMetaClass *meta_class = CLUTTER_ACTOR_META_CLASS (klass);
+  ClutterEffectClass *effect_class = CLUTTER_EFFECT_CLASS (klass);
+  ClutterDeformEffectClass *deform_class = CLUTTER_DEFORM_EFFECT_CLASS (klass);
+
+  object_class->set_property = endless_shell_fx_wobbly_set_property;
+  object_class->finalize = endless_shell_fx_wobbly_finalize;
+  meta_class->set_actor = endless_shell_fx_wobbly_set_actor;
+  effect_class->pre_paint = endless_shell_fx_wobbly_pre_paint;
+  effect_class->get_paint_volume = endless_shell_fx_wobbly_get_paint_volume;
+  deform_class->deform_vertex = endless_shell_fx_wobbly_deform_vertex;
+
+  object_properties[PROP_SPRING_K] =
+    g_param_spec_double ("spring-k",
+                         "Spring Constant",
+                         "How springy the model is",
+                         2.0f, 10.0f, 8.0f,
+                         G_PARAM_WRITABLE);
+
+  object_properties[PROP_FRICTION] =
+    g_param_spec_double ("friction",
+                         "Friction Constant",
+                         "How much friction force should be applied to moving objects",
+                         2.0f, 10.0f, 3.0f,
+                         G_PARAM_WRITABLE);
+
+  object_properties[PROP_SLOWDOWN_FACTOR] =
+    g_param_spec_double ("slowdown-factor",
+                         "Slowdown Factor",
+                         "How much to slow the model's timesteps down",
+                         1.0f, 5.0f, 1.0f,
+                         G_PARAM_WRITABLE);
+
+  object_properties[PROP_OBJECT_MOVEMENT_RANGE] =
+    g_param_spec_double ("object-movement-range",
+                         "Object Movement Range",
+                         "How much objects are allowed to move around",
+                         10.0f, 500.0f, 100.0f,
+                         G_PARAM_WRITABLE);
+
+  g_object_class_install_properties (object_class, PROP_LAST, object_properties);
+}
+
+ClutterEffect *
+endless_shell_fx_wobbly_new ()
+{
+  return reinterpret_cast <ClutterEffect *> (g_object_new (ENDLESS_SHELL_FX_TYPE_WOBBLY,
+                                                           nullptr));
+}

--- a/src/wobbly-effect.h
+++ b/src/wobbly-effect.h
@@ -1,0 +1,119 @@
+/*
+ * wobbly-effect.h
+ *
+ * Copyright © 2013-2016 Endless Mobile, Inc.
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * licence or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authors: Sam Spilsbury <sam@endlessm.com>
+ */
+
+#ifndef ENDLESS_SHELL_FX_WOBBLY_H
+#define ENDLESS_SHELL_FX_WOBBLY_H
+
+#include <glib-object.h>
+#include <clutter/clutter.h>
+
+G_BEGIN_DECLS
+
+#define ENDLESS_SHELL_FX_TYPE_WOBBLY endless_shell_fx_wobbly_get_type ()
+
+#define ENDLESS_SHELL_FX_WOBBLY(obj) \
+  (G_TYPE_CHECK_INSTANCE_CAST((obj), \
+   ENDLESS_SHELL_FX_TYPE_WOBBLY, EndlessShellFXWobbly))
+
+#define ENDLESS_SHELL_FX_WOBBLY_CLASS(obj) \
+  (G_TYPE_CHECK_CLASS_CAST((obj) \
+   ENDLESS_SHELL_FX_TYPE_WOBBLY, EndlessShellFXWobblyClass))
+
+#define ENDLESS_SHELL_FX_WOBBLY_GET_CLASS(obj) \
+  (G_TYPE_INSTANCE_GET_CLASS((obj), \
+   ENDLESS_SHELL_FX_TYPE_WOBBLY, EndlessShellFXWobblyClass))
+
+typedef struct _EndlessShellFXWobbly EndlessShellFXWobbly;
+typedef struct _EndlessShellFXWobblyClass EndlessShellFXWobblyClass;
+
+struct _EndlessShellFXWobbly
+{
+  ClutterDeformEffect parent;
+};
+
+struct _EndlessShellFXWobblyClass
+{
+  ClutterDeformEffectClass parent_class;
+};
+
+GType endless_shell_fx_wobbly_get_type (void);
+
+/**
+ * endless_shell_fx_wobbly_grab:
+ * @effect: An #EndlessShellFXWobbly
+ * @x: The x-coordinate on the mesh to grab, specified relative to the
+ * upper-left corner of the mesh
+ * @y: The y-coordinate on the mesh to grab, specified relative to the
+ * upper-left corner of the mesh.
+ *
+ * Grabs the anchor specified by @x and @y on the mesh. While
+ * the mesh is in this state, this point will move immediately,
+ * causing spring forces to be applied to other points on the mesh
+ *
+ * It is a precondition violation to call this function when the mesh is
+ * already grabbed.
+ *
+ */
+void endless_shell_fx_wobbly_grab (EndlessShellFXWobbly *effect,
+                                   double         x,
+                                   double         y);
+
+/**
+ * endless_shell_fx_wobbly_ungrab:
+ * @effect: An #EndlessShellFXWobbly
+ * Removes the current grab. When the actor is moved, the mesh will
+ * move uniformly.
+ *
+ * It is a precondition violation to call this function when the mesh is
+ * not grabbed.
+ */
+void endless_shell_fx_wobbly_ungrab (EndlessShellFXWobbly *effect);
+
+/**
+ * endless_shell_fx_wobbly_move_by:
+ * @effect: An #EndlessShellFXWobbly
+ * @dx: A delta-x coordinate to move the mesh by
+ * @dy: A delta-y coordinate to move the mesh by
+ *
+ * Moves the mesh by @dx and @dy
+ *
+ * If the mesh is grabbed, then spring forces will be applied causing
+ * some points on the mesh to move more slowly than others. The nature
+ * of the moment will depend on the window's maximization state.
+ *
+ */
+void endless_shell_fx_wobbly_move_by (EndlessShellFXWobbly *effect,
+                                      double         dx,
+                                      double         dy);
+
+/**
+ * endless_shell_fx_wobbly_new:
+ *
+ * Creates a new #ClutterEffect which makes the window "wobble"
+ * on a spring mesh for the actor
+ *
+ * Returns: (transfer full): A new #ClutterEffect
+ */
+ClutterEffect * endless_shell_fx_wobbly_new ();
+
+G_END_DECLS
+
+#endif


### PR DESCRIPTION
Link to libendless_wobbly (from libwobbly) and add a new
EndlessShellFXWobbly class to bridge between a clutter effect
and the wobbly::Model/wobbly::Anchor.

Use endless_shell_fx_wobbly_grab to grab a point on the mesh
and move it around.

Use endless_shell_fx_wobbly_ungrab to release a point on the mesh.

Each of the above functions may only be called once whilst in the
opposing state and cannot be called again whilst in the same state.

EOSShellWobbly is a JavaScript subclass of EndlessShellFXWobbly
which handles integration between the shell itself and the wobbly
effect. It provides API to handle mouse grab / ungrab of a window
and window movement whilst grabbed.

Provide the following new keys in org.gnome.shell:

 'wobbly-spring-k' : Spring K
 'wobbly-spring-friction' : Spring Friction
 'wobbly-slowdown-factor' : Amount to slow effect down
 'wobbly-object-movement-range' : Amount points on the mesh are
  allowed to deviate from their target position once the mesh is
  settled.

https://phabricator.endlessm.com/T17123