### PR TITLE
appDisplay: ignore evergreen applications from search

### DIFF
--- a/js/ui/appDisplay.js
+++ b/js/ui/appDisplay.js
@@ -1389,6 +1389,10 @@ const AppSearchProvider = new Lang.Class({
             'com.endlessm.Coding.Chatbox.desktop',
             'eos-shell-extension-prefs.desktop'
         ];
+        let evergreenApps = [
+            'com.endlessm.quote_of_the_day.en.desktop',
+            'com.endlessm.word_of_the_day.en.desktop'
+        ];
         let replacementMap = {};
         let seenAppIDs = new Set();
 
@@ -1404,6 +1408,10 @@ const AppSearchProvider = new Lang.Class({
 
                 // exclude coding related apps if coding game is not enabled
                 if (!codingEnabled && codingApps.indexOf(appID) > -1)
+                    return false;
+
+                // exclude "evergreen" apps, since they may not have NoDisplay=true
+                if (evergreenApps.indexOf(appID) > -1)
                     return false;
 
                 if (app && app.should_show()) {


### PR DESCRIPTION
This is a temporary fix while the apps get a NoDisplay=true flag.

https://phabricator.endlessm.com/T19013