### PR TITLE
feed: Add a changeVisbilityState to be used instead of visible

### DIFF
--- a/js/ui/discoveryFeedButton.js
+++ b/js/ui/discoveryFeedButton.js
@@ -67,6 +67,14 @@ const DiscoveryFeedButton = new Lang.Class({
         Main.layoutManager.connect('monitors-changed', Lang.bind(this, function() {
             this.visible = _primaryMonitorWidthPassesThreshold();
         }));
+    },
+
+    changeVisbilityState: function(value) {
+        // Helper function to ensure that visibility is set correctly,
+        // consumers of this button should use this function as opposed
+        // to mutating 'visible' directly, since it prevents the
+        // button from appearing in cases where it should not.
+        this.visible = value && _primaryMonitorWidthPassesThreshold();
     }
 });
 

--- a/js/ui/viewSelector.js
+++ b/js/ui/viewSelector.js
@@ -256,7 +256,7 @@ const ViewsDisplayLayout = new Lang.Class({
         this._searchResultsActor.opacity = v * 255;
 
         if (this._discoveryFeedButton) {
-            this._discoveryFeedButton.visible = v != 1;
+            this._discoveryFeedButton.changeVisbilityState(v != 1);
             this._discoveryFeedButton.opacity = (1 - v) * 255;
         }
 


### PR DESCRIPTION
The viewSelector was making the feed button visible again when
it faded in all components by setting 'visible' directly. This
bypassed our resolution check. For some uninteresting reasons
we can't fix this by defining a setter on the visible property
(it seems like this is not supported for GObject properties
since that would also require a getter and get_property is
not introspectable). So add a new API and have the viewSelector
use that instead.

https://phabricator.endlessm.com/T18546