### PR TITLE
remoteSearch: fix search order for apps on desktop

### DIFF
--- a/js/ui/remoteSearch.js
+++ b/js/ui/remoteSearch.js
@@ -174,11 +174,11 @@ function loadRemoteSearchProviders(searchSettings, callback) {
                         appIdB == CONTROL_CENTER_DESKTOP_ID);
 
             // if providerA is on the desktop, it's sorted before providerB
-            if (hasA)
+            if (hasA && !hasB)
                 return -1;
 
             // if providerB is on the desktop, it's sorted before providerA
-            if (hasB)
+            if (hasB && !hasA)
                 return 1;
 
             // fall back to alphabetical order


### PR DESCRIPTION
The search order properly put prioritized apps first, then apps
that are on the desktop, and finally apps that are installed
but not on the desktop.  The apps not on the desktop
were properly sorted alphabetically, but the apps that are on
the desktop were not sorted alphabetically with the old logic.

https://phabricator.endlessm.com/T15929