### PR TITLE
Move 40-gdm.rules to $(datadir)

### DIFF
--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -39,7 +39,7 @@ endif
 	$(AM_V_GEN) $(MSGFMT) --desktop --template $(builddir)/$< \
 	                      -d $(top_srcdir)/po -o $@
 
-rulesdir = $(sysconfdir)/polkit-1/rules.d
+rulesdir = $(datadir)/polkit-1/rules.d
 rules_DATA = 40-gdm.rules
 
 introspectiondir = $(datadir)/dbus-1/interfaces


### PR DESCRIPTION
Per Cosimo Cecchi, the rules file belongs under /usr/share/
rather than /etc/, since it is not a distributor override.

This was missed when we rebased on gnome-shell 3.22.

https://phabricator.endlessm.com/T19035