### PR TITLE
Revert "shell-app: Don't transition to STOPPED while still in the STARTING state"

### DIFF
--- a/src/shell-app.c
+++ b/src/shell-app.c
@@ -1100,10 +1100,16 @@ _shell_app_remove_window (ShellApp   *app,
     app->running_state->interesting_windows--;
   else if (shell_window_tracker_is_speedwagon_window (window))
     app->running_state->speedwagon_windows--;
-  shell_app_sync_running_state (app);
 
   if (app->running_state->windows == NULL)
-    g_clear_pointer (&app->running_state, unref_running_state);
+    {
+      g_clear_pointer (&app->running_state, unref_running_state);
+      shell_app_state_transition (app, SHELL_APP_STATE_STOPPED);
+    }
+  else
+    {
+      shell_app_sync_running_state (app);
+    }
 
   g_signal_emit (app, shell_app_signals[WINDOWS_CHANGED], 0);
 }


### PR DESCRIPTION
It turns out that this fix broke our eos-google-chrome-helper mechanism (T19684):
It will cause the Chrome fake "app" (the one that opens the App Center when Chrome
is not installed) to be permanently moved to the STARTING state after running it
once, causing the speedwagon to never go away until hitting the timeout if you
choose not to install it when the App Center opens.

Since the problem with Speedwagon this ticket was supposed to fix is not strictly
speaking a regression (it's been there for a while), we're temporarily reverting
this patch so that Chrome is not broken at least.

This reverts commit 3c27b824053ec4bc55fdd155365c801abeb1b4ff.

https://phabricator.endlessm.com/T19424
https://phabricator.endlessm.com/T19684