### PR TITLE
appDisplay: use right actor when dragging

### DIFF
--- a/js/ui/appDisplay.js
+++ b/js/ui/appDisplay.js
@@ -2143,10 +2143,6 @@ const FolderIcon = new Lang.Class({
         return true;
     },
 
-    getDragActor: function() {
-        return this.view.createFolderIcon(this._iconSize);
-    },
-
     handleIconDrop: function(source) {
         // Move the source icon into this folder
         IconGridLayout.layout.appendIcon(source.getId(), this.getId());


### PR DESCRIPTION
The override FolderIcon provides for getDragActor() is harmful, as the
base class already has the right logic we need.