### PR TITLE
appDisplay: Bring back the DnD hover effect when dragging over folders

### DIFF
--- a/js/ui/appDisplay.js
+++ b/js/ui/appDisplay.js
@@ -960,7 +960,7 @@ const AllView = new Lang.Class({
 
         if (this._dragIcon.parentView.actor.contains(dragEvent.targetActor))
             dragView = this._dragIcon.parentView;
-        else if (this.actor.contains(dragEvent.targetActor))
+        else
             dragView = this;
 
         if (dragView != this._dragView) {


### PR DESCRIPTION
The hierarchy of ClutterActors in the desktop has changed slightly since
the times of EOS pre-3.2, and there's no need for an extra check when
finding the "target drag view" for an actor since it's always going to
be either a folder or the AllView object otherwise.

Eliminating this extra check and always using the AllView object as the
fallback target drag view both fixes a weirdness on the first time you
try to DnD after a shell restart and brings back the "hover effect" that
we used to have when dragging icons over folders in the icon grid.

https://phabricator.endlessm.com/T18037