### PR TITLE
iconGridLayout: Add ReplaceAppIfPossible method to ShellAppStore

### DIFF
--- a/js/ui/iconGridLayout.js
+++ b/js/ui/iconGridLayout.js
@@ -33,6 +33,14 @@ const APPEND_CONFIG_NAME_BASE = 'icon-grid-append';
  */
 const SHELL_APP_REMOVED_EVENT = '683b40a7-cac0-4f9a-994c-4b274693a0a0';
 
+function findInArray(array, func) {
+    for (let i = 0; i < array.length; ++i)
+        if (func(array[i]))
+            return array[i];
+
+    return null;
+}
+
 const IconGridLayout = new Lang.Class({
     Name: 'IconGridLayout',
 
@@ -214,6 +222,23 @@ const IconGridLayout = new Lang.Class({
 
     appendIcon: function(id, folderId) {
         this.repositionIcon(id, null, folderId);
+    },
+
+    // Two operations, first insert the new icon
+    // to the left of the old one, then remove
+    // the old one
+    //
+    // defaultFolderId here refers to the folder id
+    // to insert the icon into if the icon is not already
+    // in a folder. Otherwise, we use the folder that
+    // the icon is in already.
+    replaceIcon: function(originalId, replacementId, defaultFolderId) {
+        let folderId = findInArray(Object.keys(this._iconTree), Lang.bind(this, function(key) {
+            return this._iconTree[key].indexOf(originalId) !== -1;
+        })) || defaultFolderId;
+
+        this.repositionIcon(replacementId, originalId, folderId);
+        this.removeIcon(originalId, false);
     },
 
     removeIcon: function(id, interactive) {

--- a/js/ui/shellDBus.js
+++ b/js/ui/shellDBus.js
@@ -490,6 +490,10 @@ const AppStoreIface = '<node> \
 <method name="AddAppIfNotVisible"> \
     <arg type="s" direction="in" name="id" /> \
 </method> \
+<method name="ReplaceApplication"> \
+    <arg type="s" direction="in" name="originalId" /> \
+    <arg type="s" direction="in" name="replacementId" /> \
+</method> \
 <method name="RemoveApplication"> \
     <arg type="s" direction="in" name="id" /> \
 </method> \
@@ -540,6 +544,21 @@ const AppStoreService = new Lang.Class({
         let visibleIcons = IconGridLayout.layout.getIcons(IconGridLayout.DESKTOP_GRID_ID);
         if (visibleIcons.indexOf(id) == -1)
             IconGridLayout.layout.appendIcon(id, IconGridLayout.DESKTOP_GRID_ID);
+    },
+
+    ReplaceApplication: function(originalId, replacementId) {
+        let eventRecorder = EosMetrics.EventRecorder.get_default();
+        let appId = new GLib.Variant('s', replacementId);
+        eventRecorder.record_event(SHELL_APP_ADDED_EVENT, appId);
+
+        // Can't replace a folder
+        if (IconGridLayout.layout.iconIsFolder(originalId))
+            return;
+
+        // We can just replace the app icon directly now,
+        // since the replace operation degenerates to
+        // append if the source icon was not available
+        IconGridLayout.layout.replaceIcon(originalId, replacementId, IconGridLayout.DESKTOP_GRID_ID);
     },
 
     RemoveApplication: function(id) {


### PR DESCRIPTION
This removes the old icon and inserts the new one in its place. We'll
use this from the app store in order to replace the "Get X" launchers
with the actual application once installed.

https://phabricator.endlessm.com/T18657