### PR TITLE
main: Add $(pkglibdir) to GIR's list of search path for scanned libraries

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -201,6 +201,13 @@ shell_introspection_init (void)
 
   g_irepository_prepend_search_path (MUTTER_TYPELIB_DIR);
   g_irepository_prepend_search_path (GNOME_SHELL_PKGLIBDIR);
+
+  /* We need to explicitly add the directory where the private libraries are
+   * copied to to the GIR's library path, so that they can be found at runtime
+   * when linking using DT_RUNPATH (instead of DT_RPATH), which is the default
+   * for some linkers (e.g. gold) and in some distros (e.g. Debian).
+   */
+  g_irepository_prepend_library_path (GNOME_SHELL_PKGLIBDIR);
 }
 
 static void


### PR DESCRIPTION
This is not strictly necessary when linking the shell with DT_RPATH as
the runtime path will be extracted from the introspected libraries and
used from gobject introspection to find them when loading them based on
the typelib files, but when linking with DT_RUNPATH, as it's the case
for some linkers (e.g. ld.gold, or ld.bfd in some distros like Debian).

By explicitly prepending this directory as a library path for GIR, we're
making sure that the wrapped shared objects can be found in all cases.

https://phabricator.endlessm.com/T18325