### PR TITLE
RenmoteSearch: exclude content from evergreen apps

### DIFF
--- a/js/ui/remoteSearch.js
+++ b/js/ui/remoteSearch.js
@@ -96,6 +96,9 @@ function loadRemoteSearchProviders(searchSettings, callback) {
             try {
                 let desktopId = keyfile.get_string(group, 'DesktopId');
                 appInfo = Gio.DesktopAppInfo.new(desktopId);
+                // exclude app content that should not be shown e.g. evergreen apps
+                if (!appInfo.should_show())
+                    return;
             } catch (e) {
                 log('Ignoring search provider ' + path + ': missing DesktopId');
                 return;


### PR DESCRIPTION
The apps word of the day and quote of the day do
provide a search provider. We want those to be
excluded from the search.

https://phabricator.endlessm.com/T19013