### PR TITLE
search: Activate the app context before the result

### DIFF
--- a/js/ui/remoteSearch.js
+++ b/js/ui/remoteSearch.js
@@ -7,6 +7,7 @@ const Lang = imports.lang;
 const St = imports.gi.St;
 const Shell = imports.gi.Shell;
 
+const AppActivation = imports.ui.appActivation;
 const FileUtils = imports.misc.fileUtils;
 const Search = imports.ui.search;
 
@@ -290,6 +291,8 @@ const RemoteSearchProvider = new Lang.Class({
     },
 
     activateResult: function(id) {
+        // Activate the app so the splash is shown if needed
+        this.activateAppContext();
         this.proxy.ActivateResultRemote(id);
     },
 
@@ -297,7 +300,13 @@ const RemoteSearchProvider = new Lang.Class({
         // the provider is not compatible with the new version of the interface, launch
         // the app itself but warn so we can catch the error in logs
         log('Search provider ' + this.appInfo.get_id() + ' does not implement LaunchSearch');
-        this.appInfo.launch([], global.create_app_launch_context(0, -1));
+        this.activateAppContext();
+    },
+
+    activateAppContext: function() {
+        let app = Shell.AppSystem.get_default().lookup_app(this.appInfo.get_id());
+        let context = new AppActivation.AppActivationContext(app);
+        context.activate();
     }
 });
 
@@ -312,10 +321,14 @@ const RemoteSearchProvider2 = new Lang.Class({
     },
 
     activateResult: function(id, terms) {
+        // Activate the app so the splash is shown if needed
+        this.activateAppContext();
         this.proxy.ActivateResultRemote(id, terms, global.get_current_time());
     },
 
     launchSearch: function(terms) {
+        // Activate the app so the splash is shown if needed
+        this.activateAppContext();
         this.proxy.LaunchSearchRemote(terms, global.get_current_time());
     }
 });


### PR DESCRIPTION
The reason for this is that showing the search results in an app can
take some time, and thus its speedwagon should be shown if needed (which
accomplished by activating the app context).

https://phabricator.endlessm.com/T3968