### PR TITLE
Remove GSettings schema override from debian package

### DIFF
--- a/debian/gnome-shell.gsettings-override
+++ b/debian/gnome-shell.gsettings-override
@@ -1,2 +1,0 @@
-[org.gnome.shell]
-favorite-apps=[ 'firefox-esr.desktop', 'evolution.desktop', 'rhythmbox.desktop', 'libreoffice-writer.desktop', 'org.gnome.Nautilus.desktop', 'org.gnome.Software.desktop', 'yelp.desktop' ]


### PR DESCRIPTION
We now specify this from the master branch (see commit 6f5e31dd) so
we don't need to do this again via an override. Also, it's not only
that's not needed but also that keeping this in place is harmful,
since it would break set ups like the live installer where we patch
the defaults via other means, as this override file will then be
applied, rendering those other customizations useless.

https://phabricator.endlessm.com/T17622