### PR TITLE
appDisplay: Only defer redisplay of the icon grid on startup

### DIFF
--- a/js/ui/appDisplay.js
+++ b/js/ui/appDisplay.js
@@ -587,14 +587,14 @@ const AllView = new Lang.Class({
         this._redisplayWorkId = Main.initializeDeferredWork(this.actor, Lang.bind(this, this._redisplay));
 
         Shell.AppSystem.get_default().connect('installed-changed', Lang.bind(this, function() {
-            Main.queueDeferredWork(this._redisplayWorkId);
+            this._redisplay();
         }));
 
         IconGridLayout.layout.connect('changed', Lang.bind(this, function() {
-            Main.queueDeferredWork(this._redisplayWorkId);
+            this._redisplay();
         }));
         global.settings.connect('changed::' + EOS_ENABLE_APP_CENTER_KEY, Lang.bind(this, function() {
-            Main.queueDeferredWork(this._redisplayWorkId);
+            this._redisplay();
         }));
 
         this._addedFolderId = null;


### PR DESCRIPTION
In Endless, we have the apps grid (or a clone of it) showing up
all the time, so we can't defer updating it until the grid's actor
is mapped because that would create an artificial delay between an
icon gets added to the grid and the moment is made visible if the
"real" grid (not the clone) is not visible at that moment.

We still need to defer the call to redisplay() when starting up,
though, so that we don't draw anything until the grid is mapped.

https://phabricator.endlessm.com/T19596