### PR TITLE
viewSelector: Fix lock-ups when printing from the certain apps

### DIFF
--- a/js/ui/viewSelector.js
+++ b/js/ui/viewSelector.js
@@ -746,11 +746,10 @@ const ViewSelector = new Lang.Class({
     },
 
     show: function(viewPage) {
-        this._activePage = null;
         this._clearSearch();
+        this._workspacesDisplay.show(true);
 
         this._showPage(this._pageFromViewPage(viewPage));
-        this._workspacesDisplay.show(true);
     },
 
     animateFromOverview: function() {
@@ -771,7 +770,7 @@ const ViewSelector = new Lang.Class({
     },
 
     hide: function() {
-        // Nothing to do, since we always show the app selector
+        this._workspacesDisplay.hide();
     },
 
     focusSearch: function() {


### PR DESCRIPTION
This commit is actually "Fix broken transitions between pages in
overview modes" (09e8fd6b) from the 3.22 version of our shell,
which got lost somehow during the 3.24 rebase.

This caused the problem of having the desktop locking up mainly due
to a missing call to workspacesDisplay.hide() in viewSelector:hide(),
which was initially removed in commit 1ed19818, and then fix by this
other commit that never made it to our 3.24 shell.

Thus, this commit should be squashed along with 91cd581f (it's just
a revert of that one) and 5b241cec during the next rebase.

https://phabricator.endlessm.com/T17817