### PR TITLE
overview, viewSelector: Handle first time the overview is shown

### DIFF
--- a/js/ui/layout.js
+++ b/js/ui/layout.js
@@ -1013,10 +1013,6 @@ const LayoutManager = new Lang.Class({
         // We don't update the stage input region while in a modal,
         // so queue an update now.
         this._queueUpdateRegions();
-    },
-
-    get startingUp() {
-        return this._startingUp;
     }
 });
 Signals.addSignalMethods(LayoutManager.prototype);

--- a/js/ui/overview.js
+++ b/js/ui/overview.js
@@ -226,6 +226,7 @@ const Overview = new Lang.Class({
         this._toggleToHidden = false;   // Whether to hide the overview when either toggle function is called
         this._targetPage = null;        // do we have a target page to animate to?
         this._modal = false;            // have a modal grab
+        this._shownOnce = false;         // useful for handling events relevant only the first time it's shown
         this.animationInProgress = false;
         this.visibleTarget = false;
         this.opacityPrepared = false;
@@ -729,7 +730,7 @@ const Overview = new Lang.Class({
         this._coverPane.show();
         this.emit('showing');
 
-        if (Main.layoutManager.startingUp || this.opacityPrepared) {
+        if (!this._shownOnce || this.opacityPrepared) {
             this._overview.opacity = EOS_ACTIVE_GRID_OPACITY;
             this.opacityPrepared = false;
             this._showDone();
@@ -756,6 +757,10 @@ const Overview = new Lang.Class({
         this._coverPane.hide();
 
         this.emit('shown');
+
+        // This variable should only be false right after starting up.
+        this._shownOnce = true;
+
         // Handle any calls to hide* while we were showing
         if (!this._shown)
             this._animateNotVisible();
@@ -869,6 +874,10 @@ const Overview = new Lang.Class({
 
     getActivePage: function() {
         return this.viewSelector.getActivePage();
+    },
+
+    get shownOnce() {
+        return this._shownOnce;
     }
 });
 Signals.addSignalMethods(Overview.prototype);

--- a/js/ui/viewSelector.js
+++ b/js/ui/viewSelector.js
@@ -679,7 +679,7 @@ const ViewSelector = new Lang.Class({
 
                 // Make sure to hide the overview immediately if we're starting up
                 // coming from a previous session with apps running and visible.
-                if (Main.layoutManager.startingUp && Main.workspaceMonitor.hasVisibleWindows)
+                if (!Main.overview.shownOnce && Main.workspaceMonitor.hasVisibleWindows)
                     Main.overview.hide();
             }));
 


### PR DESCRIPTION
The fact that we want to start up directly in the Overview mode
on Endless combined with the possibility of having lots of icons
on the desktop makes it necessary to handle the first time the
overview is shown in a particular way in order to make it less
prone to flickering and confusion (e.g. already running apps
disappearing when restarting the shell).

However, we can't check the value of the startingUp property
from the layout because by the time Overview::show() gets called
the layout manager is no longer "starting up". Thus, add an
additional property to the overview so that we can do an extra
check to see if it's the first time it's shown, when needed.

This should be squashed with 4d34e93d in future rebases.

https://phabricator.endlessm.com/T19778