### PR TITLE
appActivation: Disconnect from the SplashClosed D-Bus signal

### DIFF
--- a/js/ui/appActivation.js
+++ b/js/ui/appActivation.js
@@ -333,7 +333,7 @@ const SpeedwagonSplash = new Lang.Class({
         this._proxy = new SpeedwagonProxy(Gio.DBus.session,
                                           'com.endlessm.Speedwagon',
                                           '/com/endlessm/Speedwagon');
-        this._proxy.connectSignal('SplashClosed', Lang.bind(this, function() {
+        this._splashClosedId = this._proxy.connectSignal('SplashClosed', Lang.bind(this, function() {
             this.emit('close-clicked');
         }));
     },
@@ -344,6 +344,7 @@ const SpeedwagonSplash = new Lang.Class({
 
     rampOut: function() {
         this._proxy.HideSplashRemote(this._app.get_id());
+        this._proxy.disconnectSignal(this._splashClosedId);
     },
 });
 Signals.addSignalMethods(SpeedwagonSplash.prototype);


### PR DESCRIPTION
Otherwise, the callback will be called for any running app that
has ever shown the Speedwagon window, forcing them to close if
another Speedwagon window shown afterwards is manually closed.

https://phabricator.endlessm.com/T20699