### PR TITLE
Move eos-image-defaults to /var/lib

### DIFF
--- a/js/ui/iconGridLayout.js
+++ b/js/ui/iconGridLayout.js
@@ -22,13 +22,9 @@ const FOLDER_DIR_NAME = 'desktop-directories';
 const DEFAULT_CONFIGS_DIR = Config.DATADIR + '/eos-shell-content/icon-grid-defaults';
 const DEFAULT_CONFIG_NAME_BASE = 'icon-grid';
 
-const OVERRIDE_CONFIGS_DIR = Config.LOCALSTATEDIR + '/eos-image-defaults/icon-grid';
+const OVERRIDE_CONFIGS_DIR = Config.LOCALSTATEDIR + '/lib/eos-image-defaults/icon-grid';
 const OVERRIDE_CONFIG_NAME_BASE = 'icon-grid';
-
-const PREPEND_CONFIGS_DIR = Config.LOCALSTATEDIR + '/eos-image-defaults/icon-grid';
 const PREPEND_CONFIG_NAME_BASE = 'icon-grid-prepend';
-
-const APPEND_CONFIGS_DIR = Config.LOCALSTATEDIR + '/eos-image-defaults/icon-grid';
 const APPEND_CONFIG_NAME_BASE = 'icon-grid-append';
 
 /* Occurs when an application is uninstalled, meaning removed from the desktop's
@@ -158,8 +154,8 @@ const IconGridLayout = new Lang.Class({
         let mergedJson = this._mergeJsonStrings(
             this._loadConfigJsonString(DEFAULT_CONFIGS_DIR, DEFAULT_CONFIG_NAME_BASE),
             this._loadConfigJsonString(OVERRIDE_CONFIGS_DIR, OVERRIDE_CONFIG_NAME_BASE),
-            this._loadConfigJsonString(PREPEND_CONFIGS_DIR, PREPEND_CONFIG_NAME_BASE),
-            this._loadConfigJsonString(APPEND_CONFIGS_DIR ,APPEND_CONFIG_NAME_BASE)
+            this._loadConfigJsonString(OVERRIDE_CONFIGS_DIR, PREPEND_CONFIG_NAME_BASE),
+            this._loadConfigJsonString(OVERRIDE_CONFIGS_DIR, APPEND_CONFIG_NAME_BASE)
         );
         let iconTree = Json.gvariant_deserialize_data(mergedJson, -1, 'a{sas}');
 


### PR DESCRIPTION
This was fixed in the pre-rebase shell --
https://github.com/endlessm/eos-desktop/pull/266 -- but was lost in the
rebase.

https://phabricator.endlessm.com/T15704