### PR TITLE
Align patches with upstream

### DIFF
--- a/js/ui/dnd.js
+++ b/js/ui/dnd.js
@@ -522,7 +522,7 @@ const _Draggable = new Lang.Class({
             // Snap the clone back to its source
             [x, y] = this._dragActorSource.get_transformed_position();
             let [sourceScaledWidth, sourceScaledHeight] = this._dragActorSource.get_transformed_size();
-            scale = sourceScaledWidth ? this._dragActor.width / sourceScaledWidth : 1;
+            scale = this._dragActor.width / sourceScaledWidth;
         } else if (this._dragOrigParent) {
             // Snap the actor back to its original position within
             // its parent, adjusting for the fact that the parent

--- a/js/ui/dnd.js
+++ b/js/ui/dnd.js
@@ -522,7 +522,7 @@ const _Draggable = new Lang.Class({
             // Snap the clone back to its source
             [x, y] = this._dragActorSource.get_transformed_position();
             let [sourceScaledWidth, sourceScaledHeight] = this._dragActorSource.get_transformed_size();
-            scale = this._dragActor.width / sourceScaledWidth;
+            scale = sourceScaledWidth ? this._dragActor.width / sourceScaledWidth : 0;
         } else if (this._dragOrigParent) {
             // Snap the actor back to its original position within
             // its parent, adjusting for the fact that the parent

--- a/src/shell-app.c
+++ b/src/shell-app.c
@@ -262,13 +262,11 @@ shell_app_get_name (ShellApp *app)
     return g_app_info_get_name (G_APP_INFO (app->info));
   else
     {
+      MetaWindow *window = window_backed_app_get_window (app);
       const char *name = NULL;
-      if (app->running_state)
-        {
-          MetaWindow *window = window_backed_app_get_window (app);
-          if (window)
-            name = meta_window_get_wm_class (window);
-        }
+
+      if (window)
+        name = meta_window_get_wm_class (window);
       if (!name)
         name = C_("program", "Unknown");
       return name;


### PR DESCRIPTION
This PRs drops a patch that is no longer needed in 3.24 and replaces another one with the right implementation, already landed upstream.

https://phabricator.endlessm.com/T19421