### PR TITLE
boxPointer: Fix arrow's position the second time a folder is opened

### DIFF
--- a/js/ui/boxpointer.js
+++ b/js/ui/boxpointer.js
@@ -234,6 +234,10 @@ const BoxPointer = new Lang.Class({
             this._reposition();
             this._updateFlip();
         }
+
+        // Since the allocation changed, we need to redraw the arrow, otherwise
+        // it can be left in the wrong place
+        this._border.queue_repaint();
     },
 
     _drawBorder: function(area) {


### PR DESCRIPTION
The second time a folder is opened, the arrow of the folder popup will
be shown in the wrong position (as if pushed to the left). This is due
to its transformed position, which is affected depending on the
allocation of the boxPointer's container.

This patch simply queues a repaint when the allocation is changed which
fixes the issue.

https://phabricator.endlessm.com/T17838