### PR TITLE
Don't show the splash screen for an app that's already running

### DIFF
--- a/js/ui/appActivation.js
+++ b/js/ui/appActivation.js
@@ -33,6 +33,10 @@ const LAUNCH_MAXIMIZED_DESKTOP_KEY = 'X-Endless-LaunchMaximized';
 function _shouldShowSplash(app) {
     let info = app.get_app_info();
 
+    // Don't show the splash screen if the app is already running.
+    if (app.state == Shell.AppState.RUNNING)
+        return false;
+
     if (!(info && info.has_key(LAUNCH_MAXIMIZED_DESKTOP_KEY) &&
           info.get_boolean(LAUNCH_MAXIMIZED_DESKTOP_KEY)))
         return false;
@@ -123,9 +127,7 @@ const AppActivationContext = new Lang.Class({
                 });
             });
 
-            if (this._app.state != Shell.AppState.RUNNING)
-                this.showSplash();
-
+            this.showSplash();
             invoke();
         }));
     },


### PR DESCRIPTION
This was already being checked when activating and app over the
org.gnome.Shell.AppLauncher D-Bus interface, but surprisingly
enough not when activating an app from the search results.

To fix this and make it less error prone, incorporate the check
into _shouldShowSplash(), and remove it from anywhere else.

https://phabricator.endlessm.com/T20114