### PR TITLE
remoteSearch: sort providers for apps on the desktop before

### DIFF
--- a/js/ui/remoteSearch.js
+++ b/js/ui/remoteSearch.js
@@ -9,9 +9,11 @@ const Shell = imports.gi.Shell;
 
 const AppActivation = imports.ui.appActivation;
 const FileUtils = imports.misc.fileUtils;
+const IconGridLayout = imports.ui.iconGridLayout;
 const Search = imports.ui.search;
 
 const KEY_FILE_GROUP = 'Shell Search Provider';
+const CONTROL_CENTER_DESKTOP_ID = 'gnome-control-center.desktop';
 
 const SearchProviderIface = '<node> \
 <interface name="org.gnome.Shell.SearchProvider"> \
@@ -159,8 +161,24 @@ function loadRemoteSearchProviders(searchSettings, callback) {
         idxA = sortOrder.indexOf(appIdA);
         idxB = sortOrder.indexOf(appIdB);
 
-        // if no provider is found in the order, use alphabetical order
+        // none of the providers are in the list; check if they're on the desktop
         if ((idxA == -1) && (idxB == -1)) {
+            // We special case gnome-control-center, since we don't have it on
+            // the desktop but still want to see the results it provides
+            let hasA = (IconGridLayout.layout.hasIcon(appIdA) ||
+                        appIdA == CONTROL_CENTER_DESKTOP_ID);
+            let hasB = (IconGridLayout.layout.hasIcon(appIdB) ||
+                        appIdB == CONTROL_CENTER_DESKTOP_ID);
+
+            // if providerA is on the desktop, it's sorted before providerB
+            if (hasA)
+                return -1;
+
+            // if providerB is on the desktop, it's sorted before providerA
+            if (hasB)
+                return 1;
+
+            // fall back to alphabetical order
             let nameA = providerA.appInfo.get_name();
             let nameB = providerB.appInfo.get_name();
 


### PR DESCRIPTION
This should be squashed with f5dc86c3 in future rebases.

https://phabricator.endlessm.com/T4008