### PR TITLE
main: Also add Mutter's private libdir to GIR's list of search paths

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -202,11 +202,12 @@ shell_introspection_init (void)
   g_irepository_prepend_search_path (MUTTER_TYPELIB_DIR);
   g_irepository_prepend_search_path (GNOME_SHELL_PKGLIBDIR);
 
-  /* We need to explicitly add the directory where the private libraries are
-   * copied to to the GIR's library path, so that they can be found at runtime
+  /* We need to explicitly add the directories where the private libraries are
+   * installed to the GIR's library path, so that they can be found at runtime
    * when linking using DT_RUNPATH (instead of DT_RPATH), which is the default
    * for some linkers (e.g. gold) and in some distros (e.g. Debian).
    */
+  g_irepository_prepend_library_path (MUTTER_TYPELIB_DIR);
   g_irepository_prepend_library_path (GNOME_SHELL_PKGLIBDIR);
 }
 


### PR DESCRIPTION
As it is setup now, the shell will work fine without this addition since
the shell will reach Mutter's private libraries through the usual loading
mechanisms, but adding it should make things more robust against potential
future changes, besides making it consistent with the similar calls to
g_irepository_prepend_search_path() right before these lines.

https://phabricator.endlessm.com/T18325