### PR TITLE
build: Set mutter rpath on libraries

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -249,6 +249,7 @@ libeos_shell_fx_la_LIBADD =	\
 
 libeos_shell_fx_la_LDFLAGS =	\
 	-avoid-version		\
+	-R $(MUTTER_TYPELIB_DIR) \
 	$(NULL)
 
 libeos_shell_fx_la_CPPFLAGS =	\
@@ -319,7 +320,7 @@ shell-enum-types.c: $(srcdir)/shell-enum-types.c.in stamp-shell-enum-types.h
 	rm -f $(@F).tmp
 EXTRA_DIST += shell-enum-types.c.in
 
-libgnome_shell_ldflags = -avoid-version
+libgnome_shell_ldflags = -avoid-version -R $(MUTTER_TYPELIB_DIR)
 libgnome_shell_libadd =		\
 	-lm			\
 	$(GNOME_SHELL_LIBS)	\


### PR DESCRIPTION
When the GIR files are being generated, the path to the private mutter
libraries (e.g., libmutter-clutter.so) is provided to g-ir-scanner.
g-ir-scanner uses this to pass a -rpath to libtool so that the dumper it
builds and runs can also find the private mutter libraries during
introspection.

Unfortunately, this breaks when binutils is configured to set the rpath
using the DT_RUNPATH tag rather than the DT_RPATH tag
(--enable-new-dtags from the build or command line). Unlike DT_RPATH,
which works recursively from an executable, DT_RUNPATH only affects the
search path for the immediate object. So, when a shared library has a
dependency on another shared library, it must contain the DT_RUNPATH to
that library if it's not in a standard path.

In this case, the gnome-shell libraries (e.g., libgnome-shell-menu.so)
are the ones that depend on the mutter libraries and need to contain the
DT_RUNPATH tag. Add the libtool -R flag when linking the libraries to do
that. This can be used to add additional rpaths to the libraries and
allows the g-ir-scanner dumper program to be linked.

A more robust fix would probably be to have the mutter private library
pkg-config files contain the -R arguments since mutter knows they're
being installed outside of standard paths.

https://phabricator.endlessm.com/T18131