### PR TITLE
viewSelector: Scroll the grid's clone to match the original one's pos…

### DIFF
--- a/js/ui/appDisplay.js
+++ b/js/ui/appDisplay.js
@@ -1342,6 +1342,10 @@ const AppDisplay = new Lang.Class({
         return this._allView.adaptToSize(width, height);
     },
 
+    get gridContainer() {
+        return this._allView.actor;
+    },
+
     get gridActor() {
         return this._allView.gridActor;
     }

--- a/js/ui/viewSelector.js
+++ b/js/ui/viewSelector.js
@@ -515,6 +515,12 @@ const ViewsClone = new Lang.Class({
                       reactive: false,
                       opacity: AppDisplay.EOS_ACTIVE_GRID_OPACITY });
 
+        // Ensure the cloned grid is scrolled to the same page as the original one
+        let originalGridContainer = appDisplay.gridContainer;
+        let originalAdjustment = originalGridContainer.scrollView.vscroll.adjustment;
+        let cloneAdjustment = appGridContainer.scrollView.vscroll.adjustment;
+        originalAdjustment.bind_property('value', cloneAdjustment, 'value', GObject.BindingFlags.SYNC_CREATE);
+
         this._saturation = new Clutter.DesaturateEffect({ factor: AppDisplay.EOS_INACTIVE_GRID_SATURATION,
                                                           enabled: false });
         iconGridClone.add_effect(this._saturation);


### PR DESCRIPTION
…ition

Otherwise the clone will always display the first page of the grid which
is noticeable when apps are not maximized.
This patch fixes that by binding the original grid's scroll adjustment's
value with the clone's one.

https://phabricator.endlessm.com/T17979