### PR TITLE
theme: Add selector for solid bottom bar

### DIFF
--- a/data/theme/gnome-shell.css
+++ b/data/theme/gnome-shell.css
@@ -2137,7 +2137,8 @@ stage {
     transition-duration: 500ms;
 }
 
-#panel .endless-button:hover {
+#panel .endless-button:hover,
+#panel.solid .endless-button:hover {
     color: #f15a22;
 }
 


### PR DESCRIPTION
The Endless button's hover state was applied only when the
bottom bar was semi-transparent because it was missing a
selector to apply the same color when the bottom bar was
fully opaque.

Fix that by adding the hover state to #panel.solid selector
as well.

https://phabricator.endlessm.com/T17521