### PR TITLE
screenShield: lift the shield if user clicks without dragging

### DIFF
--- a/js/ui/screenShield.js
+++ b/js/ui/screenShield.js
@@ -752,6 +752,8 @@ const ScreenShield = new Lang.Class({
         if (this._isLocked)
             this._ensureUnlockDialog(false, false);
 
+        this._haveDragMotion = false;
+
         return true;
     },
 
@@ -764,13 +766,16 @@ const ScreenShield = new Lang.Class({
 
 	this._lockScreenGroup.y = newY;
 
+        this._haveDragMotion = true;
+
 	return true;
     },
 
     _onDragEnd: function(action, actor, eventX, eventY, modifiers) {
         if (this._lockScreenState != MessageTray.State.HIDING)
             return;
-        if (this._lockScreenGroup.y < -(ARROW_DRAG_THRESHOLD * global.stage.height)) {
+        if ((this._lockScreenGroup.y < -(ARROW_DRAG_THRESHOLD * global.stage.height)) ||
+            !this._haveDragMotion) {
             // Complete motion automatically
 	    let [velocity, velocityX, velocityY] = this._dragAction.get_velocity(0);
             this._liftShield(true, -velocityY);


### PR DESCRIPTION
Upon releasing the mouse, if there was no drag motion,
lift the shield.  If there is any drag motion, only lift
the shield if the original drag threshold was achieved.

Many novice users are confused by the need to drag the shield open,
so we make it as easy as possible at the expense that touchscreen
users may unintentionally lift the shield with a stray screen touch.

https://phabricator.endlessm.com/T17550