### PR TITLE
remoteSearch: don't activate the app twice

### DIFF
--- a/js/ui/remoteSearch.js
+++ b/js/ui/remoteSearch.js
@@ -324,7 +324,7 @@ const RemoteSearchProvider = new Lang.Class({
     activateAppContext: function() {
         let app = Shell.AppSystem.get_default().lookup_app(this.appInfo.get_id());
         let context = new AppActivation.AppActivationContext(app);
-        context.activate();
+        context.showSplash();
     }
 });
 


### PR DESCRIPTION
We already call the remote search method to activate the app; don't
activate it again by calling activate() on the AppActivationContext.

https://phabricator.endlessm.com/T18669