### PR TITLE
Revert "debian/rules: Remove work around for binutils behaviour change"

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -5,6 +5,8 @@ include /usr/share/gnome-pkg-tools/1/rules/gnome-get-source.mk
 # Ensure at build time that the library has no dependencies on undefined
 # symbols, and speed up loading.
 export DEB_LDFLAGS_MAINT_APPEND = -Wl,-z,defs -Wl,-O1 -Wl,--as-needed
+# Work around binutils behaviour change https://bugs.debian.org/847298
+DEB_LDFLAGS_MAINT_APPEND += -Wl,--disable-new-dtags
 
 %:
 	dh $@ --with gir,gnome


### PR DESCRIPTION
Apparently, even though the changes made in the master branch allowed us
to build the shell using the new behaviour in the build time linker (that
now uses DT_RUNPATH instead of DT_RPATH), that is not a complete solution
since the shell will fail to find the shared objects wrapped by private
introspected libraries (e.g. ShellMenu-0.1.gir), as they live in the non
standard & private /usr/lib/gnome-shell directory.

So, this is sad an ugly but, as I was not able to figure out yet a way
to have the GIR scanner & compiler generating the bindings in a way that
they will find those private shared objects at runtime, I'm proposing to
revert here to Debian's current strategy of using the old dtags when
linking (that is, using DT_RPATH again), that will make our shell run
again as this way the runtime paths set in the gnome-shell binary will
be transitively honoured on runtime also when using introspected libraries.

Note that we still need the fixes in 62d5d5d1 and e3c1c00a in the master
branch for GNOME Shell to build in Jenkins just for the purpose of being
able to generate the Debian sources and upload them to OBS, which will
then be built with -Wl,--disable-new-tags as specified in debian/rules.

This reverts commit aaf8453b03193a981e2e30de6a2dc22e06661591.

https://phabricator.endlessm.com/T18325