### PR TITLE
passwordMode: add keyboard layout switcher for password entries

### DIFF
--- a/js/gdm/authPrompt.js
+++ b/js/gdm/authPrompt.js
@@ -15,7 +15,7 @@ const Animation = imports.ui.animation;
 const Batch = imports.gdm.batch;
 const Config = imports.misc.config;
 const GdmUtil = imports.gdm.util;
-const InputSourceManager = imports.ui.status.keyboard;
+const Keyboard = imports.ui.status.keyboard;
 const Params = imports.misc.params;
 const ShellEntry = imports.ui.shellEntry;
 const Tweener = imports.ui.tweener;
@@ -116,8 +116,8 @@ const AuthPrompt = new Lang.Class({
                          y_fill: false,
                          x_align: St.Align.START });
 
-        // for setting passwords we switch to a latin keyboard layout
-        this._inputSourceManager = InputSourceManager.getInputSourceManager();
+        // for setting passwords we enable a password mode for kbd layouts
+        this._inputSourceManager = Keyboard.getInputSourceManager();
         this._inputSourceManager.passwordModeEnabled = true;
 
         this._entry.grab_key_focus();

--- a/js/gdm/authPrompt.js
+++ b/js/gdm/authPrompt.js
@@ -15,6 +15,7 @@ const Animation = imports.ui.animation;
 const Batch = imports.gdm.batch;
 const Config = imports.misc.config;
 const GdmUtil = imports.gdm.util;
+const InputSourceManager = imports.ui.status.keyboard;
 const Params = imports.misc.params;
 const ShellEntry = imports.ui.shellEntry;
 const Tweener = imports.ui.tweener;
@@ -115,6 +116,10 @@ const AuthPrompt = new Lang.Class({
                          y_fill: false,
                          x_align: St.Align.START });
 
