### PR TITLE
Disable the background menu when in initial-setup mode

### DIFF
--- a/js/ui/backgroundMenu.js
+++ b/js/ui/backgroundMenu.js
@@ -44,6 +44,11 @@ const BackgroundMenu = new Lang.Class({
 });
 
 function _addBackgroundMenuFull(actor, clickAction, layoutManager) {
+    // We don't want the background menu enabled on the desktop
+    // during the FBE, or in any mode without an overview, fwiw.
+    if (!Main.sessionMode.hasOverview)
+        return;
+
     // Either the actor or the action has to be defined
     if (!actor && !clickAction)
         return;


### PR DESCRIPTION
Otherwise it's possible to launch the App Center from it and,
with some additional effort, ending up executing anything even
before the FBE is finished.

https://phabricator.endlessm.com/T20471