### PR TITLE
runDialog: hide overview when launching command/document

### DIFF
--- a/js/ui/runDialog.js
+++ b/js/ui/runDialog.js
@@ -219,6 +219,7 @@ const RunDialog = new Lang.Class({
                     command = exec + ' ' + exec_arg + ' ' + input;
                 }
                 Util.trySpawnCommandLine(command);
+                Main.overview.hide();
             } catch (e) {
                 // Mmmh, that failed - see if @input matches an existing file
                 let path = null;
@@ -235,6 +236,7 @@ const RunDialog = new Lang.Class({
                     try {
                         Gio.app_info_launch_default_for_uri(file.get_uri(),
                                                             global.create_app_launch_context(0, -1));
+                        Main.overview.hide();
                     } catch (e) {
                         // The exception from gjs contains an error string like:
                         //     Error invoking Gio.app_info_launch_default_for_uri: No application


### PR DESCRIPTION
This change makes it more convenient for developers to use Alt-F2,
without any impact to the normal user behavior.

[endlessm/eos-shell#555]
https://phabricator.endlessm.com/T19585