### PR TITLE
config: Properly define DATADIR, PKGDATADIR and LOCALSTATEDIR

### DIFF
--- a/js/Makefile.am
+++ b/js/Makefile.am
@@ -10,7 +10,9 @@ misc/config.js: misc/config.js.in Makefile
 	    -e "s|[@]GETTEXT_PACKAGE@|$(GETTEXT_PACKAGE)|g" \
 	    -e "s|[@]datadir@|$(datadir)|g" \
 	    -e "s|[@]libexecdir@|$(libexecdir)|g" \
+	    -e "s|[@]pkgdatadir@|$(pkgdatadir)|g" \
 	    -e "s|[@]sysconfdir@|$(sysconfdir)|g" \
+	    -e "s|[@]localstatedir@|$(localstatedir)|g" \
                $< > $@
 
 js_resource_files = $(shell $(GLIB_COMPILE_RESOURCES) --sourcedir=$(srcdir) --sourcedir=$(builddir) --generate-dependencies $(srcdir)/js-resources.gresource.xml)

--- a/js/misc/config.js.in
+++ b/js/misc/config.js.in
@@ -13,5 +13,9 @@ const GETTEXT_PACKAGE = '@GETTEXT_PACKAGE@';
 /* locale dir */
 const LOCALEDIR = '@datadir@/locale';
 /* other standard directories */
+const DATADIR = '@datadir@';
 const LIBEXECDIR = '@libexecdir@';
 const SYSCONFDIR = '@sysconfdir@';
+const LOCALSTATEDIR = '@localstatedir@';
+/* subdirectories under standard directories */
+const PKGDATADIR = '@pkgdatadir@';


### PR DESCRIPTION
This small change that I overlooked while porting other changes
makes it possible to visualize the default desktop's icon grid
when no customizations have been done before at all by the user.

In other words, it makes the desktop grid to show up on newly
flashed images which otherwise would fail to load the defaults.

https://phabricator.endlessm.com/T17653