### PR TITLE
Bring back DnD operations inside folders

### DIFF
--- a/data/theme/gnome-shell.css
+++ b/data/theme/gnome-shell.css
@@ -2546,6 +2546,12 @@ stage {
   color: #222;
   icon-size: 30px; }
 
+.app-well-app.app-folder {
+  /* Avoid folder popups being positioned too far away */
+  width: 118px;
+  height: 118px;
+}
+
 .app-well-app .overview-icon,
 .app-well-app.app-folder .overview-icon {
   width: 118px;

--- a/js/ui/appDisplay.js
+++ b/js/ui/appDisplay.js
@@ -105,6 +105,9 @@ const EOS_DRAG_OVER_FOLDER_OPACITY = 128;
 
 const EOS_REPLACED_BY_KEY = 'X-Endless-Replaced-By';
 
+const EOS_NEW_ICON_ANIMATION_TIME = 0.5;
+const EOS_NEW_ICON_ANIMATION_DELAY = 0.7;
+
 function _getCategories(info) {
     let categoriesStr = info.get_categories();
     if (!categoriesStr)
@@ -218,6 +221,25 @@ const BaseAppView = new Lang.Class({
         return [movedList, removedList];
     },
 
+    _findAddedIcons: function() {
+        let oldItemLayout = this._allItems.map(function(icon) { return icon.getId(); });
+        if (oldItemLayout.length === 0)
+            return [];
+
+        let newItemLayout = this.getLayoutIds();
+        newItemLayout = this._trimInvisible(newItemLayout);
+
+        let addedIds = [];
+        for (let newItem of newItemLayout) {
+            let oldItemIdx = oldItemLayout.indexOf(newItem);
+
+            if (oldItemIdx < 0)
+                addedIds.push(newItem);
+        }
+
+        return addedIds;
+    },
+
     iconsNeedRedraw: function() {
         // Check if the icons moved around
         let [movedList, removedList] = this._findIconChanges();
@@ -266,6 +288,10 @@ const BaseAppView = new Lang.Class({
     },
 
     _loadApps: function() {
+        let addedIds = this._findAddedIcons();
+
+        this.removeAll();
+
         let ids = this.getLayoutIds();
 
         for (let itemId of ids) {
@@ -276,6 +302,9 @@ const BaseAppView = new Lang.Class({
             let icon = this._createItemIcon(item);
             if (!icon)
                 continue;
+
+            if (addedIds.indexOf(itemId) != -1)
+                icon.scheduleScaleIn();
 
             this.addItem(icon);
         }
@@ -293,7 +322,6 @@ const BaseAppView = new Lang.Class({
         if (!forceRedisplay && !this.iconsNeedRedraw())
             return;
 
-        this.removeAll();
         this._loadApps();
     },
 
@@ -1883,6 +1911,8 @@ const ViewIcon = new Lang.Class({
         this.canDrop = false;
         this.blockHandler = false;
 
+        this._scaleInId = 0;
+
         // Might be changed once the createIcon() method is called.
         this._iconSize = IconGrid.ICON_SIZE;
         this._iconState = ViewIconState.NORMAL;
@@ -1953,6 +1983,8 @@ const ViewIcon = new Lang.Class({
     },
 
     _onDestroy: function() {
+        this._unscheduleScaleIn();
+
         this.actor._delegate = null;
         this._removeMenuTimeout();
     },
@@ -2074,6 +2106,47 @@ const ViewIcon = new Lang.Class({
             return new St.Icon({ icon_size: this._iconSize });
 
         return this._createIconFunc(this._iconSize);
+    },
+
+    _scaleIn: function() {
+        this.actor.scale_x = 0;
+        this.actor.scale_y = 0;
+        this.actor.pivot_point = new Clutter.Point({ x: 0.5, y: 0.5 });
+
+        Tweener.addTween(this.actor, {
+            scale_x: 1,
+            scale_y: 1,
+            time: EOS_NEW_ICON_ANIMATION_TIME,
+            delay: EOS_NEW_ICON_ANIMATION_DELAY,
+            transition: function(t, b, c, d) {
+                // Similar to easeOutElastic, but less aggressive.
+                t /= d;
+                let p = 0.5;
+                return b + c * (Math.pow(2, -11 * t) * Math.sin(2 * Math.PI * (t - p / 4) / p) + 1);
+            }
+        });
+    },
+
+    _unscheduleScaleIn: function() {
+        if (this._scaleInId != 0) {
+            Main.overview.disconnect(this._scaleInId);
+            this._scaleInId = 0;
+        }
+    },
+
+    scheduleScaleIn: function() {
+        if (this._scaleInId != 0)
+            return;
+
+        if (Main.overview.visible) {
+            this._scaleIn();
+            return;
+        }
+
+        this._scaleInId = Main.overview.connect('shown', () => {
+            this._unscheduleScaleIn();
+            this._scaleIn();
+        });
     },
 
     remove: function() {

--- a/js/ui/appDisplay.js
+++ b/js/ui/appDisplay.js
@@ -173,6 +173,40 @@ const BaseAppView = new Lang.Class({
         // Nothing by default
     },
 
+    _createItemForId: function(itemId) {
+        if (IconGridLayout.layout.iconIsFolder(itemId))
+            return Shell.DesktopDirInfo.new(itemId);
+
+        return Shell.AppSystem.get_default().lookup_app(itemId);
+    },
+
+    _createItemIcon: function(item) {
+        throw new Error('Not implemented');
+    },
+
+    getLayoutIds: function() {
+        let viewId = this.getViewId();
+        return IconGridLayout.layout.getIcons(viewId).slice();
+    },
+
+    _loadApps: function() {
+        let ids = this.getLayoutIds();
+
+        for (let itemId of ids) {
+            let item = this._createItemForId(itemId);
+            if (!item)
+                continue;
+
+            let icon = this._createItemIcon(item);
+            if (!icon)
+                continue;
+
+            this.addItem(icon);
+        }
+
+        this.loadGrid();
+    },
+
     removeAll: function() {
         this._grid.destroyAll();
         this._items = {};
@@ -612,8 +646,28 @@ const AllView = new Lang.Class({
                                           // and set it to edit mode
                                           this._addedFolderId = id;
                                       }));
+    },
 
-        this._loadApps();
+    loadGrid: function() {
+        this._maybeAddAppCenterIcon();
+        this.parent();
+    },
+
+    getLayoutIds: function() {
+        let layoutIds = this.parent();
+
+        if (!global.settings.get_boolean(EOS_ENABLE_APP_CENTER_KEY))
+            return layoutIds;
+
+        let appSys = Shell.AppSystem.get_default();
+        if (appSys.lookup_app(EOS_APP_CENTER_ID)) {
+            // AllView also has the App Center icon appended at the end of the list.
+            // For Drag n' Drop work correctly, we must take this icon into account
+            // when calculating the diff between before and after the DnD.
+            layoutIds.push(EOS_APP_CENTER_ID);
+        }
+
+        return layoutIds;
     },
 
     removeAll: function() {
@@ -633,47 +687,47 @@ const AllView = new Lang.Class({
         this._grid.addItem(item, newIdx);
     },
 
-    _loadApps: function() {
-        let desktopIds = IconGridLayout.layout.getIcons(IconGridLayout.DESKTOP_GRID_ID);
+    _ensureAppCenterIcon: function() {
+        if (this._appCenterIcon)
+            return;
 
-        let items = [];
-        for (let idx in desktopIds) {
-            let itemId = desktopIds[idx];
-            items.push(itemId);
+        this._appCenterIcon = new AppCenterIcon(this);
+        this._appCenterItem = {
+            get_name: () => { return this._appCenterIcon.getName(); }
+        };
+    },
+
+    _createItemForId: function(itemId) {
+        if (itemId == EOS_APP_CENTER_ID) {
+            this._ensureAppCenterIcon();
+            return this._appCenterItem;
         }
 
-        let appSys = Shell.AppSystem.get_default();
+        return this.parent(itemId);
+    },
 
-        items.forEach(Lang.bind(this, function(itemId) {
-            let icon = null;
+    _createItemIcon: function(item) {
+        if (item == this._appCenterItem)
+            return this._appCenterIcon;
 
-            if (IconGridLayout.layout.iconIsFolder(itemId)) {
-                let item = Shell.DesktopDirInfo.new(itemId);
-                icon = new FolderIcon(item, this);
-                icon.connect('name-changed', Lang.bind(this, this._itemNameChanged));
-                this.folderIcons.push(icon);
-                if (this._addedFolderId == itemId) {
-                    this.selectAppWithLabelMode(this._addedFolderId, EditableLabelMode.EDIT);
-                    this._addedFolderId = null;
-                }
-            } else {
-                let app = appSys.lookup_app(itemId);
-                if (app)
-                    icon = new AppIcon(app,
-                                       { isDraggable: true,
-                                         parentView: this },
-                                       null);
-            }
+        let itemId = item.get_id();
 
-            // Some apps defined by the icon grid layout might not be installed
-            if (icon)
-                this.addItem(icon);
-        }));
+        if (!IconGridLayout.layout.iconIsFolder(itemId)) {
+            return new AppIcon(item,
+                               { isDraggable: true,
+                                 parentView: this },
+                               null);
+        }
 
-        // Add the App Center icon if it is enabled (and installed)
-        this._maybeAddAppCenterIcon();
+        let icon = new FolderIcon(item, this);
+        icon.connect('name-changed', this._itemNameChanged.bind(this));
+        this.folderIcons.push(icon);
+        if (this._addedFolderId == itemId) {
+            this.selectAppWithLabelMode(this._addedFolderId, EditableLabelMode.EDIT);
+            this._addedFolderId = null;
+        }
 
-        this.loadGrid();
+        return icon;
     },
 
     _maybeAddAppCenterIcon: function() {
@@ -689,7 +743,7 @@ const AllView = new Lang.Class({
             return;
         }
 
-        this._appCenterIcon = new AppCenterIcon(this);
+        this._ensureAppCenterIcon();
         this.addItem(this._appCenterIcon);
     },
 
@@ -1136,15 +1190,6 @@ const AllView = new Lang.Class({
             source.blockHandler = true;
             this._eventBlocker.reactive = false;
             this._currentPopup.popdown();
-
-            // Append the inserted app to the end of the grid
-            let appSystem = Shell.AppSystem.get_default();
-            let app  = appSystem.lookup_app(source.getId());
-            let icon = new AppIcon(app,
-                                   { isDraggable: true,
-                                     parentView: this },
-                                   null);
-            this.addItem(icon);
         }
 
         IconGridLayout.layout.repositionIcon(source.getId(), insertId, folderId);
@@ -1537,28 +1582,16 @@ const FolderView = new Lang.Class({
         this._redisplay();
     },
 
-    _loadApps: function() {
-        let appSys = Shell.AppSystem.get_default();
-        let addAppId = (function addAppId(appId) {
-            let app = appSys.lookup_app(appId);
-            if (!app)
-                return;
-
-            if (!app.get_app_info().should_show())
-                return;
-
-            let icon = new AppIcon(app,
-                                   { isDraggable: true,
-                                     parentView: this },
-                                   null);
-            this.addItem(icon);
-        }).bind(this);
-
-        let folderApps = IconGridLayout.layout.getIcons(this._dirInfo.get_id());
-        folderApps.forEach(addAppId);
-
-        this.loadGrid();
+    _redisplay: function() {
+        this.parent();
         this.updateNoAppsLabelVisibility();
+    },
+
+    _createItemIcon: function(item) {
+        return new AppIcon(item,
+                           { isDraggable: true,
+                             parentView: this },
+                           null);
     },
 
     updateNoAppsLabelVisibility: function() {

--- a/js/ui/appDisplay.js
+++ b/js/ui/appDisplay.js
@@ -1626,12 +1626,6 @@ const FolderView = new Lang.Class({
 
     getViewId: function() {
         return this._folderIcon.getId();
-    },
-
-    canDropAt: function(x, y, canDropPastEnd) {
-        // FIXME: Temporarily disable dragging elements around inside a
-        // folder, as it's causing the GrabHelper to crash for some reason.
-        return [-1, IconGrid.CursorLocation.DEFAULT];
     }
 });
 

--- a/js/ui/appDisplay.js
+++ b/js/ui/appDisplay.js
@@ -189,6 +189,82 @@ const BaseAppView = new Lang.Class({
         return IconGridLayout.layout.getIcons(viewId).slice();
     },
 
+    _trimInvisible: function(ids) {
+        let appSystem = Shell.AppSystem.get_default();
+        return ids.filter((id) => {
+            return IconGridLayout.layout.iconIsFolder(id) || appSystem.lookup_app(id) || (id == EOS_APP_CENTER_ID);
+        });
+    },
+
+    _findIconChanges: function() {
+        let oldItemLayout = this._allItems.map(function(icon) { return icon.getId(); });
+        let newItemLayout = this.getLayoutIds();
+        newItemLayout = this._trimInvisible(newItemLayout);
+
+        let movedList = new Map();
+        let removedList = [];
+        for (let oldItemIdx in oldItemLayout) {
+            let oldItem = oldItemLayout[oldItemIdx];
+            let newItemIdx = newItemLayout.indexOf(oldItem);
+
+            if (oldItemIdx != newItemIdx) {
+                if (newItemIdx < 0)
+                    removedList.push(oldItemIdx);
+                else
+                    movedList.set(oldItemIdx, newItemIdx);
+            }
+        }
+
+        return [movedList, removedList];
+    },
+
+    iconsNeedRedraw: function() {
+        // Check if the icons moved around
+        let [movedList, removedList] = this._findIconChanges();
+        if (movedList.size > 0 || removedList.length > 0)
+            return true;
+
+        // Create a map from app ids to icon objects
+        let iconTable = {};
+        for (let item of this._allItems)
+            iconTable[item.getId()] = item;
+
+        let layoutIds = this.getLayoutIds();
+
+        // Iterate through all visible icons
+        for (let itemId of layoutIds) {
+            let item = this._createItemForId(itemId);
+            if (!item)
+                continue;
+
+            // The App Center icon cannot be changed or renamed
+            if (item == this._appCenterItem)
+                continue;
+
+            let currentIcon = iconTable[itemId];
+
+            // This icon is new
+            if (!currentIcon)
+                return true;
+
+            // This icon was renamed out of band
+            if (currentIcon.getName() != item.get_name())
+                return true;
+
+            // currentIcon is a ViewIcon (AppIcon or FolderIcon).
+            let oldIconInfo = currentIcon.getIcon();
+
+            // item is either a ShellApp or a  ShellDesktopDirInfo.
+            let newIconInfo = item.get_icon();
+
+            // The icon image changed
+            if (newIconInfo && !newIconInfo.equal(oldIconInfo))
+                return true;
+        }
+
+        return false;
+    },
+
     _loadApps: function() {
         let ids = this.getLayoutIds();
 
@@ -214,6 +290,9 @@ const BaseAppView = new Lang.Class({
     },
 
     _redisplay: function() {
+        if (!this.iconsNeedRedraw())
+            return;
+
         this.removeAll();
         this._loadApps();
     },

--- a/js/ui/appDisplay.js
+++ b/js/ui/appDisplay.js
@@ -941,13 +941,9 @@ const AllView = new Lang.Class({
     _onDragBegin: function(overview, source) {
         // Save the currently dragged item info
         this._setupDragState(source);
-
-        // Hide the event blocker in all cases to allow for dash DnD
-        this._eventBlocker.hide();
     },
 
     _onDragEnd: function(overview, source) {
-        this._eventBlocker.show();
         this._clearDragState(source);
     },
 

--- a/js/ui/appDisplay.js
+++ b/js/ui/appDisplay.js
@@ -1830,7 +1830,15 @@ const ViewIcon = new Lang.Class({
         }
     },
 
+    getId: function() {
+        throw new Error('Not implemented');
+    },
+
     getName: function() {
+        throw new Error('Not implemented');
+    },
+
+    getIcon: function() {
         throw new Error('Not implemented');
     },
 
@@ -2093,12 +2101,16 @@ const FolderIcon = new Lang.Class({
             }));
     },
 
+    getId: function() {
+        return this._dirInfo.get_id();
+    },
+
     getName: function() {
         return this._name;
     },
 
-    getId: function() {
-        return this._dirInfo.get_id();
+    getIcon: function() {
+        return this._dirInfo.get_icon();
     },
 
     getAppIds: function() {
@@ -2469,8 +2481,16 @@ const AppIcon = new Lang.Class({
                                                            Lang.bind(this, this._sourceAdded));
     },
 
+    getId: function() {
+        return this.app.get_id();
+    },
+
     getName: function() {
         return this.name;
+    },
+
+    getIcon: function() {
+        return this.app.get_icon();
     },
 
     _onDestroy: function() {
@@ -2519,10 +2539,6 @@ const AppIcon = new Lang.Class({
             this._dot.show();
         else
             this._dot.hide();
-    },
-
-    getId: function() {
-        return this.app.get_id();
     },
 
     animateLaunch: function() {

--- a/js/ui/appDisplay.js
+++ b/js/ui/appDisplay.js
@@ -289,8 +289,8 @@ const BaseAppView = new Lang.Class({
         this._allItems = [];
     },
 
-    _redisplay: function() {
-        if (!this.iconsNeedRedraw())
+    _redisplay: function(forceRedisplay) {
+        if (!forceRedisplay && !this.iconsNeedRedraw())
             return;
 
         this.removeAll();
@@ -1658,12 +1658,35 @@ const FolderView = new Lang.Class({
         action.connect('pan', Lang.bind(this, this._onPan));
         this.actor.add_action(action);
 
-        this._redisplay();
+        this.actor.connect('notify::mapped', (actor) => {
+            // The only way to make the folder popover get the correct sizing
+            // is by removing and re-adding all the icons. To not hit the
+            // performance too badly, only do that when absolutely necessary.
+            if (this.actor.mapped)
+                this._redisplay(true);
+        });
+
+        this._redisplayFolderWorkId = Main.initializeDeferredWork(this._folderIcon.actor, () => { this._redisplay(); });
+        let layoutChangedId = IconGridLayout.layout.connect('changed', () => {
+            // AllView only checks for the toplevel icons, not those inside folders.
+            Main.queueDeferredWork(this._redisplayFolderWorkId);
+        });
+
+        this._folderIcon.actor.connect('destroy', () => {
+            // The deferred work will not be valid after the folderIcon is destroyed.
+            IconGridLayout.layout.disconnect(layoutChangedId);
+        });
+
+        // Don't call _redisplay() here, since that will call reloadIcon() which, besides
+        // not been needed at this point, will fail due to the view not being created yet.
+        this._loadApps();
+        this.updateNoAppsLabelVisibility();
     },
 
-    _redisplay: function() {
-        this.parent();
+    _redisplay: function(forceRedisplay) {
+        this.parent(forceRedisplay);
         this.updateNoAppsLabelVisibility();
+        this._folderIcon.icon.reloadIcon();
     },
 
     _createItemIcon: function(item) {

--- a/js/ui/appDisplay.js
+++ b/js/ui/appDisplay.js
@@ -648,7 +648,8 @@ const AllView = new Lang.Class({
             let icon = null;
 
             if (IconGridLayout.layout.iconIsFolder(itemId)) {
-                icon = new FolderIcon(itemId, this);
+                let item = Shell.DesktopDirInfo.new(itemId);
+                icon = new FolderIcon(item, this);
                 icon.connect('name-changed', Lang.bind(this, this._itemNameChanged));
                 this.folderIcons.push(icon);
                 if (this._addedFolderId == itemId) {
@@ -2022,7 +2023,7 @@ const FolderIcon = new Lang.Class({
     Name: 'FolderIcon',
     Extends: ViewIcon,
 
-    _init: function(id, parentView) {
+    _init: function(dirInfo, parentView) {
         let viewIconParams = { isDraggable: true,
                                parentView: parentView };
         let buttonParams = { button_mask: St.ButtonMask.ONE,
@@ -2030,11 +2031,12 @@ const FolderIcon = new Lang.Class({
         let iconParams = { createIcon: Lang.bind(this, this._createIcon),
                            setSizeManually: false,
                            editable: true };
-        this.id = id;
+
         this.name = '';
         this._parentView = parentView;
 
-        this._dirInfo = Shell.DesktopDirInfo.new(id);
+        this.id = dirInfo.get_id();
+        this._dirInfo = dirInfo;
         this._name = this._dirInfo.get_name();
 
         this.parent(viewIconParams, buttonParams, iconParams);

--- a/js/ui/appDisplay.js
+++ b/js/ui/appDisplay.js
@@ -213,6 +213,9 @@ const BaseAppView = new Lang.Class({
     },
 
     getIconForIndex: function(index) {
+        if (index < 0 || index >= this._allItems.length)
+            return null;
+
         return this._allItems[index];
     },
 

--- a/js/ui/dnd.js
+++ b/js/ui/dnd.js
@@ -94,6 +94,7 @@ const _Draggable = new Lang.Class({
             this.disconnectAll();
         }));
         this._onEventId = null;
+        this._touchSequence = null;
 
         this._restoreOnSuccess = params.restoreOnSuccess;
         this._dragActorMaxSize = params.dragActorMaxSize;

--- a/js/ui/iconGrid.js
+++ b/js/ui/iconGrid.js
@@ -1,7 +1,9 @@
 // -*- mode: js; js-indent-level: 4; indent-tabs-mode: nil -*-
 
 const Clutter = imports.gi.Clutter;
+const GLib = imports.gi.GLib;
 const Gtk = imports.gi.Gtk;
+const Mainloop = imports.mainloop;
 const Meta = imports.gi.Meta;
 const Shell = imports.gi.Shell;
 const Signals = imports.signals;
@@ -1208,14 +1210,26 @@ const PaginatedIconGrid = new Lang.Class({
             Tweener.addTween(this._translatedChildren[i],
                              { translation_y: 0,
                                time: EXTRA_SPACE_ANIMATION_TIME,
-                               transition: 'easeInOutQuad',
-                               onComplete: Lang.bind(this,
-                                   function() {
-                                       this._extraSpaceData = null;
-                                       this.emit('space-closed');
-                                   })
+                               transition: 'easeInOutQuad'
                              });
         }
+
+        // This is not entirely correct since we should ideally do
+        // this on onComplete, but in our current implementation of
+        // folders and DnD it can happen that the actor of the icons
+        // we are moving back into their position get destroyed before
+        // the tween completes (e.g. dragging icons out of folders),
+        // meaning that the onComplete callback is never called, and
+        // leaving this in an inconsistent state.
+        //
+        // As a temporary solution for now, let's assume that the folder
+        // will be closed after EXTRA_SPACE_ANIMATION_TIME and reset the
+        // status + emit the space-closed signal only once at that point.
+        Mainloop.timeout_add_seconds(EXTRA_SPACE_ANIMATION_TIME * St.get_slow_down_factor(), () => {
+            this._extraSpaceData = null;
+            this.emit('space-closed');
+            return GLib.SOURCE_REMOVE;
+        });
     }
 });
 Signals.addSignalMethods(PaginatedIconGrid.prototype);

--- a/js/ui/workspace.js
+++ b/js/ui/workspace.js
@@ -1113,6 +1113,7 @@ const Workspace = new Lang.Class({
         // do some simple aspect ratio like math to fit the layout calculated
         // for the full geometry into this area.
         this._actualGeometry = null;
+        this._actualGeometryLater = 0;
 
         this._currentLayout = null;
 

--- a/js/ui/workspaceSwitcherPopup.js
+++ b/js/ui/workspaceSwitcherPopup.js
@@ -31,6 +31,7 @@ const WorkspaceSwitcherPopup = new Lang.Class({
         this._itemSpacing = 0;
         this._childHeight = 0;
         this._childWidth = 0;
+        this._timeoutId = 0;
         this._list.connect('style-changed', Lang.bind(this, function() {
                                                         this._itemSpacing = this._list.get_theme_node().get_length('spacing');
                                                      }));

--- a/src/shell-app.c
+++ b/src/shell-app.c
@@ -292,6 +292,21 @@ shell_app_get_description (ShellApp *app)
 }
 
 /**
+ * shell_app_get_icon:
+ * @app: a #ShellApp
+ *
+ * Returns: (transfer none): The #GIcon associated with this app, or %NULL if none is available.
+ */
+GIcon *
+shell_app_get_icon (ShellApp *app)
+{
+  if (app->info)
+    return g_app_info_get_icon (G_APP_INFO (app->info));
+  else
+    return NULL;
+}
+
+/**
  * shell_app_is_window_backed:
  *
  * A window backed application is one which represents just an open

--- a/src/shell-app.h
+++ b/src/shell-app.h
@@ -26,6 +26,8 @@ ClutterActor *shell_app_create_icon_texture (ShellApp *app, int size);
 const char *shell_app_get_name (ShellApp *app);
 const char *shell_app_get_generic_name (ShellApp *app);
 const char *shell_app_get_description (ShellApp *app);
+GIcon *shell_app_get_icon (ShellApp *app);
+
 gboolean shell_app_is_window_backed (ShellApp *app);
 
 void shell_app_activate_window (ShellApp *app, MetaWindow *window, guint32 timestamp);


### PR DESCRIPTION
Rebase of the previous work started in this branch in August, incorporating the changes done by @GeorgesStavracas in https://github.com/endlessm/gnome-shell/pull/165 and (hopefully) finishing it by simplifying it and fixing all the issues observed in that PR.

Main changes with regard to https://github.com/endlessm/gnome-shell/pull/165:
  * Removed the animations performed when "reshuffling" icons on the desktop, as a result of DnD. Those animations were still pretty confusing as implemented in the previous PR (source of the animation did not match where the icon was being dropped from), and on top of that were inconsistent since no animations were shown when DnD'ing inside folders, so I'll file a new ticket for those and keep them out of this one, which should be focused on re-enabling DnD inside folders.
  * Removed the hack to initialize the extra space taken by folders by making sure the estate is always reset after closing a popup. Still a workaround, but it seems to work better since it makes sure the state is correct right after closing a popup, without waiting until another folder is opened again.
  * Fixed the problem that was printing the backtrace mentioned above by making sure that any callback from which we would run a deferred job gets disconnected when the folder icon's actor is destroyed.
  * Removed the animation that was supposed to happen on startup, as it was causing trouble and was not related to this story anyway.
  * Cleaned up the commit history, by making smaller and clearer (hopefully) commits, removing everything that is not actually needed.

This PR replaces #165, so closing that one.

https://phabricator.endlessm.com/T18012