### PR TITLE
shell: Allow editing desktop icon names

### DIFF
--- a/data/theme/gnome-shell.css
+++ b/data/theme/gnome-shell.css
@@ -2411,6 +2411,40 @@ stage {
     font-size: 9pt;
 }
 
+/* Icon Grid labels */
+.overview-icon-label {
+    width: 118px;
+    text-shadow: black 0px 2px 2px;
+
+    border: none;
+    background-color: transparent;
+}
+
+.overview-icon-label:focus {
+    border-radius: 4px;
+    background-gradient-start: rgb(200,200,200);
+    background-gradient-end: white;
+    background-gradient-direction: vertical;
+
+    color: #555;
+    caret-color: #555;
+    selected-color: white;
+
+    box-shadow: inset 0px 1px 2px rgba(0,0,0,0.6);
+}
+
+.overview-icon-label:highlighted,
+.overview-icon-label:focus:highlighted {
+    border-radius: 4px;
+    background-color: #d2d2d2;
+    background-gradient-direction: none;
+
+    color: #333;
+
+    box-shadow: none;
+    text-shadow: none;
+}
+
 /* Endless Code view source */
 .view-source {
   background-color: white;

--- a/js/js-resources.gresource.xml
+++ b/js/js-resources.gresource.xml
@@ -135,6 +135,7 @@
     <file>ui/components/codingGameService.js</file>
     <file>ui/components/discoveryFeed.js</file>
     <file>ui/discoveryFeedButton.js</file>
+    <file>ui/editableLabel.js</file>
     <file>ui/endlessButton.js</file>
     <file>ui/forceAppExitDialog.js</file>
     <file>ui/hotCorner.js</file>

--- a/js/ui/editableLabel.js
+++ b/js/ui/editableLabel.js
@@ -1,0 +1,211 @@
+// -*- mode: js; js-indent-level: 4; indent-tabs-mode: nil -*-
+
+const Clutter = imports.gi.Clutter;
+const Gdk = imports.gi.Gdk;
+const GObject = imports.gi.GObject;
+const GrabHelper = imports.ui.grabHelper;
+const Lang = imports.lang;
+const Pango = imports.gi.Pango;
+const St = imports.gi.St;
+
+const EditableLabelMode = {
+    DISPLAY: 0,
+    HIGHLIGHT: 1,
+    EDIT: 2
+};
+
+const EditableLabel = new Lang.Class({
+    Name: 'EditableLabel',
+    Extends: St.Entry,
+    Signals: {
+        'label-edit-update': { param_types: [ GObject.TYPE_STRING ] },
+        'label-edit-cancel': { }
+    },
+
+    _init: function(params) {
+        this.parent(params);
+
+        this.clutter_text.editable = false;
+        this.clutter_text.selectable = false;
+        this.clutter_text.x_align = Clutter.ActorAlign.CENTER;
+        this.clutter_text.ellipsize = Pango.EllipsizeMode.END;
+
+        this.clutter_text.bind_property('editable', this.clutter_text, 'selectable',
+            GObject.BindingFlags.BIDIRECTIONAL | GObject.BindingFlags.SYNC_CREATE);
+
+        this._activateId = 0;
+        this._keyFocusId = 0;
+        this._labelMode = EditableLabelMode.DISPLAY;
+        this._oldLabelText = null;
+
+        this.connect('button-press-event', Lang.bind(this, this._onButtonPressEvent));
+        this.connect('destroy', Lang.bind(this, this._onDestroy));
+
+        this._grabHelper = new GrabHelper.GrabHelper(this);
+        this._grabHelper.addActor(this);
+    },
+
+    _onDestroy: function() {
+        this._cancelEditing();
+    },
+
+    _onButtonPressEvent: function(label, event) {
+        if (event.get_button() != Gdk.BUTTON_PRIMARY)
+            return false;
+
+        if (event.get_click_count() > 1 &&
+            this._labelMode != EditableLabelMode.HIGHLIGHT)
+            return false;
+
+        // enter highlight mode if this is the first click
+        if (this._labelMode == EditableLabelMode.DISPLAY) {
+            this._labelMode = EditableLabelMode.HIGHLIGHT;
+            this.add_style_pseudo_class('highlighted');
+
+            this._grabHelper.grab({ actor: this,
+                                    onUngrab: Lang.bind(this, this._onHighlightUngrab) });
+
+            return true;
+        }
+
+        if (this._labelMode == EditableLabelMode.HIGHLIGHT) {
+            // while in highlight mode, another extra click enters the
+            // actual edit mode, which we handle from the highlight ungrab
+            if (this._grabHelper.grabbed)
+                this._grabHelper.ungrab({ actor: this });
+
+            return true;
+        }
+
+        // ensure focus stays in the text field when clicking
+        // on the entry empty space
+        this.grab_key_focus();
+
+        let [stageX, stageY] = event.get_coords();
+        let [textX, textY] = this.clutter_text.get_transformed_position();
+
+        if (stageX < textX) {
+            this.clutter_text.cursor_position = 0;
+            this.clutter_text.set_selection(0, 0);
+        } else {
+            this.clutter_text.cursor_position = -1;
+            this.clutter_text.selection_bound = -1;
+        }
+
+        // eat button press events on the entry empty space in this mode
+        return true;
+    },
+
+    _onHighlightUngrab: function(isUser) {
+        // exit highlight mode
+        this.remove_style_pseudo_class('highlighted');
+
+        // clicked outside the label - cancel the edit
+        if (isUser) {
+            this._labelMode = EditableLabelMode.DISPLAY;
+            this.emit('label-edit-cancel');
+            return;
+        }
+
+        // now prepare for editing...
+        this._labelMode = EditableLabelMode.EDIT;
+
+        this._keyFocusId = this.connect('key-focus-in', Lang.bind(this, this._startEditing));
+        this._grabHelper.grab({ actor: this,
+                                focus: this,
+                                onUngrab: Lang.bind(this, this._onEditUngrab) });
+    },
+
+    _onEditUngrab: function(isUser) {
+        // edit has already been completed and this is an explicit
+        // ungrab from endEditing()
+        if (!isUser)
+            return;
+
+        let event = Clutter.get_current_event();
+        let eventType;
+
+        if (event)
+            eventType = event.type();
+
+        if (eventType == Clutter.EventType.KEY_PRESS) {
+            let symbol = event.get_key_symbol();
+
+            // abort editing
+            if (symbol == Clutter.KEY_Escape)
+                this._cancelEditing();
+
+            return;
+        }
+
+        // confirm editing when clicked outside the label
+        if (eventType == Clutter.EventType.BUTTON_PRESS) {
+            this._confirmEditing();
+            return;
+        }
+
+        // abort editing for other grab-breaking events
+        this._cancelEditing();
+    },
+
+    _startEditing: function() {
+        let text = this.get_text();
+
+        // select the current text when editing starts
+        this.clutter_text.editable = true;
+        this.clutter_text.cursor_position = 0;
+        this.clutter_text.selection_bound = text.length;
+
+        // save the current contents of the label, in case we
+        // need to roll back
+        this._oldLabelText = text;
+
+        this._activateId = this.clutter_text.connect('activate',
+            Lang.bind(this, this._confirmEditing));
+    },
+
+    _endEditing: function() {
+        this.clutter_text.editable = false;
+
+        this._oldLabelText = null;
+
+        if (this._activateId) {
+            this.clutter_text.disconnect(this._activateId);
+            this._activateId = 0;
+        }
+
+        if (this._keyFocusId) {
+            this.disconnect(this._keyFocusId);
+            this._keyFocusId = 0;
+        }
+
+        if (this._grabHelper.isActorGrabbed(this))
+            this._grabHelper.ungrab({ actor: this });
+
+        this._labelMode = EditableLabelMode.DISPLAY;
+    },
+
+    _cancelEditing: function() {
+        // _endEditing() below will unset oldLabelText
+        let oldText = this._oldLabelText;
+
+        this._endEditing();
+
+        this.set_text(oldText);
+        this.emit('label-edit-cancel');
+    },
+
+    _confirmEditing: function() {
+        // _endEditing() below will unset oldLabelText
+        let oldText = this._oldLabelText;
+        let text = this.get_text();
+
+        if (!text || text == oldText) {
+            this._cancelEditing();
+            return;
+        }
+
+        this._endEditing();
+        this.emit('label-edit-update', text);
+    }
+});

--- a/js/ui/iconGrid.js
+++ b/js/ui/iconGrid.js
@@ -12,6 +12,8 @@ const Params = imports.misc.params;
 const Tweener = imports.ui.tweener;
 const Main = imports.ui.main;
 
+const EditableLabel = imports.ui.editableLabel;
+
 const ICON_SIZE = 64;
 const MIN_ICON_SIZE = 16;
 
@@ -41,6 +43,7 @@ const BaseIcon = new Lang.Class({
         params = Params.parse(params, { createIcon: null,
                                         createExtraIcons: null,
                                         setSizeManually: false,
+                                        editable: false,
                                         showLabel: true });
 
         let styleClass = 'overview-icon';
@@ -88,7 +91,12 @@ const BaseIcon = new Lang.Class({
         this._layeredIcon.add_actor(shadow);
 
         if (params.showLabel) {
-            this.label = new St.Label({ text: label });
+            if (params.editable)
+                this.label = new EditableLabel.EditableLabel({ text: label,
+                                                               style_class: 'overview-icon-label' });
+            else
+                this.label = new St.Label({ text: label,
+                                            style_class: 'overview-icon-label' });
             box.add_actor(this.label);
         } else {
             this.label = null;

--- a/src/shell-app.h
+++ b/src/shell-app.h
@@ -72,7 +72,9 @@ void shell_app_update_app_menu       (ShellApp *app, MetaWindow *window);
 
 gboolean shell_app_get_busy          (ShellApp *app);
 
-gboolean shell_app_create_custom_launcher_with_name (ShellApp *app, const char *label);
+gboolean shell_app_create_custom_launcher_with_name (ShellApp    *app,
+                                                     const char  *label,
+                                                     GError     **error);
 
 G_END_DECLS
 


### PR DESCRIPTION
Previously, Endless OS shell allowed users to rename
the desktop icons and folders. With the GNOME Shell
rebase, however, that feature was lost and we cannot
rename them anymore.

This commit brings back the code to edit desktop icons
and folders, and adapts the previous work over the
rebased GNOME Shell so that only desktop icons and
folders are editable (and e.g. search results are not).

https://phabricator.endlessm.com/T17660