### PR TITLE
Restore Endless-specific default taskbar icons

### DIFF
--- a/data/org.gnome.shell.gschema.xml.in
+++ b/data/org.gnome.shell.gschema.xml.in
@@ -47,7 +47,7 @@
       </description>
     </key>
     <key name="favorite-apps" type="as">
-      <default>[ 'epiphany.desktop', 'evolution.desktop', 'rhythmbox.desktop', 'shotwell.desktop', 'org.gnome.Nautilus.desktop', 'org.gnome.Software.desktop' ]</default>
+      <default>[ 'org.gnome.Software.desktop', 'chromium-browser.desktop', 'org.gnome.Nautilus.desktop' ]</default>
       <summary>List of desktop file IDs for favorite applications</summary>
       <description>
         The applications corresponding to these identifiers


### PR DESCRIPTION
These defaults are taken from [the "taskbar-pins" key in `eos-desktop`](https://github.com/endlessm/eos-desktop/blob/ee7659e61a5dcb804065b107f68ca3b81ce1f10c/data/org.gnome.shell.gschema.xml.in.in#L223-L230), the fork of GNOME Shell used in Endless OS 3.1 and earlier.

Migrating users' existing taskbar icons from the now-obsolute "taskbar-pins" setting on upgrade is already implemented, but without this change new users would receive the upstream defaults. In particular, since we do not ship epiphany, this meant users would not have a browser on the taskbar.

https://phabricator.endlessm.com/T17622