### PR TITLE
shell-app: Make sure an app gets closed after closing its splash screen

### DIFF
--- a/js/ui/appActivation.js
+++ b/js/ui/appActivation.js
@@ -184,7 +184,9 @@ const AppActivationContext = new Lang.Class({
         }
 
         if (this._splash) {
-            this._splash.rampOut();
+            // The splash screen is already gone if manually aborted.
+            if (!this._abort)
+                this._splash.rampOut();
             this._splash = null;
         }
     },


### PR DESCRIPTION
Stop relying on the SplashClosed D-Bus signal from speedwagon, which causes race conditions we'd need to deal with since such signal arrives normally after the application being launched moves to a STOPPED state, as per the speedwagon's window being explicitly closed.

Instead, keep the signal callback for 'app-state-changed' alive for a little longer so that we can defer quitting an application whose splash screen has been manually closed until the app reaches the RUNNING state.

https://phabricator.endlessm.com/T20725