### PR TITLE
remoteSearch: ignore DefaultDisabled for Endless apps

### DIFF
--- a/js/ui/remoteSearch.js
+++ b/js/ui/remoteSearch.js
@@ -90,8 +90,9 @@ function loadRemoteSearchProviders(searchSettings, callback) {
                 return;
 
             let appInfo = null;
+            let desktopId = null;
             try {
-                let desktopId = keyfile.get_string(group, 'DesktopId');
+                desktopId = keyfile.get_string(group, 'DesktopId');
                 appInfo = Gio.DesktopAppInfo.new(desktopId);
             } catch (e) {
                 log('Ignoring search provider ' + path + ': missing DesktopId');
@@ -111,11 +112,15 @@ function loadRemoteSearchProviders(searchSettings, callback) {
                 remoteProvider = new RemoteSearchProvider(appInfo, busName, objectPath);
 
             remoteProvider.defaultEnabled = true;
-            try {
-                remoteProvider.defaultEnabled = !keyfile.get_boolean(group, 'DefaultDisabled');
-            } catch(e) {
-                // ignore error
-            }
+
+            // Work around problem with all Endless flatpak apps accidentally
+            // built with "DefaultDisabled=true"
+            if (!desktopId.startsWith('com.endlessm'))
+                try {
+                    remoteProvider.defaultEnabled = !keyfile.get_boolean(group, 'DefaultDisabled')
+                } catch(e) {
+                    // ignore error
+                }
 
             objectPaths[objectPath] = remoteProvider;
             loadedProviders.push(remoteProvider);


### PR DESCRIPTION
Due to a bug in the flatpak builds, we have been accidentally
appending the search-provider.ini files with "DefaultDisabled=true".
This causes the default behavior for Endless apps to have
search disabled unless explicitly enabled in a gsetting.
Since global search of Endless apps is an important feature
of our OS, we include a hack here to pretend that Endless apps
(app ID starting with "com.endlessm.") do not set this flag.

While the proper fix is to fix the flatpak builder,
rebundle all Endless flatpaks, and update all Endless flatpaks
installed on user machines, that is a huge endeavor and not
something we can quickly patch, so we should live with this
hack for a while until we have fixed our latest flatpaks
and given users plenty of time to have updated all their apps.

We did not catch this bug in eos3.1 due to older shell code
in eos-desktop that did not check for this value.

https://phabricator.endlessm.com/T18082