+        // for setting passwords we switch to a latin keyboard layout
+        this._inputSourceManager = InputSourceManager.getInputSourceManager();
+        this._inputSourceManager.passwordModeEnabled = true;
+
         this._entry.grab_key_focus();
 
         this._message = new St.Label({ opacity: 0,
@@ -183,6 +188,7 @@ const AuthPrompt = new Lang.Class({
     _onDestroy: function() {
         this._userVerifier.destroy();
         this._userVerifier = null;
+        this._inputSourceManager.passwordModeEnabled = false;
     },
 
     _initButtons: function() {

--- a/js/misc/keyboardManager.js
+++ b/js/misc/keyboardManager.js
@@ -4,6 +4,7 @@ const GLib = imports.gi.GLib;
 const GnomeDesktop = imports.gi.GnomeDesktop;
 const Lang = imports.lang;
 const Meta = imports.gi.Meta;
+const Shell = imports.gi.Shell;
 
 const Main = imports.ui.main;
 
@@ -150,5 +151,15 @@ const KeyboardManager = new Lang.Class({
     _buildOptionsString: function() {
         let options = this._xkbOptions.join(',');
         return options;
+    },
+
+    isLatinLayout: function(id) {
+        let info = this._layoutInfos[id];
+        if (!info)
+            return false;
+        let options = this._buildOptionsString();
+        let [_layouts, variants] = this._buildGroupStrings(info.group);
+        let [_found, , , layout, _variant] = this._xkbInfo.get_layout_info(id);
+        return !Shell.util_needs_secondary_layout(layout, variants, options);
     }
 });

--- a/js/ui/components/networkAgent.js
+++ b/js/ui/components/networkAgent.js
@@ -131,15 +131,18 @@ const NetworkSecretDialog = new Lang.Class({
 
             if (rtl) {
                 let j = 0;
+                // Some network dialogs have several password entries and
+                // we only want to attach the kbd layout switcher left of the first entry
                 if (i === 0) {
                     layout.attach(this._inputSourceIndicator.container, j, pos, 1, 1);
                     j++;
                 }
-                layout.attach(secret.entry, j+1, pos, 1, 1);
-                layout.attach(label, j+2, pos, 1, 1);
+                layout.attach(secret.entry, j, pos, 1, 1);
+                layout.attach(label, j+1, pos, 1, 1);
             } else {
                 layout.attach(label, 0, pos, 1, 1);
                 layout.attach(secret.entry, 1, pos, 1, 1);
+                // We only want to attach the kbd layout switcher right to the first entry
                 if (i === 0)
                     layout.attach(this._inputSourceIndicator.container, 2, pos, 1, 1);
             }

--- a/js/ui/components/networkAgent.js
+++ b/js/ui/components/networkAgent.js
@@ -12,8 +12,7 @@ const Shell = imports.gi.Shell;
 const St = imports.gi.St;
 
 const Config = imports.misc.config;
-const InputSourceIndicator = imports.ui.status.keyboard.InputSourceIndicator;
-const InputSourceManager = imports.ui.status.keyboard;
+const Keyboard = imports.ui.status.keyboard;
 const Main = imports.ui.main;
 const MessageTray = imports.ui.messageTray;
 const ModalDialog = imports.ui.modalDialog;
@@ -40,8 +39,8 @@ const NetworkSecretDialog = new Lang.Class({
         else
             this._content = this._getContent();
 
-        this._inputSourceManager = InputSourceManager.getInputSourceManager();
-        this._inputSourceIndicator = new InputSourceIndicator(this, false);
+        this._inputSourceManager = Keyboard.getInputSourceManager();
+        this._inputSourceIndicator = new Keyboard.InputSourceIndicator(this, false);
         let manager = new PopupMenu.PopupMenuManager({ actor: this._inputSourceIndicator.container });
         manager.addMenu(this._inputSourceIndicator.menu);
         this._inputSourceManager.passwordModeEnabled = true;

--- a/js/ui/components/polkitAgent.js
+++ b/js/ui/components/polkitAgent.js
@@ -15,8 +15,7 @@ const PolkitAgent = imports.gi.PolkitAgent;
 
 const Animation = imports.ui.animation;
 const Components = imports.ui.components;
-const InputSourceManager = imports.ui.status.keyboard;
-const InputSourceIndicator = imports.ui.status.keyboard.InputSourceIndicator;
+const Keyboard = imports.ui.status.keyboard;
 const ModalDialog = imports.ui.modalDialog;
 const PopupMenu = imports.ui.popupMenu;
 const ShellEntry = imports.ui.shellEntry;
@@ -153,8 +152,8 @@ const AuthenticationDialog = new Lang.Class({
         this._passwordBox.add(this._passwordEntry,
                               { expand: true });
 
-        this._inputSourceManager = InputSourceManager.getInputSourceManager();
-        this._inputSourceIndicator = new InputSourceIndicator(this, false);
+        this._inputSourceManager = Keyboard.getInputSourceManager();
+        this._inputSourceIndicator = new Keyboard.InputSourceIndicator(this, false);
         this._passwordBox.add(this._inputSourceIndicator.container);
         let manager = new PopupMenu.PopupMenuManager({ actor: this._inputSourceIndicator.container });
         manager.addMenu(this._inputSourceIndicator.menu);

--- a/js/ui/components/polkitAgent.js
+++ b/js/ui/components/polkitAgent.js
@@ -15,7 +15,10 @@ const PolkitAgent = imports.gi.PolkitAgent;
 
 const Animation = imports.ui.animation;
 const Components = imports.ui.components;
+const InputSourceManager = imports.ui.status.keyboard;
+const InputSourceIndicator = imports.ui.status.keyboard.InputSourceIndicator;
 const ModalDialog = imports.ui.modalDialog;
+const PopupMenu = imports.ui.popupMenu;
 const ShellEntry = imports.ui.shellEntry;
 const UserWidget = imports.ui.userWidget;
 const Tweener = imports.ui.tweener;
@@ -149,6 +152,12 @@ const AuthenticationDialog = new Lang.Class({
         this._passwordEntry.clutter_text.connect('activate', Lang.bind(this, this._onEntryActivate));
         this._passwordBox.add(this._passwordEntry,
                               { expand: true });
+
+        this._inputSourceManager = InputSourceManager.getInputSourceManager();
+        this._inputSourceIndicator = new InputSourceIndicator(this, false);
+        this._passwordBox.add(this._inputSourceIndicator.container);
+        let manager = new PopupMenu.PopupMenuManager({ actor: this._inputSourceIndicator.container });
+        manager.addMenu(this._inputSourceIndicator.menu);
 
         let spinnerIcon = Gio.File.new_for_uri('resource:///org/gnome/shell/theme/process-working.svg');
         this._workSpinner = new Animation.AnimatedIcon(spinnerIcon, WORK_SPINNER_ICON_SIZE);
@@ -336,6 +345,7 @@ const AuthenticationDialog = new Lang.Class({
         else
             this._passwordEntry.clutter_text.set_password_char('\u25cf'); // ● U+25CF BLACK CIRCLE
 
+        this._inputSourceManager.passwordModeEnabled = true;
         this._passwordBox.show();
         this._passwordEntry.set_text('');
         this._passwordEntry.grab_key_focus();
@@ -363,6 +373,7 @@ const AuthenticationDialog = new Lang.Class({
 
     destroySession: function() {
         if (this._session) {
+            this._inputSourceManager.passwordModeEnabled = false;
             if (!this._completed)
                 this._session.cancel();
             this._completed = false;

--- a/js/ui/shellMountOperation.js
+++ b/js/ui/shellMountOperation.js
@@ -11,10 +11,13 @@ const St = imports.gi.St;
 const Shell = imports.gi.Shell;
 
 const CheckBox = imports.ui.checkBox;
+const InputSourceIndicator = imports.ui.status.keyboard.InputSourceIndicator;
+const InputSourceManager = imports.ui.status.keyboard;
 const Main = imports.ui.main;
 const MessageTray = imports.ui.messageTray;
 const ModalDialog = imports.ui.modalDialog;
 const Params = imports.misc.params;
+const PopupMenu = imports.ui.popupMenu;
 const ShellEntry = imports.ui.shellEntry;
 
 const LIST_ITEM_ICON_SIZE = 48;
@@ -379,6 +382,13 @@ const ShellMountPasswordDialog = new Lang.Class({
         this._passwordBox.add(this._passwordEntry, {expand: true });
         this.setInitialKeyFocus(this._passwordEntry);
 
+        this._inputSourceManager = InputSourceManager.getInputSourceManager();
+        this._inputSourceIndicator = new InputSourceIndicator(this, false);
+        this._passwordBox.add(this._inputSourceIndicator.container);
+        let manager = new PopupMenu.PopupMenuManager({ actor: this._inputSourceIndicator.container });
+        manager.addMenu(this._inputSourceIndicator.menu);
+        this._inputSourceManager.passwordModeEnabled = true;
+
         this._errorMessageLabel = new St.Label({ style_class: 'prompt-dialog-error-label',
                                                  text: _("Sorry, that didn’t work. Please try again.") });
         this._errorMessageLabel.clutter_text.ellipsize = Pango.EllipsizeMode.NONE;
@@ -414,11 +424,13 @@ const ShellMountPasswordDialog = new Lang.Class({
     },
 
     _onCancelButton: function() {
+        this._inputSourceManager.passwordModeEnabled = false;
         this.emit('response', -1, '', false);
     },
 
     _onUnlockButton: function() {
         this._onEntryActivate();
+        this._inputSourceManager.passwordModeEnabled = false;
     },
 
     _onEntryActivate: function() {

--- a/js/ui/shellMountOperation.js
+++ b/js/ui/shellMountOperation.js
@@ -11,8 +11,7 @@ const St = imports.gi.St;
 const Shell = imports.gi.Shell;
 
 const CheckBox = imports.ui.checkBox;
-const InputSourceIndicator = imports.ui.status.keyboard.InputSourceIndicator;
-const InputSourceManager = imports.ui.status.keyboard;
+const Keyboard = imports.ui.status.keyboard;
 const Main = imports.ui.main;
 const MessageTray = imports.ui.messageTray;
 const ModalDialog = imports.ui.modalDialog;
@@ -382,8 +381,8 @@ const ShellMountPasswordDialog = new Lang.Class({
         this._passwordBox.add(this._passwordEntry, {expand: true });
         this.setInitialKeyFocus(this._passwordEntry);
 
-        this._inputSourceManager = InputSourceManager.getInputSourceManager();
-        this._inputSourceIndicator = new InputSourceIndicator(this, false);
+        this._inputSourceManager = Keyboard.getInputSourceManager();
+        this._inputSourceIndicator = new Keyboard.InputSourceIndicator(this, false);
         this._passwordBox.add(this._inputSourceIndicator.container);
         let manager = new PopupMenu.PopupMenuManager({ actor: this._inputSourceIndicator.container });
         manager.addMenu(this._inputSourceIndicator.menu);

--- a/js/ui/status/keyboard.js
+++ b/js/ui/status/keyboard.js
@@ -317,6 +317,7 @@ const InputSourceManager = new Lang.Class({
         this._ibusSources = {};
 
         this._currentSource = null;
+        this._passwordModeEnabled = false;
 
         // All valid input sources currently in the gsettings
         // KEY_INPUT_SOURCES list ordered by most recently used
@@ -480,6 +481,31 @@ const InputSourceManager = new Lang.Class({
             this._updateMruSettings();
     },
 
+    get passwordModeEnabled() {
+        return this._passwordModeEnabled;
+    },
+
+    set passwordModeEnabled(enable) {
+        if (this._passwordModeEnabled === enable)
+            return;
+
+        this._passwordModeEnabled = enable;
+        this._syncPasswordMode();
+    },
+
+    _syncPasswordMode: function() {
+        if (!this._passwordModeEnabled) {
+            this._updateInputSources(false);
+            return;
+        }
+
+        if (!this._mruSources.some(Lang.bind(this, function(src) {
+            return this._keyboardManager.isLatinLayout(src.id);
+        }))) {
+            this._updateInputSources(true);
+        }
+    },
+
     _updateMruSources: function() {
         let sourcesList = [];
         for (let i in this._inputSources)
@@ -526,6 +552,10 @@ const InputSourceManager = new Lang.Class({
     },
 
     _inputSourcesChanged: function() {
+        this._updateInputSources(false);
+    },
+
+    _updateInputSources: function(needsFallbackSource = false) {
         let sources = this._settings.inputSources;
         let nSources = sources.length;
 
@@ -563,7 +593,7 @@ const InputSourceManager = new Lang.Class({
                 infosList.push({ type: type, id: id, displayName: displayName, shortName: shortName });
         }
 
-        if (infosList.length == 0) {
+        if (infosList.length == 0 || needsFallbackSource) {
             let type = INPUT_SOURCE_TYPE_XKB;
             let id = KeyboardManager.DEFAULT_LAYOUT;
             let [ , displayName, shortName, , ] = this._xkbInfo.get_layout_info(id);
@@ -778,11 +808,12 @@ const InputSourceIndicator = new Lang.Class({
     Name: 'InputSourceIndicator',
     Extends: PanelMenu.Button,
 
-    _init: function() {
+    _init: function(parent, showLayout = true) {
         this.parent(0.0, _("Keyboard"));
 
         this._menuItems = {};
         this._indicatorLabels = {};
+        this._showLayoutItem = null;
 
         this._container = new Shell.GenericContainer();
         this._container.connect('get-preferred-width', Lang.bind(this, this._containerGetPreferredWidth));
@@ -801,8 +832,10 @@ const InputSourceIndicator = new Lang.Class({
         this.menu.addMenuItem(this._propSection);
         this._propSection.actor.hide();
 
-        this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
-        this._showLayoutItem = this.menu.addAction(_("Show Keyboard Layout"), Lang.bind(this, this._showLayout));
+        if (showLayout) {
+            this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
+            this._showLayoutItem = this.menu.addAction(_("Show Keyboard Layout"), Lang.bind(this, this._showLayout));
+        }
 
         Main.sessionMode.connect('updated', Lang.bind(this, this._sessionUpdated));
         this._sessionUpdated();
@@ -818,7 +851,8 @@ const InputSourceIndicator = new Lang.Class({
         // but at least for now it is used as "allow popping up windows
         // from shell menus"; we can always add a separate sessionMode
         // option if need arises.
-        this._showLayoutItem.actor.visible = Main.sessionMode.allowSettings;
+        if (this._showLayoutItem)
+            this._showLayoutItem.actor.visible = Main.sessionMode.allowSettings;
     },
 
     _sourcesChanged: function() {

--- a/src/shell-util.c
+++ b/src/shell-util.c
@@ -14,11 +14,21 @@
 #include <gdk-pixbuf/gdk-pixbuf.h>
 #include <gdk/gdkx.h>
 #include <meta/meta-shaped-texture.h>
+#include <xkbcommon/xkbcommon.h>
 
 #include <locale.h>
 #ifdef HAVE__NL_TIME_FIRST_WEEKDAY
 #include <langinfo.h>
 #endif
+
+#define DEFAULT_XKB_RULES_FILE "evdev"
+#define DEFAULT_XKB_MODEL "pc105"
+
+typedef struct _FindLatinKeysymsState
+{
+  gboolean *required_keysyms_found;
+  int n_required_keysyms;
+} FindLatinKeysymsState;
 
 static void
 stop_pick (ClutterActor       *actor,
@@ -491,4 +501,93 @@ shell_util_composite_capture_images (ClutterCapture  *captures,
   cairo_destroy (cr);
 
   return image;
+}
+
+static void
+find_latin_keysym (struct xkb_keymap *keymap,
+                   xkb_keycode_t      key,
+                   void              *data)
+{
+  FindLatinKeysymsState *state = data;
+  int n_keysyms, i;
+  const xkb_keysym_t *keysyms;
+
+  n_keysyms = xkb_keymap_key_get_syms_by_level (keymap,
+                                                key,
+                                                0,
+                                                0,
+                                                &keysyms);
+  for (i = 0; i < n_keysyms; i++)
+    {
+      xkb_keysym_t keysym = keysyms[i];
+      if (keysym >= XKB_KEY_a && keysym <= XKB_KEY_z)
+        {
+          unsigned int keysym_index = keysym - XKB_KEY_a;
+          if (!state->required_keysyms_found[keysym_index])
+            {
+              state->required_keysyms_found[keysym_index] = TRUE;
+              state->n_required_keysyms--;
+            }
+        }
+    }
+}
+
+static struct xkb_keymap *
+create_keymap (struct xkb_context *context,
+               const char         *layouts,
+               const char         *variants,
+               const char         *options)
+{
+    struct xkb_keymap *keymap;
+    struct xkb_rule_names rmlvo = {
+        .rules = DEFAULT_XKB_RULES_FILE,
+        .model = DEFAULT_XKB_MODEL,
+        .layout = layouts,
+        .variant = variants,
+        .options = options
+    };
+
+    if (!layouts || !variants || !options)
+        keymap = xkb_keymap_new_from_names (context, NULL, 0);
+    else
+        keymap = xkb_keymap_new_from_names (context, &rmlvo, 0);
+    if (!keymap)
+      {
+        fprintf (stderr,
+                 "Failed to compile RMLVO: '%s', '%s', '%s'\n",
+                 layouts, variants, options);
+        return NULL;
+      }
+
+    return keymap;
+}
+
+gboolean
+shell_util_needs_secondary_layout (const char *layouts,
+                                   const char *variants,
+                                   const char *options)
+{
+  gboolean required_keysyms_found[26];
+  FindLatinKeysymsState state = {
+    .required_keysyms_found = required_keysyms_found,
+    .n_required_keysyms = G_N_ELEMENTS (required_keysyms_found),
+  };
+  struct xkb_keymap *keymap;
+  struct xkb_context *ctx;
+  enum xkb_context_flags ctx_flags;
+
+  memset (required_keysyms_found, FALSE, sizeof (gboolean) * 26);
+
+  ctx_flags = XKB_CONTEXT_NO_DEFAULT_INCLUDES;
+  ctx = xkb_context_new (ctx_flags);
+  xkb_context_include_path_append_default (ctx);
+
+  keymap = create_keymap (ctx, layouts, variants, options);
+
+  xkb_keymap_key_for_each (keymap, find_latin_keysym, &state);
+
+  xkb_keymap_unref (keymap);
+  xkb_context_unref (ctx);
+
+  return state.n_required_keysyms != 0;
 }

--- a/src/shell-util.h
+++ b/src/shell-util.h
@@ -58,6 +58,10 @@ cairo_surface_t * shell_util_composite_capture_images (ClutterCapture  *captures
                                                        int              width,
                                                        int              height);
 
+gboolean shell_util_needs_secondary_layout (const char *layouts,
+                                            const char *variants,
+                                            const char *options);
+
 G_END_DECLS
 
 #endif /* __SHELL_UTIL_H__ */


### PR DESCRIPTION
This adds the infrastructure to verify that the current
keyboard layout in use is a latin one when the user is prompted
to enter a password. The code to determine if a keyboard
layout is a latin is using the function "find_latin_keysym"
borrowed from Mutter.

In the near future we will switch automatically to an available
latin layout. If no suitable layout is available we
fallback to the default layout 'en'. The change is reflected in
the layout switcher in the taskbar.

When the password entry is in a modal dialog and the keyboard
switcher in the taskbar can not be accessed, we add another
switcher in the dialog, next to the password entry. The changes
made using this switcher are propagated to the keyboard
switcher in the taskbar and the popover menu revealed by the
super+space keybinding.

The cases handled are the authPrompt used in the lock screen and
the login view, the polkitAgent used to unlock the user page
in the control center for editing, the network security dialog
dealing with passwords for a Wireless or VPN connection and
the dialog prompting for a password when mounting encrypted
partitions.

https://phabricator.endlessm.com/T19956