### PR TITLE
Fix closing Speedwagon quickly before the app starts

### DIFF
--- a/src/shell-app.c
+++ b/src/shell-app.c
@@ -1102,12 +1102,14 @@ _shell_app_remove_window (ShellApp   *app,
     app->running_state->speedwagon_windows--;
 
   if (app->running_state->windows == NULL)
-    g_clear_pointer (&app->running_state, unref_running_state);
-
-  if (app->running_state == NULL)
-    shell_app_state_transition (app, SHELL_APP_STATE_STOPPED);
+    {
+      g_clear_pointer (&app->running_state, unref_running_state);
+      shell_app_state_transition (app, SHELL_APP_STATE_STOPPED);
+    }
   else
-    shell_app_sync_running_state (app);
+    {
+      shell_app_sync_running_state (app);
+    }
 
   g_signal_emit (app, shell_app_signals[WINDOWS_CHANGED], 0);
 }

--- a/src/shell-app.c
+++ b/src/shell-app.c
@@ -1102,13 +1102,14 @@ _shell_app_remove_window (ShellApp   *app,
     app->running_state->speedwagon_windows--;
 
   if (app->running_state->windows == NULL)
+    g_clear_pointer (&app->running_state, unref_running_state);
+
+  if (app->state != SHELL_APP_STATE_STARTING)
     {
-      g_clear_pointer (&app->running_state, unref_running_state);
-      shell_app_state_transition (app, SHELL_APP_STATE_STOPPED);
-    }
-  else
-    {
-      shell_app_sync_running_state (app);
+      if (app->running_state == NULL)
+        shell_app_state_transition (app, SHELL_APP_STATE_STOPPED);
+      else
+        shell_app_sync_running_state (app);
     }
 
   g_signal_emit (app, shell_app_signals[WINDOWS_CHANGED], 0);


### PR DESCRIPTION
This broke during the rebases to 3.22 and 3.24, so let's pick this patch again and drop the one with "leftovers" after squashing so many things during the rebases.

https://phabricator.endlessm.com/T19424