### PR TITLE
viewSelector: Don't show the workspacesDisplay actor when starting up

### DIFF
--- a/js/ui/viewSelector.js
+++ b/js/ui/viewSelector.js
@@ -752,7 +752,12 @@ const ViewSelector = new Lang.Class({
 
     show: function(viewPage) {
         this._clearSearch();
-        this._workspacesDisplay.show(viewPage == ViewPage.APPS);
+
+        // We're always starting up to the APPS page, so avoid making the workspacesDisplay
+        // (used for the Windows picker) visible to prevent situations where that actor
+        // would intercept clicks meant for the desktop's icons grid.
+        if (!Main.layoutManager.startingUp)
+            this._workspacesDisplay.show(viewPage == ViewPage.APPS);
 
         this._showPage(this._pageFromViewPage(viewPage), viewPage == ViewPage.APPS);
     },


### PR DESCRIPTION
We're always starting up to the APPS page, and making the workspacesDisplay
visible when starting up would cause its actor to intercept Clutter 'picks'
intended for the grid unless it gets hidden first.

Since we're not interested in showing the Window picker on start up, just
avoid showing the workspacesDisplay actor when starting up to prevent this.

https://phabricator.endlessm.com/T19869