### PR TITLE
js: rename yelp desktop file

### DIFF
--- a/js/ui/userMenu.js
+++ b/js/ui/userMenu.js
@@ -25,7 +25,7 @@ const ONLINE_ACCOUNTS_PANEL_LAUNCHER = 'gnome-online-accounts-panel.desktop';
 const USER_ACCOUNTS_PANEL_LAUNCHER = 'gnome-user-accounts-panel.desktop';
 
 const HELP_CENTER_TEXT = _("Help Center");
-const HELP_CENTER_LAUNCHER = 'yelp.desktop';
+const HELP_CENTER_LAUNCHER = 'org.gnome.Yelp.desktop';
 
 const UserAccountSection = new Lang.Class({
     Name: 'UserAccountSection',


### PR DESCRIPTION
Yelp desktop file was renamed from yelp.desktop to org.gnome.Yelp.desktop
to make yelp application D-Bus launchable.

First we should merge https://github.com/endlessm/yelp/pull/40.

https://phabricator.endlessm.com/T10165