### PR TITLE
endlessButton: fix hover label location for dual display

### DIFF
--- a/js/ui/endlessButton.js
+++ b/js/ui/endlessButton.js
@@ -102,7 +102,7 @@ const EndlessButton = new Lang.Class({
             // Update the tooltip position
             let monitor = Main.layoutManager.findMonitorForActor(this._label);
             let iconMidpoint = this.actor.get_transformed_position()[0] + this.actor.width / 2;
-            this._label.translation_x = Math.floor(iconMidpoint - this._label.width / 2) + monitor.x + this._labelOffsetX;
+            this._label.translation_x = Math.floor(iconMidpoint - this._label.width / 2) + this._labelOffsetX;
             this._label.translation_y = Math.floor(this.actor.get_transformed_position()[1] - this._labelOffsetY);
 
             // Clip left edge to be the left edge of the screen


### PR DESCRIPTION
We were adding the monitor's x position in the wrong place,
which mis-placed the label when the primary monitor is on the right.

https://phabricator.endlessm.com/T18565