### PR TITLE
appDisplay: Add a scale-in animation when adding new icons to the grid

### DIFF
--- a/js/ui/appDisplay.js
+++ b/js/ui/appDisplay.js
@@ -105,6 +105,9 @@ const EOS_DRAG_OVER_FOLDER_OPACITY = 128;
 
 const EOS_REPLACED_BY_KEY = 'X-Endless-Replaced-By';
 
+const EOS_NEW_ICON_ANIMATION_TIME = 0.5;
+const EOS_NEW_ICON_ANIMATION_DELAY = 0.7;
+
 function _getCategories(info) {
     let categoriesStr = info.get_categories();
     if (!categoriesStr)
@@ -218,6 +221,25 @@ const BaseAppView = new Lang.Class({
         return [movedList, removedList];
     },
 
+    _findAddedIcons: function() {
+        let oldItemLayout = this._allItems.map(function(icon) { return icon.getId(); });
+        if (oldItemLayout.length === 0)
+            return [];
+
+        let newItemLayout = this.getLayoutIds();
+        newItemLayout = this._trimInvisible(newItemLayout);
+
+        let addedIds = [];
+        for (let newItem of newItemLayout) {
+            let oldItemIdx = oldItemLayout.indexOf(newItem);
+
+            if (oldItemIdx < 0)
+                addedIds.push(newItem);
+        }
+
+        return addedIds;
+    },
+
     iconsNeedRedraw: function() {
         // Check if the icons moved around
         let [movedList, removedList] = this._findIconChanges();
@@ -266,6 +288,10 @@ const BaseAppView = new Lang.Class({
     },
 
     _loadApps: function() {
+        let addedIds = this._findAddedIcons();
+
+        this.removeAll();
+
         let ids = this.getLayoutIds();
 
         for (let itemId of ids) {
@@ -276,6 +302,9 @@ const BaseAppView = new Lang.Class({
             let icon = this._createItemIcon(item);
             if (!icon)
                 continue;
+
+            if (addedIds.indexOf(itemId) != -1)
+                icon.scheduleScaleIn();
 
             this.addItem(icon);
         }
@@ -293,7 +322,6 @@ const BaseAppView = new Lang.Class({
         if (!forceRedisplay && !this.iconsNeedRedraw())
             return;
 
-        this.removeAll();
         this._loadApps();
     },
 
@@ -1883,6 +1911,8 @@ const ViewIcon = new Lang.Class({
         this.canDrop = false;
         this.blockHandler = false;
 
+        this._scaleInId = 0;
+
         // Might be changed once the createIcon() method is called.
         this._iconSize = IconGrid.ICON_SIZE;
         this._iconState = ViewIconState.NORMAL;
@@ -1953,6 +1983,8 @@ const ViewIcon = new Lang.Class({
     },
 
     _onDestroy: function() {
+        this._unscheduleScaleIn();
+
         this.actor._delegate = null;
         this._removeMenuTimeout();
     },
@@ -2074,6 +2106,47 @@ const ViewIcon = new Lang.Class({
             return new St.Icon({ icon_size: this._iconSize });
 
         return this._createIconFunc(this._iconSize);
+    },
+
+    _scaleIn: function() {
+        this.actor.scale_x = 0;
+        this.actor.scale_y = 0;
+        this.actor.pivot_point = new Clutter.Point({ x: 0.5, y: 0.5 });
+
+        Tweener.addTween(this.actor, {
+            scale_x: 1,
+            scale_y: 1,
+            time: EOS_NEW_ICON_ANIMATION_TIME,
+            delay: EOS_NEW_ICON_ANIMATION_DELAY,
+            transition: function(t, b, c, d) {
+                // Similar to easeOutElastic, but less aggressive.
+                t /= d;
+                let p = 0.5;
+                return b + c * (Math.pow(2, -11 * t) * Math.sin(2 * Math.PI * (t - p / 4) / p) + 1);
+            }
+        });
+    },
+
+    _unscheduleScaleIn: function() {
+        if (this._scaleInId != 0) {
+            Main.overview.disconnect(this._scaleInId);
+            this._scaleInId = 0;
+        }
+    },
+
+    scheduleScaleIn: function() {
+        if (this._scaleInId != 0)
+            return;
+
+        if (Main.overview.visible) {
+            this._scaleIn();
+            return;
+        }
+
+        this._scaleInId = Main.overview.connect('shown', () => {
+            this._unscheduleScaleIn();
+            this._scaleIn();
+        });
     },
 
     remove: function() {


### PR DESCRIPTION
This brings back the nice "bounce" animation we had in the old version
of the shell, that is run whenever a new icon is added to the icon
grid (e.g. Added to desktop from the App Center).

PS: Note that this PR goes against T18012 instead of master, as it depends on it to work.

https://phabricator.endlessm.com/T20087