### PR TITLE
Add integration with AppActivation from the grid

### DIFF
--- a/js/ui/appDisplay.js
+++ b/js/ui/appDisplay.js
@@ -1798,21 +1798,8 @@ const AppIcon = new Lang.Class({
 
     activate: function (button) {
         let event = Clutter.get_current_event();
-        let modifiers = event ? event.get_state() : 0;
-        let openNewWindow = this.app.can_open_new_window () &&
-                            modifiers & Clutter.ModifierType.CONTROL_MASK &&
-                            this.app.state == Shell.AppState.RUNNING ||
-                            button && button == 2;
-
-        if (this.app.state == Shell.AppState.STOPPED || openNewWindow)
-            this.animateLaunch();
-
-        if (openNewWindow)
-            this.app.open_new_window(-1);
-        else
-            this.app.activate();
-
-        Main.overview.hide();
+        let activationContext = new AppActivation.AppActivationContext(this.app);
+        activationContext.activate(event);
     },
 
     animateLaunch: function() {

--- a/js/ui/workspace.js
+++ b/js/ui/workspace.js
@@ -1793,14 +1793,20 @@ const Workspace = new Lang.Class({
         global.screen.disconnect(this._windowEnteredMonitorId);
         global.screen.disconnect(this._windowLeftMonitorId);
 
-        if (this._repositionWindowsId > 0)
+        if (this._repositionWindowsId > 0) {
             Mainloop.source_remove(this._repositionWindowsId);
+            this._repositionWindowsId = 0;
+        }
 
-        if (this._positionWindowsId > 0)
+        if (this._positionWindowsId > 0) {
             Meta.later_remove(this._positionWindowsId);
+            this._positionWindowsId = 0;
+        }
 
-        if (this._actualGeometryLater > 0)
+        if (this._actualGeometryLater > 0) {
             Meta.later_remove(this._actualGeometryLater);
+            this._actualGeometryLater = 0;
+        }
 
         this._windows = [];
     },

--- a/js/ui/workspaceMonitor.js
+++ b/js/ui/workspaceMonitor.js
@@ -66,7 +66,7 @@ const WorkspaceMonitor = new Lang.Class({
         }
     },
 
-    _getRunningApps: function() {
+    _getVisibleApps: function() {
         let runningApps = this._appSystem.get_running();
         return runningApps.filter(function(app) {
             let windows = app.get_windows();
@@ -77,18 +77,6 @@ const WorkspaceMonitor = new Lang.Class({
                 if (window.get_transient_for())
                     continue;
 
-                return true;
-            }
-
-            return false;
-        });
-    },
-
-    _getVisibleApps: function() {
-        let runningApps = this._getRunningApps();
-        return runningApps.filter(function(app) {
-            let windows = app.get_windows();
-            for (let window of windows) {
                 if (!window.minimized)
                     return true;
             }
@@ -102,7 +90,7 @@ const WorkspaceMonitor = new Lang.Class({
         if (this._inFullscreen)
             return true;
 
-        let apps = this._getRunningApps();
+        let apps = this._appSystem.get_running();
         return apps.length > 0;
     },
 

--- a/src/shell-app.c
+++ b/src/shell-app.c
@@ -400,6 +400,17 @@ shell_app_activate_window (ShellApp     *app,
       guint32 last_user_timestamp = meta_display_get_last_user_time (display);
       MetaWindow *most_recent_transient;
 
+      /* HACK: we shouldn't really get this far with a zero timestamp,
+       * but shell_app_activate_window() can be called from shell_app_activate_full()
+       * which will not be able to fetch a valid timestamp in some cases - e.g.
+       * if we're just activating an app over DBus from Chromium.
+       * Since passing a zero timestamp will trigger focus stealing prevention,
+       * and passing zero to meta_window_activate() will trigger a WM warning,
+       * just fetch the timestamp here instead.
+       */
+      if (timestamp == 0)
+        timestamp = meta_display_get_current_time_roundtrip (display);
+
       if (meta_display_xserver_time_is_before (display, timestamp, last_user_timestamp))
         {
           meta_window_set_demands_attention (window);


### PR DESCRIPTION
Besides that change (last commit), this PR also a fix from upstream to silent a critical error that happens when closing windows, a cherry pick of a AppActivation-related patch missed during the rebase, and a fix for the way the property `hasActiveWindows` gets computed.

https://phabricator.endlessm.com/T17936