### PR TITLE
payg: Don't auto-lock out of user sessions based on PAYG status

### DIFF
--- a/js/ui/screenShield.js
+++ b/js/ui/screenShield.js
@@ -1425,11 +1425,17 @@ var ScreenShield = new Lang.Class({
 
     // If the previous shell crashed, and gnome-session restarted us, then re-lock
     lockIfWasLocked: function() {
-        if (!this._settings.get_boolean(LOCK_ENABLED_KEY) && !Main.paygManager.isLocked)
+        // We need to add some extra checks for PAYG becasue we don't want to
+        // end up loging the screen for not regular sessions (e.g. initial-setup).
+        let shouldLockForPayg = Main.paygManager.isLocked &&
+            (Main.sessionMode.currentMode == 'user' ||
+             Main.sessionMode.currentMode == 'user-coding');
+
+        if (!this._settings.get_boolean(LOCK_ENABLED_KEY) && !shouldLockForPayg)
             return;
 
         let wasLocked = global.get_runtime_state('b',LOCKED_STATE_STR);
-        if (wasLocked === null && !Main.paygManager.isLocked)
+        if (wasLocked === null && !shouldLockForPayg)
             return;
         Meta.later_add(Meta.LaterType.BEFORE_REDRAW, Lang.bind(this, function() {
             this.lock(false);


### PR DESCRIPTION
The lockIfWasLocked routine is meant to automatically lock a machine
if it was locked before to protect against crashes while running a
session, and we added extra checks for PAYG to make sure we consider
that as well when deciding whether we should lock or not.

However, those checks are not good enough since we want to make sure
we only consider PAYG to force locking the machine there when running
a session, otherwise we would run into weird states when this code is
run from other session modes such as 'initial-setup' (which breaks FBE).

https://phabricator.endlessm.com/T21830