### PR TITLE
Revert "Revert "debian/rules: Remove work around for binutils behaviour change

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -5,8 +5,6 @@ include /usr/share/gnome-pkg-tools/1/rules/gnome-get-source.mk
 # Ensure at build time that the library has no dependencies on undefined
 # symbols, and speed up loading.
 export DEB_LDFLAGS_MAINT_APPEND = -Wl,-z,defs -Wl,-O1 -Wl,--as-needed
-# Work around binutils behaviour change https://bugs.debian.org/847298
-DEB_LDFLAGS_MAINT_APPEND += -Wl,--disable-new-dtags
 
 %:
 	dh $@ --with gir,gnome


### PR DESCRIPTION
Turns out that we finally figured out (thanks @dbnicholson and @ptomato for your
help!) what the missing piece of the puzzle was in commit ec0f63ff, so there's
no need to build with --disable-new-dtags (now for real) now that we have patched
the master branch so that the shell builds AND runs just fine with DT_RUNPATH.

Sorry for the back and forth, but I think it's good to remove this workaround
from the code if possible, to remove papering over the actual problem.

This reverts commit 7fae4585 and should be squashed into it in future rebases.

https://phabricator.endlessm.com/T18325