### PR TITLE
panelMenu: Set the clicked state on more modifiers

### DIFF
--- a/js/ui/panelMenu.js
+++ b/js/ui/panelMenu.js
@@ -137,7 +137,9 @@ const Button = new Lang.Class({
              event.type() == Clutter.EventType.BUTTON_PRESS))
             this.menu.toggle();
 
-        if (event.get_state() & Clutter.ModifierType.BUTTON1_MASK)
+        if ((event.get_state() & Clutter.ModifierType.BUTTON1_MASK) ||
+            (event.get_state() & Clutter.ModifierType.BUTTON2_MASK) ||
+            (event.get_state() & Clutter.ModifierType.BUTTON3_MASK))
             this.actor.add_style_pseudo_class('clicked');
         else
             this.actor.remove_style_pseudo_class('clicked');


### PR DESCRIPTION
The current code only qualifies the first button (usually
the left mouse button) as the qualifier for setting the
'clicked' pseudo class, when in fact all the three buttons
can trigger the popup menu.

Fix that by setting the clicked state on more buttons.

Should be squashed to 603c34c350c5 next rebase.

https://phabricator.endlessm.com/T20327