### PR TITLE
Fix Jenkins build: use RPATH instead of RUNPATH for ELF binaries

### DIFF
--- a/docs/reference/shell/Makefile.am
+++ b/docs/reference/shell/Makefile.am
@@ -113,7 +113,7 @@ expand_content_files=
 # e.g. GTKDOC_CFLAGS=-I$(top_srcdir) -I$(top_builddir) $(GTK_DEBUG_FLAGS)
 # e.g. GTKDOC_LIBS=$(top_builddir)/gtk/$(gtktargetlib)
 GTKDOC_CFLAGS=$(GNOME_SHELL_CFLAGS)
-GTKDOC_LIBS=$(GNOME_SHELL_LIBS) $(top_builddir)/src/libgnome-shell-menu.la $(top_builddir)/src/libgnome-shell-base.la $(top_builddir)/src/libgnome-shell.la $(top_builddir)/src/libeos-shell-fx.la -rpath $(MUTTER_TYPELIB_DIR)
+GTKDOC_LIBS=$(GNOME_SHELL_LIBS) $(top_builddir)/src/libgnome-shell-menu.la $(top_builddir)/src/libgnome-shell-base.la $(top_builddir)/src/libgnome-shell.la $(top_builddir)/src/libeos-shell-fx.la -R $(MUTTER_TYPELIB_DIR)
 
 # This includes the standard gtk-doc make rules, copied by gtkdocize.
 include $(top_srcdir)/gtk-doc.make

--- a/docs/reference/st/Makefile.am
+++ b/docs/reference/st/Makefile.am
@@ -78,7 +78,7 @@ expand_content_files=
 # e.g. GTKDOC_CFLAGS=-I$(top_srcdir) -I$(top_builddir) $(GTK_DEBUG_FLAGS)
 # e.g. GTKDOC_LIBS=$(top_builddir)/gtk/$(gtktargetlib)
 GTKDOC_CFLAGS=
-GTKDOC_LIBS=$(top_builddir)/src/libst-1.0.la -rpath $(MUTTER_TYPELIB_DIR)
+GTKDOC_LIBS=$(top_builddir)/src/libst-1.0.la -R $(MUTTER_TYPELIB_DIR)
 
 # This includes the standard gtk-doc make rules, copied by gtkdocize.
 include $(top_srcdir)/gtk-doc.make

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -249,6 +249,7 @@ libeos_shell_fx_la_LIBADD =	\
 
 libeos_shell_fx_la_LDFLAGS =	\
 	-avoid-version		\
+	-R $(MUTTER_TYPELIB_DIR) \
 	$(NULL)
 
 libeos_shell_fx_la_CPPFLAGS =	\

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -205,7 +205,7 @@ gnome_shell_CPPFLAGS = \
 # Here, and after, we repeat mutter and bluetooth libraries just for the rpath
 # The dependency is already pulled in by libtool
 gnome_shell_LDADD = libgnome-shell.la $(GNOME_SHELL_LIBS) $(MUTTER_LIBS)
-gnome_shell_LDFLAGS = -rpath $(MUTTER_TYPELIB_DIR)
+gnome_shell_LDFLAGS = -R $(MUTTER_TYPELIB_DIR)
 gnome_shell_DEPENDENCIES = libgnome-shell.la
 
 gnome_shell_extension_prefs_SOURCES = \
@@ -217,7 +217,7 @@ nodist_gnome_shell_extension_prefs_SOURCES = \
 	$(NULL)
 gnome_shell_extension_prefs_CPPFLAGS = $(gnome_shell_cflags)
 gnome_shell_extension_prefs_LDADD = $(GNOME_SHELL_LIBS)
-gnome_shell_extension_prefs_LDFLAGS = -rpath $(MUTTER_TYPELIB_DIR)
+gnome_shell_extension_prefs_LDFLAGS = -R $(MUTTER_TYPELIB_DIR)
 
 if HAVE_NETWORKMANAGER
 
@@ -231,7 +231,7 @@ nodist_gnome_shell_portal_helper_SOURCES = \
 	$(NULL)
 gnome_shell_portal_helper_CPPFLAGS = $(gnome_shell_cflags)
 gnome_shell_portal_helper_LDADD = $(GNOME_SHELL_LIBS)
-gnome_shell_portal_helper_LDFLAGS = -rpath $(MUTTER_TYPELIB_DIR)
+gnome_shell_portal_helper_LDFLAGS = -R $(MUTTER_TYPELIB_DIR)
 
 endif
 
@@ -290,7 +290,7 @@ noinst_PROGRAMS += run-js-test
 
 run_js_test_CPPFLAGS = $(MUTTER_CFLAGS) $(gnome_shell_cflags)
 run_js_test_LDADD = libgnome-shell.la $(GNOME_SHELL_JS_LIBS) $(MUTTER_LIBS)
-run_js_test_LDFLAGS = -export-dynamic -rpath $(MUTTER_TYPELIB_DIR)
+run_js_test_LDFLAGS = -export-dynamic -R $(MUTTER_TYPELIB_DIR)
 
 run_js_test_SOURCES =			\
 	run-js-test.c
@@ -319,7 +319,11 @@ shell-enum-types.c: $(srcdir)/shell-enum-types.c.in stamp-shell-enum-types.h
 	rm -f $(@F).tmp
 EXTRA_DIST += shell-enum-types.c.in
 
-libgnome_shell_ldflags = -avoid-version
+libgnome_shell_ldflags = \
+	-avoid-version \
+	-R $(MUTTER_TYPELIB_DIR) \
+	$(NULL)
+
 libgnome_shell_libadd =		\
 	-lm			\
 	$(GNOME_SHELL_LIBS)	\


### PR DESCRIPTION
This is a workaround for a change in behaviour in binutils, which we're basically bringing from the debian/rules file right into the autotools sources, with the hope of getting it merged upstream too.

https://phabricator.endlessm.com/T18131