### PR TITLE
appDisplay: Don't animate icons one by one when opening a folder

### DIFF
--- a/js/ui/appDisplay.js
+++ b/js/ui/appDisplay.js
@@ -1514,11 +1514,6 @@ const FolderView = new Lang.Class({
         Util.ensureActorVisibleInScrollView(this.actor, actor);
     },
 
-    // Overriden from BaseAppView
-    animate: function(animationDirection) {
-        this._grid.animatePulse(animationDirection);
-    },
-
     createFolderIcon: function(size) {
         let layout = new Clutter.GridLayout();
         let icon = new St.Widget({ layout_manager: layout,


### PR DESCRIPTION
That animation doesn't feel right when opening a folder with many
apps inside, specially on slow computers where we skip many frames.

https://phabricator.endlessm.com/T18330