### PR TITLE
T19320

### DIFF
--- a/data/theme/gnome-shell-high-contrast.css
+++ b/data/theme/gnome-shell-high-contrast.css
@@ -1220,6 +1220,12 @@ StScrollBar {
   .icon-grid .overview-icon {
     icon-size: 96px; }
 
+.system-action-icon {
+  background-color: black;
+  color: white;
+  border-radius: 99px;
+  icon-size: 48px; }
+
 .app-view-controls {
   padding-bottom: 32px; }
 

--- a/data/theme/gnome-shell.css
+++ b/data/theme/gnome-shell.css
@@ -1220,6 +1220,12 @@ StScrollBar {
   .icon-grid .overview-icon {
     icon-size: 96px; }
 
+.system-action-icon {
+  background-color: black;
+  color: white;
+  border-radius: 99px;
+  icon-size: 48px; }
+
 .app-view-controls {
   padding-bottom: 32px; }
 

--- a/js/js-resources.gresource.xml
+++ b/js/js-resources.gresource.xml
@@ -25,6 +25,7 @@
     <file>misc/params.js</file>
     <file>misc/permissionStore.js</file>
     <file>misc/smartcardManager.js</file>
+    <file>misc/systemActions.js</file>
     <file>misc/util.js</file>
     <file>misc/weather.js</file>
 

--- a/js/misc/systemActions.js
+++ b/js/misc/systemActions.js
@@ -73,15 +73,40 @@ const SystemActions = new Lang.Class({
 
         this._actions = new Map();
         this._actions.set(POWER_OFF_ACTION_ID,
-                          { available: false });
+                          { // Translators: The name of the power-off action in search
+                            name: C_("search-result", "Power off"),
+                            iconName: 'system-shutdown-symbolic',
+                            // Translators: A list of keywords that match the power-off action, separated by semicolons
+                            keywords: _("power off;shutdown").split(';'),
+                            available: false });
         this._actions.set(LOCK_SCREEN_ACTION_ID,
-                          { available: false });
+                          { // Translators: The name of the lock screen action in search
+                            name: C_("search-result", "Lock screen"),
+                            iconName: 'system-lock-screen-symbolic',
+                            // Translators: A list of keywords that match the lock screen action, separated by semicolons
+                            keywords: _("lock screen").split(';'),
+                            available: false });
         this._actions.set(LOGOUT_ACTION_ID,
-                          { available: false });
+                          { // Translators: The name of the logout action in search
+                            name: C_("search-result", "Log out"),
+                            iconName: 'application-exit-symbolic',
+                            // Translators: A list of keywords that match the logout action, separated by semicolons
+                            keywords: _("logout;sign off").split(';'),
+                            available: false });
         this._actions.set(SUSPEND_ACTION_ID,
-                          { available: false });
+                          { // Translators: The name of the suspend action in search
+                            name: C_("search-result", "Suspend"),
+                            iconName: 'media-playback-pause-symbolic',
+                            // Translators: A list of keywords that match the suspend action, separated by semicolons
+                            keywords: _("suspend;sleep").split(';'),
+                            available: false });
         this._actions.set(SWITCH_USER_ACTION_ID,
-                          { available: false });
+                          { // Translators: The name of the switch user action in search
+                            name: C_("search-result", "Switch user"),
+                            iconName: 'system-switch-user-symbolic',
+                            // Translators: A list of keywords that match the switch user action, separated by semicolons
+                            keywords: _("switch user").split(';'),
+                            available: false });
 
         this._loginScreenSettings = new Gio.Settings({ schema_id: LOGIN_SCREEN_SCHEMA });
         this._lockdownSettings = new Gio.Settings({ schema_id: LOCKDOWN_SCHEMA });
