### PR TITLE
theme: add missing style selector for AppIconBarNavButton

### DIFF
--- a/data/theme/gnome-shell.css
+++ b/data/theme/gnome-shell.css
@@ -1946,6 +1946,12 @@ stage {
     spacing: 10px;
 }
 
+.app-bar-nav-icon {
+    icon-size: 16px;
+    color: #555;
+    transition-duration: 100ms;
+}
+
 .app-bar-nav-button:active .app-bar-nav-icon,
 .app-bar-nav-button:hover:active  .app-bar-nav-icon {
     color: #383838;


### PR DESCRIPTION
It will be very large and bright without it.

https://phabricator.endlessm.com/T17482