### PR TITLE
Fix folder icon alignment on grid

### DIFF
--- a/data/theme/gnome-shell.css
+++ b/data/theme/gnome-shell.css
@@ -1297,11 +1297,6 @@ StScrollBar {
   .page-indicator:checked .page-indicator-icon, .page-indicator:checked:active {
     background-image: url(resource:///org/gnome/shell/theme/page-indicator-checked.svg); }
 
-.app-well-app > .overview-icon.overview-icon-with-label,
-.grid-search-result .overview-icon.overview-icon-with-label {
-  padding: 10px 8px 5px 8px;
-  spacing: 4px; }
-
 .workspace-thumbnails {
   visible-width: 32px;
   spacing: 11px;


### PR DESCRIPTION
Removes some stray CSS that did not seem to be helpful
and instead caused the folder icons to appear misaligned
relative to the app icons.

https://phabricator.endlessm.com/T17824