### PR TITLE
gtk-embed: ensure we only listen for window-created events once

### DIFF
--- a/src/shell-gtk-embed.c
+++ b/src/shell-gtk-embed.c
@@ -124,13 +124,14 @@ shell_gtk_embed_on_window_mapped (GtkWidget     *object,
   ShellGtkEmbedPrivate *priv = shell_gtk_embed_get_instance_private (embed);
   MetaDisplay *display = shell_global_get_display (shell_global_get ());
 
-  /* Listen for new windows so we can detect when Mutter has
-     created a MutterWindow for this window */
-  priv->window_created_handler =
-    g_signal_connect (display,
-                      "window-created",
-                      G_CALLBACK (shell_gtk_embed_window_created_cb),
-                      embed);
+  if (priv->window_created_handler == 0 && priv->window_actor == NULL)
+    /* Listen for new windows so we can detect when Mutter has
+       created a MutterWindow for this window */
+    priv->window_created_handler =
+      g_signal_connect (display,
+                        "window-created",
+                        G_CALLBACK (shell_gtk_embed_window_created_cb),
+                        embed);
 }
 
 static void


### PR DESCRIPTION
If a tray icon gets a mapped and unmapped and the mapped again
in quick succession, we can end up with multiple handlers
listening for window creation events.

This commit tries to guard against that by only listening for
window-created events when we don't  know the actor associated
with the icon.

https://bugzilla.gnome.org/show_bug.cgi?id=787361