### PR TITLE
viewSelector: Don't set the spinner on when there are nothing to search

### DIFF
--- a/js/ui/viewSelector.js
+++ b/js/ui/viewSelector.js
@@ -399,7 +399,11 @@ const ViewsDisplay = new Lang.Class({
     },
 
     _updateSpinner: function() {
-        this.entry.setSpinning(this._searchResults.searchInProgress);
+        // Make sure we never set the spinner on when there's nothing to search,
+        // regardless of the reported current state, as it can be out of date.
+        let searchTerms = this.entry.text.trim();
+        let spinning = (searchTerms.length > 0) && this._searchResults.searchInProgress;
+        this.entry.setSpinning(spinning);
     },
 
     _enterSearch: function() {


### PR DESCRIPTION
The spinner is being set whenever the search-progress-updated signal is
received, and then uses the .searchInProgress property to determine whether
to spin or not, but the problem is that this property is being set from
multiple places, so sometimes we can end in a race condition that ends up
with the callback being called with no text in the entry but still the
searchResults object reporting that it's searching.

When this happens, the spinner enters a state where it's constantly
spinning, consuming lots of CPU for no reason unless some user initiated
action takes it out of that state.

Probably not a real fix, but let's at least prevent this situation from
happening by double checking that there's something to search before
setting the spinner on fire.

https://phabricator.endlessm.com/T17973