### PR TITLE
shellEntry: ensure that search spinner stops

### DIFF
--- a/js/ui/shellEntry.js
+++ b/js/ui/shellEntry.js
@@ -328,6 +328,7 @@ const OverviewEntry = new Lang.Class({
 
     _stopSearch: function() {
         global.stage.set_key_focus(null);
+        this.setSpinning(false);
     },
 
     _startSearch: function(event) {


### PR DESCRIPTION
Make sure the spinner is stopped whenever the search is stopped.
Previously, it was easy to get into a state where the spinner
would keep running and cause CPU churn.

https://phabricator.endlessm.com/T17855