### PR TITLE
iconGrid: Increase the labels width

### DIFF
--- a/data/theme/gnome-shell.css
+++ b/data/theme/gnome-shell.css
@@ -2465,6 +2465,14 @@ stage {
     font-size: 9pt;
 }
 
+.app-well-app .overview-icon,
+.app-well-app.app-folder .overview-icon {
+  width: 118px;
+  height: 118px;
+  padding: 6px 1px 6px 1px;
+  spacing: 4px;
+}
+
 /* Icon Grid folder icons */
 
 .app-folder-icon {
@@ -2511,6 +2519,8 @@ stage {
 .overview-icon-label {
     width: 118px;
     text-shadow: black 0px 2px 2px;
+
+    padding: 4px 0 4px 0;
 
     border: none;
     background-color: transparent;

--- a/data/theme/gnome-shell.css
+++ b/data/theme/gnome-shell.css
@@ -1297,11 +1297,6 @@ StScrollBar {
   .page-indicator:checked .page-indicator-icon, .page-indicator:checked:active {
     background-image: url(resource:///org/gnome/shell/theme/page-indicator-checked.svg); }
 
-.app-well-app > .overview-icon.overview-icon-with-label,
-.grid-search-result .overview-icon.overview-icon-with-label {
-  padding: 6px 4px 5px 4px;
-  spacing: 4px; }
-
 .workspace-thumbnails {
   visible-width: 32px;
   spacing: 11px;

--- a/js/ui/iconGrid.js
+++ b/js/ui/iconGrid.js
@@ -74,7 +74,7 @@ const BaseIcon = new Lang.Class({
 
         this.actor = new St.Bin({ style_class: styleClass,
                                   x_fill: true,
-                                  y_fill: true });
+                                  y_fill: false });
         this.actor._delegate = this;
         this.actor.connect('style-changed',
                            Lang.bind(this, this._onStyleChanged));


### PR DESCRIPTION
The icon labels' width was too short for many app names to fit it, and
thus the grid showed more apps with ellipsized names than in the shell
we had in < 3.2 versions.

https://phabricator.endlessm.com/T18044