### PR TITLE
fixup! shell-app-system: Report an event when an application opens/closes

### DIFF
--- a/src/shell-app-system.c
+++ b/src/shell-app-system.c
@@ -565,12 +565,13 @@ _shell_app_system_notify_app_state_changed (ShellAppSystem *self,
   switch (state)
     {
     case SHELL_APP_STATE_RUNNING:
-      {
-        emtr_event_recorder_record_start (emtr_event_recorder_get_default (),
-                                          SHELL_APP_IS_OPEN_EVENT,
-                                          g_variant_new ("s", app_address),
-                                          g_variant_new ("s", app_info_id));
-      }
+      if (app_info_id != NULL)
+        {
+          emtr_event_recorder_record_start (emtr_event_recorder_get_default (),
+                                            SHELL_APP_IS_OPEN_EVENT,
+                                            g_variant_new_string (app_address),
+                                            g_variant_new_string (app_info_id));
+        }
       g_hash_table_insert (self->priv->running_apps, g_object_ref (app), NULL);
       g_hash_table_remove (self->priv->starting_apps, app);
       break;
@@ -582,7 +583,7 @@ _shell_app_system_notify_app_state_changed (ShellAppSystem *self,
         {
           emtr_event_recorder_record_stop (emtr_event_recorder_get_default (),
                                            SHELL_APP_IS_OPEN_EVENT,
-                                           g_variant_new ("s", app_address),
+                                           g_variant_new_string (app_address),
                                            NULL);
         }
       break;


### PR DESCRIPTION
If a window opens for which the Shell can't find an app ID, Shell logs
the following message to the journal:

Jan 05 18:09:11 endless gnome-shell[3003]: g_variant_new_string: assertion 'string != NULL' failed

This is because g_variant_new ("s", NULL) ultimately calls
g_variant_new_string (NULL) which is illegal. The
SHELL_APP_STATE_STOPPED branch has this NULL check, but it was missing
in the SHELL_APP_STATE_RUNNING branch.

While we are here, let's call g_variant_new_string() directly.