### PR TITLE
icon-grid: Style the folder icons to look closer to app icons

### DIFF
--- a/data/theme/gnome-shell.css
+++ b/data/theme/gnome-shell.css
@@ -2435,6 +2435,28 @@ stage {
     font-size: 9pt;
 }
 
+/* Icon Grid folder icons */
+
+.app-well-app.app-folder > .overview-icon,
+.app-well-app.app-folder:active .overview-icon,
+.app-well-app.app-folder:checked .overview-icon {
+  background-color: transparent;
+  box-shadow: none;
+}
+
+.app-well-app.app-folder .app-folder-icon {
+  border-radius: 12px;
+  background: rgba(23, 25, 26, 0.3);
+  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.7);
+}
+
+.app-well-app.app-folder:checked .app-folder-icon,
+.app-well-app.app-folder:selected .app-folder-icon {
+  background: rgba(23, 25, 26, 0.6);
+  transition-duration: 250ms;
+  box-shadow: inset 0 3px 4px rgba(0, 0, 0, 0.7);
+}
+
 /* Icon Grid labels */
 .overview-icon-label {
     width: 118px;


### PR DESCRIPTION
The folder icons had a gray background that encompassed the icon and
label which made it looked too different from the regular app icons.

These changes add a rounded corner square that includes only the tiny
icons of the folder which makes it look much closer to a regular app
icon.

https://phabricator.endlessm.com/T17785