### PR TITLE
windowManager: Ensure SideComponent's actor gets properly destroyed

### DIFF
--- a/js/ui/windowManager.js
+++ b/js/ui/windowManager.js
@@ -2084,6 +2084,7 @@ const WindowManager = new Lang.Class({
         }
 
         if (SideComponent.isSideComponentWindow(actor.meta_window)) {
+            this._destroying.push(actor);
             this._slideSideComponentOut(shellwm, actor,
                                         this._destroyWindowDone,
                                         this._destroyWindowDone);


### PR DESCRIPTION
A call to add the SideComponent's actor to the list of actors being
destroyed was lost with the rebase due to the having the base code
refactored, which was causing the side component's actor to never
be completely destroyed.

This was often not visible because we only use left or top side
components now, but the problem could still be seen in setups with
multiple monitors where the main monitor is not in the leftmost
position, as the side component's actor would be left forever in
the leftmost screen after closing it.

https://phabricator.endlessm.com/T18137