### PR TITLE
search: reload search providers when installed applications change

### DIFF
--- a/js/ui/search.js
+++ b/js/ui/search.js
@@ -482,6 +482,9 @@ const SearchResults = new Lang.Class({
         this._searchSettings.connect('changed::disable-external', Lang.bind(this, this._reloadRemoteProviders));
         this._searchSettings.connect('changed::sort-order', Lang.bind(this, this._reloadRemoteProviders));
 
+        let appSystem = Shell.AppSystem.get_default();
+        appSystem.connect ('installed-changed', Lang.bind(this, this._reloadRemoteProviders));
+
         this._searchTimeoutId = 0;
         this._cancellable = new Gio.Cancellable();
 


### PR DESCRIPTION
Otherwise, a shell restart will be required after installing a new
application, before its results can be seen in search.

https://phabricator.endlessm.com/T20057