@@ -153,6 +178,50 @@ const SystemActions = new Lang.Class({
         // latter, so their value may be outdated; force an update now
         this._updateHaveShutdown();
         this._updateHaveSuspend();
+    },
+
+    getMatchingActions: function(terms) {
+        // terms is a list of strings
+        terms = terms.map((term) => { return term.toLowerCase(); });
+
+        let results = [];
+
+        for (let [key, {available, keywords}] of this._actions)
+            if (available && terms.every(t => keywords.some(k => (k.indexOf(t) >= 0))))
+                results.push(key);
+
+        return results;
+    },
+
+    getName: function(id) {
+        return this._actions.get(id).name;
+    },
+
+    getIconName: function(id) {
+        return this._actions.get(id).iconName;
+    },
+
+    activateAction: function(id) {
+        switch (id) {
+            case POWER_OFF_ACTION_ID:
+                this.activatePowerOff();
+                break;
+            case LOCK_SCREEN_ACTION_ID:
+                this.activateLockScreen();
+                break;
+            case LOGOUT_ACTION_ID:
+                this.activateLogout();
+                break;
+            case SUSPEND_ACTION_ID:
+                this.activateSuspend();
+                break;
+            case SWITCH_USER_ACTION_ID:
+                this.activateSwitchUser();
+                break;
+            case LOCK_ORIENTATION_ACTION_ID:
+                this.activateLockOrientation();
+                break;
+        }
     },
 
     _updateLockScreen() {

--- a/js/misc/systemActions.js
+++ b/js/misc/systemActions.js
@@ -1,0 +1,264 @@
+const AccountsService = imports.gi.AccountsService;
+const Clutter = imports.gi.Clutter;
+const Gdm = imports.gi.Gdm;
+const Gio = imports.gi.Gio;
+const GLib = imports.gi.GLib;
+const Lang = imports.lang;
+const Meta = imports.gi.Meta;
+const GObject = imports.gi.GObject;
+
+const GnomeSession = imports.misc.gnomeSession;
+const LoginManager = imports.misc.loginManager;
+const Main = imports.ui.main;
+
+const LOCKDOWN_SCHEMA = 'org.gnome.desktop.lockdown';
+const LOGIN_SCREEN_SCHEMA = 'org.gnome.login-screen';
+const DISABLE_USER_SWITCH_KEY = 'disable-user-switching';
+const DISABLE_LOCK_SCREEN_KEY = 'disable-lock-screen';
+const DISABLE_LOG_OUT_KEY = 'disable-log-out';
+const DISABLE_RESTART_KEY = 'disable-restart-buttons';
+const ALWAYS_SHOW_LOG_OUT_KEY = 'always-show-log-out';
+
+let _singleton = null;
+
+function getDefault() {
+    if (_singleton == null)
+        _singleton = new SystemActions();
+
+    return _singleton;
+}
+
+const SystemActions = new Lang.Class({
+    Name: 'SystemActions',
+    Extends: GObject.Object,
+    Properties: {
+        'can-power-off': GObject.ParamSpec.boolean('can-power-off',
+                                                   'can-power-off',
+                                                   'can-power-off',
+                                                   GObject.ParamFlags.READABLE,
+                                                   false),
+        'can-suspend': GObject.ParamSpec.boolean('can-suspend',
+                                                 'can-suspend',
+                                                 'can-suspend',
+                                                 GObject.ParamFlags.READABLE,
+                                                 false),
+        'can-lock-screen': GObject.ParamSpec.boolean('can-lock-screen',
+                                                     'can-lock-screen',
+                                                     'can-lock-screen',
+                                                     GObject.ParamFlags.READABLE,
+                                                     false),
+        'can-switch-user': GObject.ParamSpec.boolean('can-switch-user',
+                                                     'can-switch-user',
+                                                     'can-switch-user',
+                                                     GObject.ParamFlags.READABLE,
+                                                     false),
+        'can-logout': GObject.ParamSpec.boolean('can-logout',
+                                                'can-logout',
+                                                'can-logout',
+                                                GObject.ParamFlags.READABLE,
+                                                false)
+    },
+
+    _init: function() {
+        this.parent();
+
+        this._canPowerOff = false;
+        this._canHavePowerOff = true;
+        this._canSuspend = false;
+        this._canHaveSuspend = true;
+        this._canLockScreen = false;
+        this._canSwitchUser = false;
+        this._canLogout = false;
+
+        this._loginScreenSettings = new Gio.Settings({ schema_id: LOGIN_SCREEN_SCHEMA });
+        this._lockdownSettings = new Gio.Settings({ schema_id: LOCKDOWN_SCHEMA });
+
+        this._session = new GnomeSession.SessionManager();
+        this._loginManager = LoginManager.getLoginManager();
+        this._monitorManager = Meta.MonitorManager.get();
+
+        this._userManager = AccountsService.UserManager.get_default();
+
+        this._userManager.connect('notify::is-loaded',
+                                  () => { this._updateMultiUser(); });
+        this._userManager.connect('notify::has-multiple-users',
+                                  () => { this._updateMultiUser(); });
+        this._userManager.connect('user-added',
+                                  () => { this._updateMultiUser(); });
+        this._userManager.connect('user-removed',
+                                  () => { this._updateMultiUser(); });
+
+        this._lockdownSettings.connect('changed::' + DISABLE_USER_SWITCH_KEY,
+                                       () => { this._updateSwitchUser(); });
+        this._lockdownSettings.connect('changed::' + DISABLE_LOG_OUT_KEY,
+                                       () => { this._updateLogout(); });
+        global.settings.connect('changed::' + ALWAYS_SHOW_LOG_OUT_KEY,
+                                () => { this._updateLogout(); });
+
+        this._lockdownSettings.connect('changed::' + DISABLE_LOCK_SCREEN_KEY,
+                                       () => { this._updateLockScreen(); });
+
+        this._lockdownSettings.connect('changed::' + DISABLE_LOG_OUT_KEY,
+                                       () => { this._updateHaveShutdown(); });
+
+        this.forceUpdate();
+
+        Main.sessionMode.connect('updated', () => { this._sessionUpdated(); });
+        this._sessionUpdated();
+    },
+
+    get can_power_off() {
+        return this._canPowerOff;
+    },
+
+    get can_suspend() {
+        return this._canSuspend;
+    },
+
+    get can_lock_screen() {
+        return this._canLockScreen;
+    },
+
+    get can_switch_user() {
+        return this._canSwitchUser;
+    },
+
+    get can_logout() {
+        return this._canLogout;
+    },
+
+    _sessionUpdated: function() {
+        this._updateLockScreen();
+        this._updatePowerOff();
+        this._updateSuspend();
+        this._updateMultiUser();
+    },
+
+    forceUpdate: function() {
+        // Whether those actions are available or not depends on both lockdown
+        // settings and Polkit policy - we don't get change notifications for the
+        // latter, so their value may be outdated; force an update now
+        this._updateHaveShutdown();
+        this._updateHaveSuspend();
+    },
+
+    _updateLockScreen() {
+        let showLock = !Main.sessionMode.isLocked && !Main.sessionMode.isGreeter;
+        let allowLockScreen = !this._lockdownSettings.get_boolean(DISABLE_LOCK_SCREEN_KEY);
+        this._canLockScreen = showLock && allowLockScreen && LoginManager.canLock();
+        this.notify('can-lock-screen');
+    },
+
+    _updateHaveShutdown: function() {
+        this._session.CanShutdownRemote((result, error) => {
+            if (error)
+                return;
+
+            this._canHavePowerOff = result[0];
+            this._updatePowerOff();
+        });
+    },
+
+    _updatePowerOff: function() {
+        let disabled = Main.sessionMode.isLocked ||
+                       (Main.sessionMode.isGreeter &&
+                        this._loginScreenSettings.get_boolean(DISABLE_RESTART_KEY));
+        this._canPowerOff = this._canHavePowerOff && !disabled;
+        this.notify('can-power-off');
+    },
+
+    _updateHaveSuspend: function() {
+        this._loginManager.canSuspend(
+            (canSuspend, needsAuth) => {
+                this._canHaveSuspend = canSuspend;
+                this._suspendNeedsAuth = needsAuth;
+                this._updateSuspend();
+            });
+    },
+
+    _updateSuspend: function() {
+        let disabled = (Main.sessionMode.isLocked &&
+                        this._suspendNeedsAuth) ||
+                       (Main.sessionMode.isGreeter &&
+                        this._loginScreenSettings.get_boolean(DISABLE_RESTART_KEY));
+        this._canSuspend = this._canHaveSuspend && !disabled;
+        this.notify('can-suspend');
+    },
+
+    _updateMultiUser: function() {
+        this._updateLogout();
+        this._updateSwitchUser();
+    },
+
+    _updateSwitchUser: function() {
+        let allowSwitch = !this._lockdownSettings.get_boolean(DISABLE_USER_SWITCH_KEY);
+        let multiUser = this._userManager.can_switch() && this._userManager.has_multiple_users;
+        let shouldShowInMode = !Main.sessionMode.isLocked && !Main.sessionMode.isGreeter;
+
+        let visible = allowSwitch && multiUser && shouldShowInMode;
+        this._canSwitchUser = visible;
+        this.notify('can-switch-user');
+
+        return visible;
+    },
+
+    _updateLogout: function() {
+        let user = this._userManager.get_user(GLib.get_user_name());
+
+        let allowLogout = !this._lockdownSettings.get_boolean(DISABLE_LOG_OUT_KEY);
+        let alwaysShow = global.settings.get_boolean(ALWAYS_SHOW_LOG_OUT_KEY);
+        let systemAccount = user.system_account;
+        let localAccount = user.local_account;
+        let multiUser = this._userManager.has_multiple_users;
+        let multiSession = Gdm.get_session_ids().length > 1;
+        let shouldShowInMode = !Main.sessionMode.isLocked && !Main.sessionMode.isGreeter;
+
+        let visible = allowLogout && (alwaysShow || multiUser || multiSession || systemAccount || !localAccount) && shouldShowInMode;
+        this._canLogout = visible;
+        this.notify('can-logout');
+
+        return visible;
+    },
+
+    activateLockScreen: function() {
+        if (!this._canLockScreen)
+            throw new Error('The lock-screen action is not available!');
+
+        Main.screenShield.lock(true);
+    },
+
+    activateSwitchUser: function() {
+        if (!this._canSwitchUser)
+            throw new Error('The switch-user action is not available!');
+
+        if (Main.screenShield)
+            Main.screenShield.lock(false);
+
+        Clutter.threads_add_repaint_func_full(Clutter.RepaintFlags.POST_PAINT, function() {
+            Gdm.goto_login_session_sync(null);
+            return false;
+        });
+    },
+
+    activateLogout: function() {
+        if (!this._canLogout)
+            throw new Error('The logout action is not available!');
+
+        Main.overview.hide();
+        this._session.LogoutRemote(0);
+    },
+
+    activatePowerOff: function() {
+        if (!this._canPowerOff)
+            throw new Error('The power-off action is not available!');
+
+        this._session.ShutdownRemote(0);
+    },
+
+    activateSuspend: function() {
+        if (!this._canSuspend)
+            throw new Error('The suspend action is not available!');
+
+        this._loginManager.suspend();
+    }
+});

--- a/js/ui/status/system.js
+++ b/js/ui/status/system.js
@@ -469,13 +469,11 @@ const Indicator = new Lang.Class({
 
     _onLockScreenClicked: function() {
         this.menu.itemActivated(BoxPointer.PopupAnimation.NONE);
-        Main.overview.hide();
         Main.screenShield.lock(true);
     },
 
     _onLoginScreenActivate: function() {
         this.menu.itemActivated(BoxPointer.PopupAnimation.NONE);
-        Main.overview.hide();
         if (Main.screenShield)
             Main.screenShield.lock(false);
 
@@ -487,13 +485,11 @@ const Indicator = new Lang.Class({
 
     _onQuitSessionActivate: function() {
         this.menu.itemActivated();
-        Main.overview.hide();
         this._session.LogoutRemote(0);
     },
 
     _onPowerOffClicked: function() {
         this.menu.itemActivated();
-        Main.overview.hide();
         this._session.ShutdownRemote(0);
     },
 

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -9,6 +9,7 @@ js/extensionPrefs/main.js
 js/gdm/authPrompt.js
 js/gdm/loginDialog.js
 js/gdm/util.js
+js/misc/systemActions.js
 js/misc/util.js
 js/portalHelper/main.js
 js/ui/accessDialog.js


### PR DESCRIPTION
This is a backport of the patches from https://bugzilla.gnome.org/show_bug.cgi?id=691900 on top of our fork of GNOME Shell 3.24. It needed to be adapted mainly to the fact that we have move the "settings" and "orientation lock" buttons out of the "system action" buttons, as well as to integrate with our changes for the  AppSearchProviders.

https://phabricator.endlessm.com/T19320