### PR TITLE
Adapt to the new filenames and versions of mutter and its private libraries

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -53,7 +53,7 @@ if $PKG_CONFIG --exists gstreamer-1.0 '>=' $GSTREAMER_MIN_VERSION ; then
    AC_MSG_RESULT(yes)
    build_recorder=true
    recorder_modules="gstreamer-1.0 gstreamer-base-1.0 x11 gtk+-3.0"
-   PKG_CHECK_MODULES(TEST_SHELL_RECORDER, $recorder_modules mutter-clutter-1.0)
+   PKG_CHECK_MODULES(TEST_SHELL_RECORDER, $recorder_modules mutter-clutter-0)
 else
    AC_MSG_RESULT(no)
 fi
@@ -98,8 +98,8 @@ SHARED_PCS="gio-unix-2.0 >= $GIO_MIN_VERSION
             gjs-1.0 >= $GJS_MIN_VERSION
             $recorder_modules
             gdk-x11-3.0 libsoup-2.4
-            mutter-clutter-1.0 >= $CLUTTER_MIN_VERSION
-            mutter-cogl-pango-1.0
+            mutter-clutter-0 >= $CLUTTER_MIN_VERSION
+            mutter-cogl-pango-0
             libstartup-notification-1.0 >= $STARTUP_NOTIFICATION_MIN_VERSION
             gobject-introspection-1.0 >= $GOBJECT_INTROSPECTION_MIN_VERSION
             libcanberra libcanberra-gtk3
@@ -111,14 +111,14 @@ if test x$have_systemd = xyes; then
 fi
 
 PKG_CHECK_MODULES(GNOME_SHELL, $SHARED_PCS)
-PKG_CHECK_MODULES(MUTTER, libmutter >= $MUTTER_MIN_VERSION)
+PKG_CHECK_MODULES(MUTTER, libmutter-0 >= $MUTTER_MIN_VERSION)
 
 PKG_CHECK_MODULES(GNOME_SHELL_JS, gio-2.0 gjs-1.0 >= $GJS_MIN_VERSION)
-PKG_CHECK_MODULES(ST, mutter-clutter-1.0 gtk+-3.0 libcroco-0.6 >= 0.6.8 x11)
-PKG_CHECK_MODULES(EOS_SHELL_FX, mutter-clutter-1.0 >= 1.16 glib-2.0 >= 2.38 gdk-pixbuf-2.0 libwindowfx_wobbly)
+PKG_CHECK_MODULES(ST, mutter-clutter-0 gtk+-3.0 libcroco-0.6 >= 0.6.8 x11)
+PKG_CHECK_MODULES(EOS_SHELL_FX, mutter-clutter-0 >= 1.16 glib-2.0 >= 2.38 gdk-pixbuf-2.0 libwindowfx_wobbly)
 PKG_CHECK_MODULES(SHELL_PERF_HELPER, gtk+-3.0 gio-2.0)
 PKG_CHECK_MODULES(SHELL_HOTPLUG_SNIFFER, gio-2.0 gdk-pixbuf-2.0)
-PKG_CHECK_MODULES(TRAY, mutter-clutter-1.0 gtk+-3.0)
+PKG_CHECK_MODULES(TRAY, mutter-clutter-0 gtk+-3.0)
 PKG_CHECK_MODULES(GVC, libpulse >= $PULSE_MIN_VERS libpulse-mainloop-glib gobject-2.0)
 PKG_CHECK_MODULES(DESKTOP_SCHEMAS, gsettings-desktop-schemas >= 3.21.3)
 
@@ -146,10 +146,10 @@ AC_SUBST([GNOME_KEYBINDINGS_KEYSDIR])
 
 GOBJECT_INTROSPECTION_CHECK([$GOBJECT_INTROSPECTION_MIN_VERSION])
 
-MUTTER_GIR_DIR=`$PKG_CONFIG --variable=girdir libmutter`
+MUTTER_GIR_DIR=`$PKG_CONFIG --variable=girdir libmutter-0`
 AC_SUBST(MUTTER_GIR_DIR)
 
-MUTTER_TYPELIB_DIR=`$PKG_CONFIG --variable=typelibdir libmutter`
+MUTTER_TYPELIB_DIR=`$PKG_CONFIG --variable=typelibdir libmutter-0`
 AC_SUBST(MUTTER_TYPELIB_DIR)
 
 GJS_CONSOLE=`$PKG_CONFIG --variable=gjs_console gjs-1.0`

--- a/js/ui/environment.js
+++ b/js/ui/environment.js
@@ -1,6 +1,6 @@
 // -*- mode: js; js-indent-level: 4; indent-tabs-mode: nil -*-
 
-imports.gi.versions.Clutter = '1.0';
+imports.gi.versions.Clutter = '0';
 imports.gi.versions.Gio = '2.0';
 imports.gi.versions.Gdk = '3.0';
 imports.gi.versions.GdkPixbuf = '2.0';

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -365,7 +365,7 @@ INTROSPECTION_GIRS += ShellMenu-0.1.gir
 CLEANFILES += ShellMenu-0.1.gir
 
 Shell-0.1.gir: gnome-shell St-1.0.gir ShellMenu-0.1.gir
-Shell_0_1_gir_INCLUDES = Clutter-1.0 ClutterX11-1.0 Meta-3.0 Soup-2.4
+Shell_0_1_gir_INCLUDES = Clutter-0 ClutterX11-0 Meta-0 Soup-2.4
 if HAVE_NETWORKMANAGER
 Shell_0_1_gir_INCLUDES += NetworkManager-1.0 NMClient-1.0
 endif
@@ -380,7 +380,7 @@ INTROSPECTION_GIRS += Shell-0.1.gir
 CLEANFILES += Shell-0.1.gir
 
 St-1.0.gir: libst-1.0.la
-St_1_0_gir_INCLUDES = Clutter-1.0 Gtk-3.0
+St_1_0_gir_INCLUDES = Clutter-0 Gtk-3.0
 St_1_0_gir_CFLAGS = $(st_cflags) -DST_COMPILATION
 St_1_0_gir_LIBS = libst-1.0.la
 St_1_0_gir_FILES = $(filter-out %-private.h $(st_non_gir_sources), $(addprefix $(srcdir)/,$(st_source_h))) \
@@ -389,7 +389,7 @@ INTROSPECTION_GIRS += St-1.0.gir
 CLEANFILES += St-1.0.gir
 
 EndlessShellFX-1.0.gir: libeos-shell-fx.la
-EndlessShellFX_1_0_gir_INCLUDES = Clutter-1.0
+EndlessShellFX_1_0_gir_INCLUDES = Clutter-0
 EndlessShellFX_1_0_gir_CFLAGS = $(EOS_SHELL_FX_CFLAGS) -I $(srcdir)
 EndlessShellFX_1_0_gir_LIBS = libeos-shell-fx.la
 EndlessShellFX_1_0_gir_FILES = $(libeos_shell_fx_la_SOURCES)


### PR DESCRIPTION
In mutter's commit 4ebc55f2 libmutter.so and the mutter-*.so libraries
were made parallel installable [1] which, among other things, impacted
the filenames of the shared objects and .pc files that get installed.

GNOME Shell 3.24 is already adapted to this situation (see [2]), so
we need this small fix here to keep our fork of GNOME Shell 3.22
building and running find with the newer version of mutter.

[1] https://git.gnome.org/browse/mutter/commit/?id=4ebc55f2
[2] https://git.gnome.org/browse/gnome-shell/commit/?id=a46ea3f8

https://phabricator.endlessm.com/T18787