### PR TITLE
Fix the window picker animation

### DIFF
--- a/js/ui/layout.js
+++ b/js/ui/layout.js
@@ -627,8 +627,6 @@ const LayoutManager = new Lang.Class({
         this._systemBackground.actor.destroy();
         this._systemBackground = null;
 
-        this._startingUp = false;
-
         this.keyboardBox.show();
 
         if (!Main.sessionMode.isGreeter) {
@@ -639,6 +637,7 @@ const LayoutManager = new Lang.Class({
         this._queueUpdateRegions();
 
         this.emit('startup-complete');
+        this._startingUp = false;
     },
 
     showKeyboard: function () {

--- a/js/ui/overview.js
+++ b/js/ui/overview.js
@@ -526,13 +526,7 @@ const Overview = new Lang.Class({
     },
 
     _onStartupCompleted: function() {
-        if (this.isDummy)
-            return;
-
-        if (Main.workspaceMonitor.hasActiveWindows)
-            return;
-
-        this._showOrSwitchPage(ViewSelector.ViewPage.APPS);
+        this.showApps();
     },
 
     _showOrSwitchPage: function(page) {

--- a/js/ui/viewSelector.js
+++ b/js/ui/viewSelector.js
@@ -758,11 +758,6 @@ const ViewSelector = new Lang.Class({
         this._workspacesPage.opacity = 255;
 
         this._workspacesDisplay.animateFromOverview(this._activePage != this._workspacesPage);
-
-        this._showPage(this._workspacesPage);
-
-        if (!this._workspacesDisplay.activeWorkspaceHasMaximizedWindows())
-            Main.overview.fadeInDesktop();
     },
 
     setWorkspacesFullGeometry: function(geom) {

--- a/js/ui/viewSelector.js
+++ b/js/ui/viewSelector.js
@@ -676,6 +676,11 @@ const ViewSelector = new Lang.Class({
                     this._workspacesPage.opacity = 0;
                     this._workspacesPage.hide();
                 }
+
+                // Make sure to hide the overview immediately if we're starting up
+                // coming from a previous session with apps running and visible.
+                if (Main.layoutManager.startingUp && Main.workspaceMonitor.hasVisibleWindows)
+                    Main.overview.hide();
             }));
 
         Main.wm.addKeybinding('toggle-application-view',

--- a/js/ui/viewSelector.js
+++ b/js/ui/viewSelector.js
@@ -752,7 +752,7 @@ const ViewSelector = new Lang.Class({
 
     show: function(viewPage) {
         this._clearSearch();
-        this._workspacesDisplay.show(true);
+        this._workspacesDisplay.show(viewPage == ViewPage.APPS);
 
         this._showPage(this._pageFromViewPage(viewPage));
     },


### PR DESCRIPTION
The current PR fixes the window picker animation by making it "symmetric" in that a zooming animation will now be shown both when entering and leaving the window picker. Additionally, this PR also include a couple of small fixes that are relate to this in that it makes the whole experience handling windows entering & leaving the overview better, not necessarily when interacting the window picker, but in general (e.g. when starting up).

https://phabricator.endlessm.com/T18032