### PR TITLE
power: hide indicator when not on battery

### DIFF
--- a/js/ui/status/power.js
+++ b/js/ui/status/power.js
@@ -113,9 +113,9 @@ const Indicator = new Lang.Class({
             this._item.actor.show();
             this._percentageLabel.visible = this._desktopSettings.get_boolean(SHOW_BATTERY_PERCENTAGE);
         } else {
-            // If there's no battery, then we use the power icon.
+            // If there's no battery, then we hide the indicator.
             this._item.actor.hide();
-            this._indicator.icon_name = 'system-shutdown-symbolic';
+            this._indicator.visible = false;
             this._percentageLabel.hide();
             return;
         }


### PR DESCRIPTION
Instead of using the shutdown icon, since we don't have a shutdown
option inside this menu anymore.

https://phabricator.endlessm.com/T17362