### PR TITLE
Consider scale factor when creating the folders' subicons

### DIFF
--- a/js/ui/appDisplay.js
+++ b/js/ui/appDisplay.js
@@ -1485,7 +1485,7 @@ const FolderView = new Lang.Class({
             let bin;
             if (i < numItems) {
                 let texture = this._allItems[i].app.create_icon_texture(subSize);
-                bin = new St.Bin({ child: texture });
+                bin = new St.Bin({ child: texture, width: subSize, height: subSize });
             } else {
                 bin = new St.Bin({ width: subSize, height: subSize });
             }


### PR DESCRIPTION
Otherwise the smaller icons that are shown inside a folder's icon will
be too big and overflow out of its boundaries.

https://phabricator.endlessm.com/T18351