### PR TITLE
shellEntry: Also check for overview visibility

### DIFF
--- a/js/ui/shellEntry.js
+++ b/js/ui/shellEntry.js
@@ -266,7 +266,9 @@ const OverviewEntry = new Lang.Class({
     },
 
     _onMapped: function() {
-        if (this.mapped) {
+        // The entry might get mapped because of the clone, so we also
+        // have to check if the actual overview actor is visible.
+        if (this.mapped && Main.layoutManager.overviewGroup.visible) {
             // Enable 'find-as-you-type'
             this._capturedEventId = global.stage.connect('captured-event',
                                  Lang.bind(this, this._onCapturedEvent));


### PR DESCRIPTION
The OverviewEntry class tries to watch all the events
when it gets mapped, so that it can properly quit search
if the user clicks outside of the search entry and the
results page.

Checking if the entry is mapped or not, however, might
not be the optimal solution, for the entry can potentially
get mapped because of the grid clone, in which case it
ends up watching all the events without being at the
overview.

This has various side effects, the most noticeable being
the many missing clicks all around GNOME Shell. The other
noticeable issue is that some notifications are dismissed
even when their action buttons are clicked. This is 100%
reproducible with the Bluetooth panel.

Fix that by not only checking if the entry is mapped, but
also checking if the overview actor is visible too.

https://phabricator.endlessm.com/T13041