### PR TITLE
Prevent hiding app main window when speedwagon is gone 

### DIFF
--- a/js/ui/workspace.js
+++ b/js/ui/workspace.js
@@ -1555,10 +1555,6 @@ const Workspace = new Lang.Class({
 
     _windowRemoved : function(metaWorkspace, metaWin) {
         this._doRemoveWindow(metaWin);
-
-        // Make sure to show the icon grid if we removed the last window
-        if (!Main.workspaceMonitor.hasActiveWindows)
-            Main.overview.showApps();
     },
 
     _windowEnteredMonitor : function(metaScreen, monitorIndex, metaWin) {

--- a/js/ui/workspaceMonitor.js
+++ b/js/ui/workspaceMonitor.js
@@ -15,6 +15,9 @@ const WorkspaceMonitor = new Lang.Class({
         this._shellwm.connect('destroy', Lang.bind(this, this._windowDisappearing));
         this._shellwm.connect('destroy-completed', Lang.bind(this, this._updateOverview));
 
+        this._windowTracker = Shell.WindowTracker.get_default();
+        this._windowTracker.connect('tracked-windows-changed', Lang.bind(this, this._updateOverview));
+
         this._metaScreen = global.screen;
         this._metaScreen.connect('in-fullscreen-changed', Lang.bind(this, this._fullscreenChanged));
 

--- a/src/shell-app.c
+++ b/src/shell-app.c
@@ -1050,7 +1050,7 @@ shell_app_is_interesting_window (MetaWindow *window)
   if (shell_window_tracker_is_speedwagon_window (window))
     return FALSE;
 
-  return !meta_window_is_skip_taskbar (window);
+  return shell_window_tracker_is_window_interesting (window);
 }
 
 void
@@ -1203,7 +1203,7 @@ shell_app_request_quit (ShellApp   *app)
     {
       MetaWindow *win = iter->data;
 
-      if (meta_window_is_skip_taskbar (win))
+      if (!shell_window_tracker_is_window_interesting (win))
         continue;
 
       meta_window_delete (win, shell_global_get_current_time (shell_global_get ()));

--- a/src/shell-app.c
+++ b/src/shell-app.c
@@ -1109,14 +1109,12 @@ _shell_app_remove_window (ShellApp   *app,
     app->running_state->speedwagon_windows--;
 
   if (app->running_state->windows == NULL)
-    {
-      g_clear_pointer (&app->running_state, unref_running_state);
-      shell_app_state_transition (app, SHELL_APP_STATE_STOPPED);
-    }
+    g_clear_pointer (&app->running_state, unref_running_state);
+
+  if (app->running_state == NULL)
+    shell_app_state_transition (app, SHELL_APP_STATE_STOPPED);
   else
-    {
-      shell_app_sync_running_state (app);
-    }
+    shell_app_sync_running_state (app);
 
   g_signal_emit (app, shell_app_signals[WINDOWS_CHANGED], 0);
 }

--- a/src/shell-app.c
+++ b/src/shell-app.c
@@ -263,11 +263,13 @@ shell_app_get_name (ShellApp *app)
     return g_app_info_get_name (G_APP_INFO (app->info));
   else
     {
-      MetaWindow *window = window_backed_app_get_window (app);
       const char *name = NULL;
-
-      if (window)
-        name = meta_window_get_wm_class (window);
+      if (app->running_state)
+        {
+          MetaWindow *window = window_backed_app_get_window (app);
+          if (window)
+            name = meta_window_get_wm_class (window);
+        }
       if (!name)
         name = C_("program", "Unknown");
       return name;

--- a/src/shell-app.c
+++ b/src/shell-app.c
@@ -1044,6 +1044,15 @@ shell_app_ensure_busy_watch (ShellApp *app)
                                        g_object_ref (app));
 }
 
+static gboolean
+shell_app_is_interesting_window (MetaWindow *window)
+{
+  if (shell_window_tracker_is_speedwagon_window (window))
+    return FALSE;
+
+  return !meta_window_is_skip_taskbar (window);
+}
+
 void
 _shell_app_add_window (ShellApp        *app,
                        MetaWindow      *window)
@@ -1065,7 +1074,7 @@ _shell_app_add_window (ShellApp        *app,
   shell_app_update_app_menu (app, window);
   shell_app_ensure_busy_watch (app);
 
-  if (!meta_window_is_skip_taskbar (window))
+  if (shell_app_is_interesting_window (window))
     app->running_state->interesting_windows++;
   else if (shell_window_tracker_is_speedwagon_window (window))
     app->running_state->speedwagon_windows++;
@@ -1092,7 +1101,7 @@ _shell_app_remove_window (ShellApp   *app,
   g_object_unref (window);
   app->running_state->windows = g_slist_remove (app->running_state->windows, window);
 
-  if (!meta_window_is_skip_taskbar (window))
+  if (shell_app_is_interesting_window (window))
     app->running_state->interesting_windows--;
   else if (shell_window_tracker_is_speedwagon_window (window))
     app->running_state->speedwagon_windows--;

--- a/src/shell-app.c
+++ b/src/shell-app.c
@@ -1225,6 +1225,24 @@ app_child_setup (gpointer user_data)
 }
 #endif
 
+static void
+_gather_pid_callback (GDesktopAppInfo   *gapp,
+                      GPid               pid,
+                      gpointer           data)
+{
+  ShellApp *app;
+  ShellWindowTracker *tracker;
+
+  g_return_if_fail (data != NULL);
+
+  app = SHELL_APP (data);
+  tracker = shell_window_tracker_get_default ();
+
+  _shell_window_tracker_add_child_process_app (tracker,
+                                               pid,
+                                               app);
+}
+
 /**
  * shell_app_launch:
  * @timestamp: Event timestamp, or 0 for current event timestamp
@@ -1259,13 +1277,13 @@ shell_app_launch (ShellApp     *app,
 
   ret = g_desktop_app_info_launch_uris_as_manager (app->info, NULL,
                                                    context,
-                                                   G_SPAWN_SEARCH_PATH,
+                                                   G_SPAWN_SEARCH_PATH | G_SPAWN_DO_NOT_REAP_CHILD,
 #ifdef HAVE_SYSTEMD
                                                    app_child_setup, (gpointer)shell_app_get_id (app),
 #else
                                                    NULL, NULL,
 #endif
-                                                   NULL, NULL,
+                                                   _gather_pid_callback, app,
                                                    error);
   g_object_unref (context);
 

--- a/src/shell-window-tracker.c
+++ b/src/shell-window-tracker.c
@@ -887,6 +887,12 @@ shell_window_tracker_is_window_interesting (MetaWindow *window)
   if (meta_window_is_skip_taskbar (window))
     return FALSE;
 
+  /* HACK: see https://github.com/endlessm/eos-shell/issues/548 and
+   * https://github.com/linuxmint/Cinnamon/issues/728
+   */
+  if (g_strcmp0 (meta_window_get_title (window), "JavaEmbeddedFrame") == 0)
+    return FALSE;
+
   return TRUE;
 }
 

--- a/src/shell-window-tracker.c
+++ b/src/shell-window-tracker.c
@@ -52,6 +52,9 @@ struct _ShellWindowTracker
   /* <MetaWindow * window, ShellApp *app> */
   GHashTable *window_to_app;
 
+  /* <int, ShellApp *app> */
+  GHashTable *launched_pid_to_app;
+
   MetaWindow *coding_app;
 };
 
@@ -357,6 +360,10 @@ get_app_from_window_pid (ShellWindowTracker  *tracker,
     return NULL;
 
   result = shell_window_tracker_get_app_from_pid (tracker, pid);
+
+  if (result == NULL)
+    result = g_hash_table_lookup (tracker->launched_pid_to_app, GINT_TO_POINTER (pid));
+
   if (result != NULL)
     g_object_ref (result);
 
@@ -698,6 +705,8 @@ shell_window_tracker_init (ShellWindowTracker *self)
   self->window_to_app = g_hash_table_new_full (g_direct_hash, g_direct_equal,
                                                NULL, (GDestroyNotify) g_object_unref);
 
+  self->launched_pid_to_app = g_hash_table_new_full (NULL, NULL, NULL, (GDestroyNotify) g_object_unref);
+
   screen = shell_global_get_screen (shell_global_get ());
 
   g_signal_connect (G_OBJECT (screen), "startup-sequence-changed",
@@ -713,6 +722,7 @@ shell_window_tracker_finalize (GObject *object)
   ShellWindowTracker *self = SHELL_WINDOW_TRACKER (object);
 
   g_hash_table_destroy (self->window_to_app);
+  g_hash_table_destroy (self->launched_pid_to_app);
 
   G_OBJECT_CLASS (shell_window_tracker_parent_class)->finalize(object);
 }
@@ -779,6 +789,39 @@ shell_window_tracker_get_app_from_pid (ShellWindowTracker *tracker,
   g_slist_free (running);
 
   return result;
+}
+
+static void
+on_child_exited (GPid      pid,
+                 gint      status,
+                 gpointer  unused_data)
+{
+  ShellWindowTracker *tracker;
+
+  tracker = shell_window_tracker_get_default ();
+
+  g_hash_table_remove (tracker->launched_pid_to_app, GINT_TO_POINTER((gint)pid));
+}
+
+void
+_shell_window_tracker_add_child_process_app (ShellWindowTracker *tracker,
+                                             GPid                pid,
+                                             ShellApp           *app)
+{
+  gpointer pid_ptr = GINT_TO_POINTER((int)pid);
+
+  if (g_hash_table_lookup (tracker->launched_pid_to_app, pid_ptr))
+    return;
+
+  g_hash_table_insert (tracker->launched_pid_to_app,
+                       pid_ptr,
+                       g_object_ref (app));
+  g_child_watch_add (pid, on_child_exited, NULL);
+  /* TODO: rescan unassociated windows
+   * Unlikely in practice that the launched app gets ahead of us
+   * enough to map an X window before we get scheduled after the fork(),
+   * but adding this note for future reference.
+   */
 }
 
 static void

--- a/src/shell-window-tracker.c
+++ b/src/shell-window-tracker.c
@@ -865,6 +865,32 @@ shell_window_tracker_get_startup_sequences (ShellWindowTracker *self)
 }
 
 /**
+ * shell_window_tracker_is_window_interesting:
+ *
+ * The ShellWindowTracker associates certain kinds of windows with
+ * applications; however, others we don't want to
+ * appear in places where we want to give a list of windows
+ * for an application, such as the alt-tab dialog.
+ *
+ * An example of a window we don't want to show is the root
+ * desktop window.  We skip all override-redirect types, and also
+ * exclude other window types like tooltip explicitly, though generally
+ * most of these should be override-redirect.
+ * Side component windows are considered interesting so they can be handled
+ * by the window manager.
+ *
+ * Returns: %TRUE iff a window is "interesting"
+ */
+gboolean
+shell_window_tracker_is_window_interesting (MetaWindow *window)
+{
+  if (meta_window_is_skip_taskbar (window))
+    return FALSE;
+
+  return TRUE;
+}
+
+/**
  * shell_window_tracker_is_speedwagon_window:
  *
  * A speedwagon window is shown while an application is being launched.

--- a/src/shell-window-tracker.c
+++ b/src/shell-window-tracker.c
@@ -388,6 +388,10 @@ get_app_for_window (ShellWindowTracker    *tracker,
   MetaWindow *transient_for;
   const char *startup_id;
 
+  /* Side components don't have an associated app */
+  if (g_strcmp0 (meta_window_get_role (window), SIDE_COMPONENT_ROLE) == 0)
+    return NULL;
+
   /* We do want to associate the GNOME Builder window with
    * an open app of a coding session */
   if (g_strcmp0 (meta_window_get_flatpak_id (window), BUILDER_WINDOW) == 0 &&

--- a/src/shell-window-tracker.c
+++ b/src/shell-window-tracker.c
@@ -29,6 +29,7 @@
  * Copyright Red Hat, Inc. 2006-2008
  */
 
+#define SIDE_COMPONENT_ROLE "eos-side-component"
 #define SPEEDWAGON_ROLE "eos-speedwagon"
 
 #define BUILDER_WINDOW "org.gnome.Builder"
@@ -884,6 +885,9 @@ shell_window_tracker_get_startup_sequences (ShellWindowTracker *self)
 gboolean
 shell_window_tracker_is_window_interesting (MetaWindow *window)
 {
+  if (g_strcmp0 (meta_window_get_role (window), SIDE_COMPONENT_ROLE) == 0)
+    return TRUE;
+
   if (meta_window_is_skip_taskbar (window))
     return FALSE;
 

--- a/src/shell-window-tracker.h
+++ b/src/shell-window-tracker.h
@@ -25,6 +25,8 @@ const char *_shell_window_tracker_get_app_context (ShellWindowTracker *tracker, 
 
 GSList *shell_window_tracker_get_startup_sequences (ShellWindowTracker *tracker);
 
+gboolean shell_window_tracker_is_window_interesting (MetaWindow *window);
+
 gboolean shell_window_tracker_is_speedwagon_window (MetaWindow *window);
 
 void shell_window_tracker_track_coding_app_window (ShellWindowTracker *tracker, MetaWindow *app_window);


### PR DESCRIPTION
The actual fix for this issue is 8b7a25f7 ("ShellApp: Consider speedwagon windows as 'not interesting' for a given app"), but this PR also proposes a few related commits more that fix issues related to app activation (unveiled after fixing this problem) along with backporting a few (also related) patches that got lost during the rebase process.

https://phabricator.endlessm.com/T17937