### PR TITLE
windowManager: Make sure to update overlay geometry on sideComponent changes

### DIFF
--- a/js/ui/sideComponent.js
+++ b/js/ui/sideComponent.js
@@ -37,8 +37,8 @@ function shouldHideOtherWindows (metaWindow) {
  */
 function launchedFromDesktop (metaWindow) {
     return isSideComponentWindow(metaWindow) &&
-        metaWindow.get_wm_class() == 'Eos-app-store' &&
-        Main.appStore.launchedFromDesktop;
+        ((metaWindow.get_wm_class == 'Eos-app-store' && Main.appStore.launchedFromDesktop) ||
+         (isDiscoveryFeedWindow(metaWindow) && Main.discoveryFeed.launchedFromDesktop));
 };
 
 /**


### PR DESCRIPTION
We assumed that all side components would have a y-coordinate that
was visible on screen and positioned the overlay relative to
that y-coordinate. That didn't work in the case of the discovery
feed because it starts off-screen and the overlay window's position
never got updated. We should update the geometry of the overlay
at the same time as rebuilding the overlay capture region.

Also, we were only making the overlay as large as the distance
between the left hand side of the monitor and the left hand
side of the side component window. This didn't make much sense
considering that the overlay region for the shell already blocked
out the side component window anyway and broke in the case
of the discovery feed, because the feed is in the center
of the screen.

https://phabricator.endlessm.com/T18601