### PR TITLE
Install /usr/share/polkit-1

### DIFF
--- a/debian/gnome-shell-common.install
+++ b/debian/gnome-shell-common.install
@@ -5,6 +5,7 @@ usr/share/gnome-control-center
 usr/share/gnome-shell
 usr/share/gtk-doc
 usr/share/locale
+usr/share/polkit-1
 
 # This is a hack for #853018. Remove this after Debian stretch is released.
 debian/jessie-upgrade/process-working.svg /usr/share/gnome-shell/theme


### PR DESCRIPTION
Needed for 40-gdm.rules, which was missing from the gnome-shell
3.22 rebase, and thus had effectively disabled password resets.

https://phabricator.endlessm.com/T19035