### PR TITLE
screenShield: Style the clock actor and center vertical arrows

### DIFF
--- a/data/theme/gnome-shell.css
+++ b/data/theme/gnome-shell.css
@@ -2611,3 +2611,21 @@ stage {
     box-shadow: none;
     text-shadow: none;
 }
+
+/* Lock Screen */
+
+.screen-shield-clock-time {
+  font-family: Metropolis Medium, sans-serif;
+  font-weight: 500; /* Medium */
+  font-size: 100px;
+  text-shadow: 5px 0px 7px rgba(0, 0, 0, 0.25);
+  color: rgba(246, 246, 246, 0.7);
+}
+
+.screen-shield-clock-date {
+  font-family: Metropolis Semibold, sans-serif;
+  font-weight: 600; /* Semibold */
+  font-size: 36px;
+  text-shadow: 5px 0px 7px rgba(0, 0, 0, 0.35);
+  color: rgba(246, 246, 246, 0.7);
+}

--- a/js/ui/screenShield.js
+++ b/js/ui/screenShield.js
@@ -423,6 +423,31 @@ function clamp(value, min, max) {
     return Math.max(min, Math.min(max, value));
 }
 
+const ArrowContainerConstraint = new Lang.Class({
+    Name: 'ArrowContainerConstraint',
+    Extends: Clutter.Constraint,
+
+    _init: function(contentsActor, clockActor) {
+        this._contentsActor = contentsActor;
+        this._clockActor = clockActor;
+        this.parent();
+    },
+
+    vfunc_update_allocation: function(actor, actorBox) {
+        let [clockActorPosX, clockActorPosY] = this._clockActor.get_transformed_position();
+        let [clockActorWidth, clockActorHeight] = this._clockActor.get_transformed_size();
+
+        let availableHeight = this._contentsActor.get_height() - Main.panel.actor.get_height();
+        let clockActorBottom = clockActorPosY + clockActorHeight;
+        let arrowsContainerHeight = availableHeight - clockActorBottom;
+        let verticalPadding = Math.max(0, arrowsContainerHeight - actorBox.get_height()) / 2.0;
+
+        // Center vertically between the clock actor and the bottom panel.
+        actorBox.init_rect(actorBox.get_x(), clockActorBottom + verticalPadding,
+                           actorBox.get_width(), actorBox.get_height());
+    }
+});
+
 /**
  * If you are setting org.gnome.desktop.session.idle-delay directly in dconf,
  * rather than through System Settings, you also need to set
@@ -465,24 +490,6 @@ const ScreenShield = new Lang.Class({
 
         this._updateBackgrounds();
         Main.layoutManager.connect('monitors-changed', Lang.bind(this, this._updateBackgrounds));
-
-        this._arrowAnimationId = 0;
-        this._arrowWatchId = 0;
-        this._arrowActiveWatchId = 0;
-        this._arrowContainer = new St.BoxLayout({ style_class: 'screen-shield-arrows',
-                                                  vertical: true,
-                                                  x_align: Clutter.ActorAlign.CENTER,
-                                                  y_align: Clutter.ActorAlign.END,
-                                                  // HACK: without these, ClutterBinLayout
-                                                  // ignores alignment properties on the actor
-                                                  x_expand: true,
-                                                  y_expand: true });
-
-        for (let i = 0; i < N_ARROWS; i++) {
-            let arrow = new Arrow({ opacity: 0 });
-            this._arrowContainer.add_actor(arrow);
-        }
-        this._lockScreenContents.add_actor(this._arrowContainer);
 
         this._dragAction = new Clutter.GestureAction();
         this._dragAction.connect('gesture-begin', Lang.bind(this, this._onDragBegin));
@@ -1157,6 +1164,20 @@ const ScreenShield = new Lang.Class({
         this._lockScreenContentsBox.add(this._notificationsBox.actor, { x_fill: true,
                                                                         y_fill: true,
                                                                         expand: true });
+        this._arrowAnimationId = 0;
+        this._arrowWatchId = 0;
+        this._arrowActiveWatchId = 0;
+        this._arrowContainer = new St.BoxLayout({ style_class: 'screen-shield-arrows',
+                                                  vertical: true,
+                                                  x_align: Clutter.ActorAlign.CENTER,
+                                                  x_expand: true});
+
+        for (let i = 0; i < N_ARROWS; i++) {
+            let arrow = new Arrow({ opacity: 0 });
+            this._arrowContainer.add_actor(arrow);
+        }
+        this._lockScreenContents.add_actor(this._arrowContainer);
+        this._arrowContainer.add_constraint(new ArrowContainerConstraint(this._lockScreenContents, this._clock.actor));
 
         this._hasLockScreen = true;
     },


### PR DESCRIPTION
As per the design spec, we want to use the Metropolis font for
the clock actor, tweak a bit the text's color and opacity and
also ensure that the box for the vertical arrows gets vertically
centered between the bottom of the clock's actor and the top of
the task bar.

https://phabricator.endlessm.com/T19165