### PR TITLE
appDisplay: Don't get the grid to the first page on hide

### DIFF
--- a/js/ui/appDisplay.js
+++ b/js/ui/appDisplay.js
@@ -540,10 +540,6 @@ const AllView = new Lang.Class({
         Main.overview.connect('item-drag-begin', Lang.bind(this, this._onDragBegin));
         Main.overview.connect('item-drag-end', Lang.bind(this, this._onDragEnd));
 
-        Main.overview.connect('hidden', Lang.bind(this,
-            function() {
-                this.goToPage(0);
-            }));
         this._grid.connect('space-opened', Lang.bind(this,
             function() {
                 let fadeEffect = this._scrollView.get_effect('fade');


### PR DESCRIPTION
It's very confusing when the user switches between the windows view and
the grid and the latter always moves to the first page, no matter which
had it was on before.

This is being deliberately done in the code from upstream because in the
case of the upstream shell the user toggles the apps view more directly
than in EOS, and thus it makes sense to reset the view to show the first
page there. So this patch just removes the mentioned code.

https://phabricator.endlessm.com/T17979