### PR TITLE
appDisplay: avoid "Get X" apps showing in search

### DIFF
--- a/js/ui/appDisplay.js
+++ b/js/ui/appDisplay.js
@@ -1390,7 +1390,6 @@ const AppSearchProvider = new Lang.Class({
             'eos-shell-extension-prefs.desktop'
         ];
         let replacementMap = {};
-        let seenAppIDs = new Set();
 
         groups.forEach(function(group) {
             group = group.filter(function(appID) {
@@ -1407,8 +1406,6 @@ const AppSearchProvider = new Lang.Class({
                     return false;
 
                 if (app && app.should_show()) {
-                    seenAppIDs.add(appID);
-
                     let replacedByID = app.get_string(EOS_REPLACED_BY_KEY);
                     if (replacedByID)
                         replacementMap[appID] = replacedByID;
@@ -1445,7 +1442,8 @@ const AppSearchProvider = new Lang.Class({
                 return true;
 
             // the specified replacement is not installed, show it
-            if (!seenAppIDs.has(replacedByID))
+            let replacedByApp = Gio.DesktopAppInfo.new(replacedByID);
+            if (!replacedByApp)
                 return true;
 
             // the specified replacement is installed, hide it


### PR DESCRIPTION
Previously we were keeping the "seen" apps in a separate set, but
we were only ever considering those returned as results for the given
string; the app that is supposed to replace the launcher may not match
the given string at all.

Fix it by simply checking whether the replacement is installed directly.

https://phabricator.endlessm.com/T18771