### PR TITLE
search: Fix style of the round search icon in RTL languages

### DIFF
--- a/data/theme/gnome-shell-sass/_endless.scss
+++ b/data/theme/gnome-shell-sass/_endless.scss
@@ -555,8 +555,8 @@ popup-separator-menu-item {
 
     &:hover, &:focus { background-color: rgba(255, 255, 255, 0.95); }
     &:rtl {
-        padding-left: 4px;
-        padding-right: 8px;
+        padding-left: 12px;
+        padding-right: 0px;
     }
 }
 


### PR DESCRIPTION
I'm not sure how this could have worked before, but now we're using
SASS it's very clear that we need to swap the left/right paddings
used by default (0/12) when in RTL languages.

This should be squashed along with ee3f4f070d in future rebases.

https://phabricator.endlessm.com/T21235