### PR TITLE
Revert "appDisplay: Only defer redisplay of the icon grid on startup"

### DIFF
--- a/js/ui/appDisplay.js
+++ b/js/ui/appDisplay.js
@@ -587,14 +587,14 @@ const AllView = new Lang.Class({
         this._redisplayWorkId = Main.initializeDeferredWork(this.actor, Lang.bind(this, this._redisplay));
 
         Shell.AppSystem.get_default().connect('installed-changed', Lang.bind(this, function() {
-            this._redisplay();
+            Main.queueDeferredWork(this._redisplayWorkId);
         }));
 
         IconGridLayout.layout.connect('changed', Lang.bind(this, function() {
-            this._redisplay();
+            Main.queueDeferredWork(this._redisplayWorkId);
         }));
         global.settings.connect('changed::' + EOS_ENABLE_APP_CENTER_KEY, Lang.bind(this, function() {
-            this._redisplay();
+            Main.queueDeferredWork(this._redisplayWorkId);
         }));
 
         this._addedFolderId = null;


### PR DESCRIPTION
This broke folders management in that the event blocker won't work
correctly after having dragged and dropped an icon inside a folder,
preventing further open folders from being correctly dismissed.

This reverts commit e25680b16b6f941c8d79b48cd70f6b0c8793619b.

https://phabricator.endlessm.com/T19982