### PR TITLE
paswordMode, keyboardManager: expose isLatinLayout method over D-Bus

### DIFF
--- a/js/ui/status/keyboard.js
+++ b/js/ui/status/keyboard.js
@@ -22,6 +22,17 @@ const Util = imports.misc.util;
 const INPUT_SOURCE_TYPE_XKB = 'xkb';
 const INPUT_SOURCE_TYPE_IBUS = 'ibus';
 
+const InputSourceManagerIface = '<node> \
+<interface name="org.gnome.InputSourceManager"> \
+<method name="GetPasswordModeEnabled"> \
+    <arg type="b" direction="out" name="enabled"/> \
+</method> \
+<method name="SetPasswordModeEnabled"> \
+    <arg type="b" direction="in" name="enable"/> \
+</method> \
+</interface> \
+</node>';
+
 const LayoutMenuItem = new Lang.Class({
     Name: 'LayoutMenuItem',
     Extends: PopupMenu.PopupBaseMenuItem,
@@ -319,6 +330,9 @@ const InputSourceManager = new Lang.Class({
         this._currentSource = null;
         this._needsFallbackSource = false;
         this._passwordModeEnabled = false;
+        this._dbusImpl = Gio.DBusExportedObject.wrapJSObject(InputSourceManagerIface, this);
+        this._dbusImpl.export(Gio.DBus.session, '/org/gnome/Shell/InputSourceManager');
+        Gio.DBus.session.own_name('org.gnome.Shell.InputSourceManager', Gio.BusNameOwnerFlags.REPLACE, null, null);
 
         // All valid input sources currently in the gsettings
         // KEY_INPUT_SOURCES list ordered by most recently used
@@ -480,6 +494,14 @@ const InputSourceManager = new Lang.Class({
 
         if (interactive)
             this._updateMruSettings();
+    },
+
+    GetPasswordModeEnabled: function() {
+        return this._passwordModeEnabled;
+    },
+
+    SetPasswordModeEnabled: function(enable) {
+        this.passwordModeEnabled = enable;
     },
 
     get passwordModeEnabled() {


### PR DESCRIPTION
This can only handle layouts that are currently loaded
in the KeyboardManager.