### PR TITLE
css: Re-style the "Clear All" button in the calendar popup menu

### DIFF
--- a/data/theme/gnome-shell.css
+++ b/data/theme/gnome-shell.css
@@ -2629,3 +2629,10 @@ stage {
   text-shadow: 5px 0px 7px rgba(0, 0, 0, 0.35);
   color: rgba(246, 246, 246, 0.7);
 }
+
+/* Calendar menu */
+
+.message-list-clear-button.button {
+  box-shadow: none;
+  border: 1px solid #454f52;
+}


### PR DESCRIPTION
This button was newly introduced with GNOME Shell, and the upstream
style doesn't play well with our style modifications to the background
of the menu, so replace it with a solid 1px border of the same colour
than other lines in the menu, to make it clear to the user that there
is a button in there.

https://phabricator.endlessm.com/T19807