### PR TITLE
loginDialog: Fix vertical misalignment of items in the users list

### DIFF
--- a/data/theme/gnome-shell-sass/_endless.scss
+++ b/data/theme/gnome-shell-sass/_endless.scss
@@ -11,6 +11,21 @@
 // is probably the best way forward (e.g. modifying _common.css for $font-family)).
 
 
+// Login dialog
+
+.login-dialog-user-list-item {
+    .login-dialog-timed-login-indicator {
+        // Don't allocate this space in CSS, do it in code instead
+        height: 0px;
+        margin: 0;
+
+        &:showing {
+            height: 2px;
+            margin: 2px 0 0 0;
+        }
+    }
+}
+
 // Lock screen
 
 #lockDialogGroup {

--- a/js/gdm/loginDialog.js
+++ b/js/gdm/loginDialog.js
@@ -126,6 +126,7 @@ var UserListItem = new Lang.Class({
         let hold = new Batch.Hold();
 
         this.hideTimedLoginIndicator();
+        this._timedLoginIndicator.add_style_pseudo_class('showing')
         Tweener.addTween(this._timedLoginIndicator,
                          { scale_x: 1.,
                            time: time,
@@ -141,6 +142,7 @@ var UserListItem = new Lang.Class({
     hideTimedLoginIndicator: function() {
         Tweener.removeTweens(this._timedLoginIndicator);
         this._timedLoginIndicator.scale_x = 0.;
+        this._timedLoginIndicator.remove_style_pseudo_class('showing')
     }
 });
 Signals.addSignalMethods(UserListItem.prototype);


### PR DESCRIPTION
For each item in the users list there is a vertical box packing exactly
an horizontal box with the user's avatar and name, and a small StBin for
the progress bar used for timed logins. The problem is that this second
actor is always taking up 2px of vertical space regardless of whether such
progress bar is visible or not, causing a permanent vertical misalignment
for the rest of cases, which happen to be the most common.

Fix this, by making sure that the 2px height and margin allocated for that
progress bar is only assigned when actually showing it, not always.

https://phabricator.endlessm.com/T21694