### PR TITLE
Don't exclude web links that are not in the desktop from search

### DIFF
--- a/js/ui/appDisplay.js
+++ b/js/ui/appDisplay.js
@@ -1430,10 +1430,6 @@ const AppSearchProvider = new Lang.Class({
                 let isLink = appID.startsWith(EOS_LINK_PREFIX);
                 let isOnDesktop = IconGridLayout.layout.hasIcon(appID);
 
-                // exclude links that are not part of the desktop grid
-                if (!(app && app.should_show() && !(isLink && !isOnDesktop)))
-                    return false;
-
                 // exclude coding related apps if coding game is not enabled
                 if (!codingEnabled && codingApps.indexOf(appID) > -1)
                     return false;


### PR DESCRIPTION
We used to hide this results from desktop search, but we want to include
them now so that those "native" applications are found when required, instead
of redirecting the user to the default search engine in the browser.

https://phabricator.endlessm.com/T19646