### PR TITLE
Don't use a text-shadow on folder names when in editing mode

### DIFF
--- a/data/theme/gnome-shell.css
+++ b/data/theme/gnome-shell.css
@@ -2598,6 +2598,7 @@ stage {
     selected-color: white;
 
     box-shadow: inset 0px 1px 2px rgba(0,0,0,0.6);
+    text-shadow: none;
 }
 
 .overview-icon-label:highlighted,

--- a/src/st/st-entry.c
+++ b/src/st/st-entry.c
@@ -1106,7 +1106,7 @@ st_entry_get_text (StEntry *entry)
   g_return_val_if_fail (ST_IS_ENTRY (entry), NULL);
 
   priv = st_entry_get_instance_private (entry);
-  if (clutter_actor_is_visible (priv->hint_actor))
+  if (priv->hint_actor != NULL && clutter_actor_is_visible (priv->hint_actor))
     return "";
   else
     return clutter_text_get_text (CLUTTER_TEXT (priv->entry));


### PR DESCRIPTION
Also, cherry pick a fix from upstream to avoid a crash when getting the text of a StEntry where no hint actor has been previously defined.

https://phabricator.endlessm.com/T19575