### PR TITLE
theme: Remove spacing between elements in overview

### DIFF
--- a/data/theme/gnome-shell.css
+++ b/data/theme/gnome-shell.css
@@ -2119,6 +2119,10 @@ stage {
     margin: 14px 0px;
 }
 
+#overview {
+  spacing: 0px;
+}
+
 #panel .endless-button,
 #panel.solid .endless-button {
     color: #d1d1d1;


### PR DESCRIPTION
We don't want this as we need perfect alignment.