### PR TITLE
appDisplay: Temporarily disabling DnD of applications inside a folder

### DIFF
--- a/js/ui/appDisplay.js
+++ b/js/ui/appDisplay.js
@@ -1563,6 +1563,12 @@ const FolderView = new Lang.Class({
 
     getViewId: function() {
         return this._folderIcon.getId();
+    },
+
+    canDropAt: function(x, y, canDropPastEnd) {
+        // FIXME: Temporarily disable dragging elements around inside a
+        // folder, as it's causing the GrabHelper to crash for some reason.
+        return [-1, IconGrid.CursorLocation.DEFAULT];
     }
 });
 


### PR DESCRIPTION
It's still possible to add/remove apps to/from a folder, but reordering
apps inside a given folder is currently causing a crash that we sadly
don't have more time to investigate for now (will do for the next release).

https://phabricator.endlessm.com/T18025