### PR TITLE
payg: Integrate the PAYG unlock dialog with the login screen

### DIFF
--- a/js/gdm/loginDialog.js
+++ b/js/gdm/loginDialog.js
@@ -525,6 +525,10 @@ var LoginDialog = new Lang.Class({
         // focus later
         this._startupCompleteId = Main.layoutManager.connect('startup-complete',
                                                              Lang.bind(this, this._updateDisableUserList));
+
+        // With PAYG machines this class can be created AFTER the startup process.
+        if (!Main.layoutManager.startingUp)
+            this._updateDisableUserList();
     },
 
     _getBannerAllocation: function (dialogBox) {

--- a/js/ui/screenShield.js
+++ b/js/ui/screenShield.js
@@ -600,15 +600,16 @@ var ScreenShield = new Lang.Class({
                 return;
             }
 
-            if (Main.sessionMode.currentMode == 'unlock-dialog-payg') {
+            let paygExpectedMode = this._isGreeter ? 'gdm-unlock-dialog-payg' : 'unlock-dialog-payg';
+            if (Main.sessionMode.currentMode == paygExpectedMode) {
                 // This is the most common case.
-                Main.sessionMode.popMode('unlock-dialog-payg');
+                Main.sessionMode.popMode(paygExpectedMode);
             } else if (Main.sessionMode.currentMode == 'lock-screen') {
                 // There's a chance we could be in the screen shield, instead of the
                 // unlock dialog, if the user wend back manually to it (e.g. pressed ESC)
                 // between introducing the code and the actual verification happening.
                 Main.sessionMode.popMode('lock-screen');
-                Main.sessionMode.popMode('unlock-dialog-payg');
+                Main.sessionMode.popMode(paygExpectedMode);
                 Main.sessionMode.pushMode('lock-screen');
             }
 
@@ -967,6 +968,9 @@ var ScreenShield = new Lang.Class({
         this._isGreeter = Main.sessionMode.isGreeter;
         this._isLocked = true;
 
+        if (this._isGreeter && Main.paygManager.isLocked)
+            Main.sessionMode.pushMode('gdm-unlock-dialog-payg');
+
         if (this._ensureUnlockDialog(true, true))
             this._hideLockScreen(false, 0);
     },
@@ -1276,6 +1280,8 @@ var ScreenShield = new Lang.Class({
 
         if (Main.sessionMode.currentMode == 'lock-screen')
             Main.sessionMode.popMode('lock-screen');
+        if (Main.sessionMode.currentMode == 'gdm-unlock-dialog-payg')
+            Main.sessionMode.popMode('gdm-unlock-dialog-payg');
         if (Main.sessionMode.currentMode == 'unlock-dialog-payg')
             Main.sessionMode.popMode('unlock-dialog-payg');
         if (Main.sessionMode.currentMode == 'unlock-dialog')

--- a/js/ui/sessionMode.js
+++ b/js/ui/sessionMode.js
@@ -55,6 +55,11 @@ const _modes = {
         panelStyle: 'login-screen'
     },
 
+    'gdm-unlock-dialog-payg': {
+        parentMode: 'gdm',
+        unlockDialog: imports.ui.paygUnlockDialog.PaygUnlockDialog,
+    },
+
     'lock-screen': {
         isLocked: true,
         isGreeter: undefined,


### PR DESCRIPTION
This integrates the PAYG unlock dialog in the login screen, making sure that such dialog is shown on boot & logout when the machine is locked.

https://phabricator.endlessm.com/T21609