### PR TITLE
Backport the PAYG implementation into EOS 3.3

### DIFF
--- a/data/theme/gnome-shell.css
+++ b/data/theme/gnome-shell.css
@@ -2727,3 +2727,82 @@ stage {
   box-shadow: none;
   border: 1px solid #454f52;
 }
+
+/* Pay-As-You-Go unlock screen (generated from SASS sources in master) */
+
+.unlock-dialog-payg {
+  border: none;
+  background-color: transparent; }
+  .unlock-dialog-payg .modal-dialog-button-box {
+    spacing: 3px; }
+  .unlock-dialog-payg .modal-dialog-button {
+    padding: 3px 18px; }
+    .unlock-dialog-payg .modal-dialog-button:default {
+      color: #eeeeec;
+      background-color: rgba(33, 93, 156, 0.5);
+      border-color: rgba(0, 0, 0, 0.7);
+      box-shadow: inset 0 1px #454f52;
+      text-shadow: 0 1px black;
+      icon-shadow: 0 1px black; }
+      .unlock-dialog-payg .modal-dialog-button:default:hover, .unlock-dialog-payg .modal-dialog-button:default:focus {
+        color: white;
+        border-color: rgba(0, 0, 0, 0.7);
+        background-color: rgba(33, 93, 156, 0.7);
+        box-shadow: inset 0 1px #5d696d;
+        text-shadow: 0 1px black;
+        icon-shadow: 0 1px black; }
+      .unlock-dialog-payg .modal-dialog-button:default:active {
+        color: white;
+        border-color: rgba(0, 0, 0, 0.7);
+        background-color: #1c5187;
+        box-shadow: inset 0 0 black;
+        text-shadow: none;
+        icon-shadow: none; }
+      .unlock-dialog-payg .modal-dialog-button:default:insensitive {
+        color: #949796;
+        border-color: rgba(0, 0, 0, 0.7);
+        background-color: rgba(66, 72, 73, 0.7);
+        box-shadow: none;
+        text-shadow: none;
+        icon-shadow: none; }
+  .unlock-dialog-payg .unlock-dialog-payg-layout {
+    padding-top: 24px;
+    padding-bottom: 12px;
+    spacing: 8px; }
+    .unlock-dialog-payg .unlock-dialog-payg-layout .unlock-dialog-payg-title {
+      color: #eeeeec;
+      font-size: 24px;
+      font-weight: bold;
+      text-align: left;
+      margin: 24px; }
+    .unlock-dialog-payg .unlock-dialog-payg-layout .unlock-dialog-payg-promptbox {
+      spacing: 6px;
+      min-width: 370px; }
+    .unlock-dialog-payg .unlock-dialog-payg-layout .unlock-dialog-payg-label {
+      color: #bebeb6;
+      font-size: 110%;
+      padding-top: 1em; }
+    .unlock-dialog-payg .unlock-dialog-payg-layout .unlock-dialog-payg-entry {
+      font-size: 24px;
+      padding-left: 12px;
+      padding-right: 12px;
+      letter-spacing: 12px; }
+    .unlock-dialog-payg .unlock-dialog-payg-layout .unlock-dialog-payg-session-list-button {
+      color: #a6a69b; }
+      .unlock-dialog-payg .unlock-dialog-payg-layout .unlock-dialog-payg-session-list-button:hover, .unlock-dialog-payg .unlock-dialog-payg-layout .unlock-dialog-payg-session-list-button:focus {
+        color: #eeeeec; }
+      .unlock-dialog-payg .unlock-dialog-payg-layout .unlock-dialog-payg-session-list-button:active {
+        color: #747467; }
+    .unlock-dialog-payg .unlock-dialog-payg-layout .unlock-dialog-payg-message {
+      color: #f57900; }
+    .unlock-dialog-payg .unlock-dialog-payg-layout .unlock-dialog-payg-button-box {
+      spacing: 5px; }
+    .unlock-dialog-payg .unlock-dialog-payg-layout .unlock-dialog-payg-help-main {
+      color: #eeeeec;
+      font-weight: bold;
+      text-align: left;
+      margin-top: 36px; }
+    .unlock-dialog-payg .unlock-dialog-payg-layout .unlock-dialog-payg-help-sub {
+      color: #eeeeec;
+      font-size: 100%;
+      text-align: left; }

--- a/js/gdm/loginDialog.js
+++ b/js/gdm/loginDialog.js
@@ -502,6 +502,10 @@ const LoginDialog = new Lang.Class({
         // focus later
         this._startupCompleteId = Main.layoutManager.connect('startup-complete',
                                                              Lang.bind(this, this._updateDisableUserList));
+
+        // With PAYG machines this class can be created AFTER the startup process.
+        if (!Main.layoutManager.startingUp)
+            this._updateDisableUserList();
     },
 
     _getBannerAllocation: function (dialogBox) {

--- a/js/js-resources.gresource.xml
+++ b/js/js-resources.gresource.xml
@@ -149,6 +149,7 @@
     <file>ui/hotCorner.js</file>
     <file>ui/iconGridLayout.js</file>
     <file>ui/internetSearch.js</file>
+    <file>ui/paygUnlockDialog.js</file>
     <file>ui/sideComponent.js</file>
     <file>ui/status/codingGame.js</file>
     <file>ui/status/orientation.js</file>

--- a/js/js-resources.gresource.xml
+++ b/js/js-resources.gresource.xml
@@ -134,6 +134,7 @@
 
     <!-- Endless-specific UI resources below this point -->
 
+    <file>misc/paygManager.js</file>
     <file>ui/appActivation.js</file>
     <file>ui/appIconBar.js</file>
     <file>ui/components/appStore.js</file>

--- a/js/misc/paygManager.js
+++ b/js/misc/paygManager.js
@@ -1,0 +1,191 @@
+// -*- mode: js; js-indent-level: 4; indent-tabs-mode: nil -*-
+//
+// Copyright (C) 2018 Endless Mobile, Inc.
+//
+// This is a GNOME Shell component to wrap the interactions over
+// D-Bus with the eos-payg system daemon.
+//
+// Licensed under the GNU General Public License Version 2
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+const Gio = imports.gi.Gio;
+const GLib = imports.gi.GLib;
+
+const Main = imports.ui.main;
+const Lang = imports.lang;
+const Signals = imports.signals;
+
+const EOS_PAYG_NAME = 'com.endlessm.Payg1';
+const EOS_PAYG_PATH = '/com/endlessm/Payg1';
+
+const EOS_PAYG_IFACE = '<node> \
+<interface name="com.endlessm.Payg1"> \
+<method name="AddCode"> \
+  <arg type="s" direction="in" name="code"/> \
+</method> \
+<method name="ClearCode" /> \
+<signal name="Expired" /> \
+<property name="ExpiryTime" type="t" access="read"/> \
+<property name="Enabled" type="b" access="read"/> \
+<property name="RateLimitEndTime" type="t" access="read"/> \
+</interface> \
+</node>';
+
+var PaygErrorDomain = GLib.quark_from_string('payg-error');
+
+var PaygError = {
+    INVALID_CODE      : 0,
+    CODE_ALREADY_USED : 1,
+    TOO_MANY_ATTEMPTS : 2,
+    DISABLED          : 3,
+};
+
+const DBusErrorsMapping = {
+    INVALID_CODE      : 'com.endlessm.Payg1.Error.InvalidCode',
+    CODE_ALREADY_USED : 'com.endlessm.Payg1.Error.CodeAlreadyUsed',
+    TOO_MANY_ATTEMPTS : 'com.endlessm.Payg1.Error.TooManyAttempts',
+    DISABLED          : 'com.endlessm.Payg1.Error.Disabled',
+};
+
+var PaygManager = new Lang.Class({
+    Name: 'PaygManager',
+
+    _init: function() {
+        this._initialized = false;
+
+        this._proxy = null;
+        this._proxyInfo = Gio.DBusInterfaceInfo.new_for_xml(EOS_PAYG_IFACE);
+
+        this._enabled = false;
+        this._expiryTime = 0;
+        this._rateLimitEndTime = 0;
+
+        this._codeExpiredId = 0;
+        this._propertiesChangedId = 0;
+
+        this._proxy = new Gio.DBusProxy({ g_connection: Gio.DBus.system,
+                                          g_interface_name: this._proxyInfo.name,
+                                          g_interface_info: this._proxyInfo,
+                                          g_name: EOS_PAYG_NAME,
+                                          g_object_path: EOS_PAYG_PATH,
+                                          g_flags: Gio.DBusProxyFlags.NONE })
+
+        this._proxy.init_async(GLib.PRIORITY_DEFAULT, null, this._onProxyConstructed.bind(this));
+
+        for (let errorCode in DBusErrorsMapping)
+            Gio.DBusError.register_error(PaygErrorDomain, PaygError[errorCode], DBusErrorsMapping[errorCode]);
+    },
+
+    _onProxyConstructed: function(object, res) {
+        let success = false;
+        try {
+            success = object.init_finish (res);
+        } catch (e) {
+            logError(e, "Error while constructing D-Bus proxy for " + EOS_PAYG_NAME);
+        }
+
+        if (success) {
+            // Don't use the setters here to prevent emitting a -changed signal
+            // on startup, which is useless and confuses the screenshield when
+            // selecting the session mode to construct the right unlock dialog.
+            this._enabled = this._proxy.Enabled;
+            this._expiryTime = this._proxy.ExpiryTime;
+            this._rateLimitEndTime = this._proxy.RateLimitEndTime;
+
+            this._propertiesChangedId = this._proxy.connect('g-properties-changed', this._onPropertiesChanged.bind(this));
+            this._codeExpiredId = this._proxy.connectSignal('Expired', this._onCodeExpired.bind(this));
+        }
+
+        this._initialized = true;
+        this.emit('initialized');
+    },
+
+    _onPropertiesChanged: function(proxy, changedProps, invalidatedProps) {
+        let propsDict = changedProps.deep_unpack();
+        if (propsDict.hasOwnProperty('Enabled'))
+            this._setEnabled(this._proxy.Enabled);
+
+        if (propsDict.hasOwnProperty('ExpiryTime'))
+            this._setExpiryTime(this._proxy.ExpiryTime);
+
+        if (propsDict.hasOwnProperty('RateLimitEndTime'))
+            this._setRateLimitEndTime(this._proxy.RateLimitEndTime);
+    },
+
+    _setEnabled: function(value) {
+        if (this._enabled === value)
+            return;
+
+        this._enabled = value;
+        this.emit('enabled-changed', this._enabled);
+    },
+
+    _setExpiryTime: function(value) {
+        if (this._expiryTime === value)
+            return;
+
+        this._expiryTime = value;
+        this.emit('expiry-time-changed', this._expiryTime);
+    },
+
+    _setRateLimitEndTime: function(value) {
+        if (this._rateLimitEndTime === value)
+            return;
+
+        this._rateLimitEndTime = value;
+        this.emit('rate-limit-end-time-changed', this._rateLimitEndTime);
+    },
+
+    _onCodeExpired: function(proxy) {
+        this.emit('code-expired');
+    },
+
+    addCode: function(code, callback) {
+        this._proxy.AddCodeRemote(code, (result, error) => {
+            if (callback)
+                callback(error);
+        });
+    },
+
+    clearCode: function() {
+        this._proxy.ClearCodeRemote();
+    },
+
+    get initialized() {
+        return this._initialized;
+    },
+
+    get enabled() {
+        return this._enabled;
+    },
+
+    get expiryTime() {
+        return this._expiryTime;
+    },
+
+    get rateLimitEndTime() {
+        return this._rateLimitEndTime;
+    },
+
+    get isLocked() {
+        if (!this.enabled)
+            return false;
+
+        return this._expiryTime <= (GLib.get_real_time() / GLib.USEC_PER_SEC);
+    },
+
+});
+Signals.addSignalMethods(PaygManager.prototype);

--- a/js/misc/paygManager.js
+++ b/js/misc/paygManager.js
@@ -222,6 +222,7 @@ var PaygManager = new Lang.Class({
             this._propertiesChangedId = this._proxy.connect('g-properties-changed', this._onPropertiesChanged.bind(this));
             this._codeExpiredId = this._proxy.connectSignal('Expired', this._onCodeExpired.bind(this));
 
+            this._maybeNotifyUser();
             this._updateExpirationReminders();
         }
 
@@ -302,6 +303,16 @@ var PaygManager = new Lang.Class({
         this._notification.connect('destroy', function() {
             this._notification = null;
         });
+    },
+
+    _maybeNotifyUser: function() {
+        // Sanity check.
+        if (notificationAlertTimesSecs.length == 0)
+            return;
+
+        let secondsLeft = this._timeRemainingSecs();
+        if (secondsLeft <= notificationAlertTimesSecs[0])
+            this._notifyPaygReminder(secondsLeft);
     },
 
     _updateExpirationReminders: function() {

--- a/js/misc/paygManager.js
+++ b/js/misc/paygManager.js
@@ -21,10 +21,13 @@
 // along with this program; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
+const Gettext = imports.gettext;
 const Gio = imports.gi.Gio;
 const GLib = imports.gi.GLib;
 
 const Main = imports.ui.main;
+const Mainloop = imports.mainloop;
+const MessageTray = imports.ui.messageTray;
 const Lang = imports.lang;
 const Signals = imports.signals;
 
@@ -60,6 +63,27 @@ const DBusErrorsMapping = {
     DISABLED          : 'com.endlessm.Payg1.Error.Disabled',
 };
 
+// Title and description text to be shown in the periodic reminders.
+const NOTIFICATION_TITLE_FORMAT_STRING = _("Pay-as-you-go time will expire in %s");
+const NOTIFICATION_DETAILED_TEXT = _("Talk to your sales representative to buy a new code.")
+
+// This list defines the different instants in time where we would
+// want to show notifications to the user reminding that the payg
+// subscription will be expiring soon.
+//
+// It contains a list of integers representing the number of seconds
+// earlier to the expiration time when we want to show a notification,
+// which needs to be sorted in DESCENDING order.
+const notificationAlertTimesSecs = [
+    60 * 60 * 48, // 2 days
+    60 * 60 * 24, // 1 day
+    60 * 60 * 2,  // 2 hours
+    60 * 60,      // 1 hour
+    60 * 30,      // 30 minutes
+    60 * 2,       // 2 minutes
+    30,           // 30 seconds
+];
+
 // This function checks the configuration file of PAYG directly
 // from the expected locations on disk, on an attempt to figure
 // out whether the feature is enabled, so that we don't wake up
@@ -88,6 +112,57 @@ function _isPaygEnabled() {
     return false;
 }
 
+// Takes an UNIX timestamp (in seconds) and returns a string
+// with a precision level appropriate to show to the user.
+//
+// The returned string will be formatted just in seconds for times
+// under 1 minute, in minutes for times under 2 hours, in hours and
+// minutes (if applicable) for times under 1 day, and then in days
+// and hours (if applicable) for anything longer than that in days.
+//
+// Some examples:
+//   - 45 seconds => "45 seconds"
+//   - 60 seconds => "1 minute"
+//   - 95 seconds => "1 minute"
+//   - 120 seconds => "2 minutes"
+//   - 3600 seconds => "60 minutes"
+//   - 4500 seconds => "75 minutes"
+//   - 7200 seconds => "2 hours"
+//   - 8640 seconds => "2 hours 24 minutes"
+//   - 86400 seconds => "1 day"
+//   - 115200 seconds => "1 day 8 hours"
+//   - 172800 seconds => "2 days"
+function timeToString(seconds) {
+    if (seconds < 60)
+        return Gettext.ngettext("%s second", "%s seconds", seconds).format(seconds);
+
+    let minutes = Math.floor(seconds / 60);
+    if (minutes < 120)
+        return Gettext.ngettext("%s minute", "%s minutes", minutes).format(minutes);
+
+    let hours = Math.floor(minutes / 60);
+    if (hours < 24) {
+        let hoursStr = Gettext.ngettext("%s hour", "%s hours", hours).format(hours);
+
+        let minutesPast = minutes % 60;
+        if (minutesPast == 0)
+            return hoursStr;
+
+        let minutesStr = Gettext.ngettext("%s minute", "%s minutes", minutesPast).format(minutesPast);
+        return ("%s %s").format(hoursStr, minutesStr);
+    }
+
+    let days = Math.floor(hours / 24);
+    let daysStr = Gettext.ngettext("%s day", "%s days", days).format(days);
+
+    let hoursPast = hours % 24;
+    if (hoursPast == 0)
+        return daysStr;
+
+    let hoursStr = Gettext.ngettext("%s hour", "%s hours", hoursPast).format(hoursPast);
+    return ("%s %s").format(daysStr, hoursStr);
+}
+
 var PaygManager = new Lang.Class({
     Name: 'PaygManager',
 
@@ -98,6 +173,7 @@ var PaygManager = new Lang.Class({
         this._enabled = false;
         this._expiryTime = 0;
         this._rateLimitEndTime = 0;
+        this._notification = null;
 
         if (!_isPaygEnabled()) {
             // Consider this manager initialized if PAYG is not
@@ -112,6 +188,7 @@ var PaygManager = new Lang.Class({
 
         this._codeExpiredId = 0;
         this._propertiesChangedId = 0;
+        this._expirationReminderId = 0;
 
         this._proxy = new Gio.DBusProxy({ g_connection: Gio.DBus.system,
                                           g_interface_name: this._proxyInfo.name,
@@ -144,6 +221,8 @@ var PaygManager = new Lang.Class({
 
             this._propertiesChangedId = this._proxy.connect('g-properties-changed', this._onPropertiesChanged.bind(this));
             this._codeExpiredId = this._proxy.connectSignal('Expired', this._onCodeExpired.bind(this));
+
+            this._updateExpirationReminders();
         }
 
         this._initialized = true;
@@ -175,6 +254,8 @@ var PaygManager = new Lang.Class({
             return;
 
         this._expiryTime = value;
+        this._updateExpirationReminders();
+
         this.emit('expiry-time-changed', this._expiryTime);
     },
 
@@ -188,6 +269,76 @@ var PaygManager = new Lang.Class({
 
     _onCodeExpired: function(proxy) {
         this.emit('code-expired');
+    },
+
+    _timeRemainingSecs: function() {
+        if (!this._enabled)
+            return GLib.MAXUINT64;
+
+        return Math.max(0, this._expiryTime - (GLib.get_real_time() / GLib.USEC_PER_SEC));
+    },
+
+    _notifyPaygReminder: function(secondsLeft) {
+        // Only notify when in an regular session, not in GDM or initial-setup.
+        if (Main.sessionMode.currentMode != 'user' &&
+            Main.sessionMode.currentMode != 'user-coding') {
+            return;
+        }
+
+        if (this._notification)
+            this._notification.destroy();
+
+        let source = new MessageTray.SystemNotificationSource();
+        Main.messageTray.add(source);
+
+        let title = timeToString(secondsLeft);
+        this._notification = new MessageTray.Notification(source,
+                                                          NOTIFICATION_TITLE_FORMAT_STRING.format(title),
+                                                          NOTIFICATION_DETAILED_TEXT);
+        this._notification.setUrgency(MessageTray.Urgency.HIGH);
+        this._notification.setTransient(false);
+        source.notify(this._notification);
+
+        this._notification.connect('destroy', function() {
+            this._notification = null;
+        });
+    },
+
+    _updateExpirationReminders: function() {
+        if (this._expirationReminderId > 0) {
+            Mainloop.source_remove(this._expirationReminderId);
+            this._expirationReminderId = 0;
+        }
+
+        let secondsLeft = this._timeRemainingSecs();
+        if (secondsLeft <= 0)
+            return;
+
+        // Look for the right time to set the alarm for.
+        let targetAlertTime = 0;
+        for (let alertTime of notificationAlertTimesSecs) {
+            if (secondsLeft > alertTime) {
+                targetAlertTime = alertTime;
+                break;
+            }
+        }
+
+        // Too late to set up an alarm now.
+        if (targetAlertTime == 0)
+            return;
+
+        this._expirationReminderId = Mainloop.timeout_add_seconds(secondsLeft - targetAlertTime, () => {
+            // We want to show "round" numbers in the notification, matching
+            // whatever is specified in the notificationAlertTimeSecs array.
+            this._notifyPaygReminder(targetAlertTime);
+
+            // Reset _expirationReminderId before _updateExpirationReminders()
+            // to prevent an attempt to remove the same GSourceFunc twice.
+            this._expirationReminderId = 0;
+            this._updateExpirationReminders();
+
+            return GLib.SOURCE_REMOVE;
+        });
     },
 
     addCode: function(code, callback) {
@@ -231,7 +382,7 @@ var PaygManager = new Lang.Class({
         if (!this.enabled)
             return false;
 
-        return this._expiryTime <= (GLib.get_real_time() / GLib.USEC_PER_SEC);
+        return this._timeRemainingSecs() <= 0;
     },
 
 });

--- a/js/ui/main.js
+++ b/js/ui/main.js
@@ -47,6 +47,7 @@ const WorkspaceMonitor = imports.ui.workspaceMonitor;
 const Magnifier = imports.ui.magnifier;
 const XdndHandler = imports.ui.xdndHandler;
 const Util = imports.misc.util;
+const PaygManager = imports.misc.paygManager;
 const Watermark = imports.ui.watermark;
 
 const A11Y_SCHEMA = 'org.gnome.desktop.a11y.keyboard';
@@ -88,6 +89,7 @@ let desktopAppClient = null;
 let workspaceMonitor = null;
 let codingManager = null;
 let discoveryFeed = null;
+let paygManager = null;
 let _startDate;
 let _defaultCssStylesheet = null;
 let _cssStylesheet = null;
@@ -175,6 +177,11 @@ function _initializeUI() {
     overview = new Overview.Overview();
     wm = new WindowManager.WindowManager();
     magnifier = new Magnifier.Magnifier();
+
+    // The ScreenShield depends on the PaygManager, so this
+    // module needs to be initialized first.
+    paygManager = new PaygManager.PaygManager();
+
     if (LoginManager.canLock())
         screenShield = new ScreenShield.ScreenShield();
 

--- a/js/ui/main.js
+++ b/js/ui/main.js
@@ -243,7 +243,17 @@ function _initializeUI() {
 
     if (sessionMode.isGreeter && screenShield) {
         layoutManager.connect('startup-prepared', function() {
-            screenShield.showDialog();
+            // We can't show the login dialog (which is managed by the
+            // screenshield) until the PaygManager is initializd, since
+            // we need to check whether the machine is PAYG-locked first.
+            if (paygManager.initialized) {
+                screenShield.showDialog();
+            } else {
+                let paygManagerId = paygManager.connect('initialized', () => {
+                    screenShield.showDialog();
+                    paygManager.disconnect(paygManagerId);
+                });
+            }
         });
     }
 

--- a/js/ui/paygUnlockDialog.js
+++ b/js/ui/paygUnlockDialog.js
@@ -1,0 +1,541 @@
+// -*- mode: js; js-indent-level: 4; indent-tabs-mode: nil -*-
+//
+// Copyright (C) 2018 Endless Mobile, Inc.
+//
+// Licensed under the GNU General Public License Version 2
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+const Atk = imports.gi.Atk;
+const Clutter = imports.gi.Clutter;
+const Gettext = imports.gettext;
+const Gio = imports.gi.Gio;
+const GLib = imports.gi.GLib;
+const GObject = imports.gi.GObject;
+const Lang = imports.lang;
+const Mainloop = imports.mainloop;
+const Meta = imports.gi.Meta;
+const Pango = imports.gi.Pango;
+const Signals = imports.signals;
+const Shell = imports.gi.Shell;
+const St = imports.gi.St;
+
+const PaygManager = imports.misc.paygManager;
+
+const Animation = imports.ui.animation;
+const Main = imports.ui.main;
+const Monitor = imports.ui.monitor;
+const ShellEntry = imports.ui.shellEntry;
+const Tweener = imports.ui.tweener;
+
+const MSEC_PER_SEC = 1000
+
+// The timeout before going back automatically to the lock screen
+const IDLE_TIMEOUT_SECS = 2 * 60;
+
+const CODE_REQUIRED_LENGTH_CHARS = 8;
+
+const SPINNER_ICON_SIZE_PIXELS = 16;
+const SPINNER_ANIMATION_DELAY_SECS = 1.0;
+const SPINNER_ANIMATION_TIME_SECS = 0.3;
+
+var UnlockStatus = {
+    NOT_VERIFYING: 0,
+    VERIFYING: 1,
+    FAILED: 2,
+    TOO_MANY_ATTEMPTS: 3,
+    SUCCEEDED: 4,
+};
+
+var PaygUnlockCodeEntry = new Lang.Class({
+    Name: 'PaygUnlockCodeEntry',
+    Extends: St.Entry,
+    Signals: { 'code-changed' : { param_types: [GObject.TYPE_STRING] } },
+
+    _init: function(params) {
+        this.parent({ style_class: 'unlock-dialog-payg-entry',
+                      reactive: true,
+                      can_focus: true,
+                      x_align: Clutter.ActorAlign.FILL });
+
+        this._code = '';
+        this.clutter_text.ellipsize = Pango.EllipsizeMode.NONE;
+        this.clutter_text.x_align = Clutter.ActorAlign.CENTER;
+
+        this._enabled = false;
+        this._buttonPressEventId = this.connect('button-press-event', this._onButtonPressEvent.bind(this));
+        this._capturedEventId = this.clutter_text.connect('captured-event', this._onCapturedEvent.bind(this));
+        this._textChangedId = this.clutter_text.connect('text-changed', this._onTextChanged.bind(this));
+
+        this.connect('destroy', this._onDestroy.bind(this));
+    },
+
+    _onDestroy: function() {
+        if (this._buttonPressEventId > 0) {
+            this.disconnect(this._buttonPressEventId);
+            this._buttonPressEventId = 0;
+        }
+
+        if (this._capturedEventId > 0) {
+            this.clutter_text.disconnect(this._capturedEventId);
+            this._capturedEventId = 0;
+        }
+
+        if (this._textChangedId > 0) {
+            this.clutter_text.disconnect(this._textChangedId);
+            this._textChangedId = 0;
+        }
+    },
+
+    _onCapturedEvent: function(textActor, event) {
+        if (event.type() != Clutter.EventType.KEY_PRESS)
+            return Clutter.EVENT_PROPAGATE;
+
+        let keysym = event.get_key_symbol();
+        let isDeleteKey =
+            keysym == Clutter.KEY_Delete ||
+            keysym == Clutter.KEY_KP_Delete ||
+            keysym == Clutter.KEY_BackSpace;
+        let isEnterKey =
+            keysym == Clutter.KEY_Return ||
+            keysym == Clutter.KEY_KP_Enter ||
+            keysym == Clutter.KEY_ISO_Enter;
+        let isExitKey =
+            keysym == Clutter.KEY_Escape ||
+            keysym == Clutter.KEY_Tab;
+        let isMovementKey =
+            keysym == Clutter.KEY_Left ||
+            keysym == Clutter.KEY_Right ||
+            keysym == Clutter.KEY_Home ||
+            keysym == Clutter.KEY_KP_Home ||
+            keysym == Clutter.KEY_End ||
+            keysym == Clutter.KEY_KP_End;
+
+        // Make sure we can leave the entry and delete and
+        // navigate numbers with the keyboard.
+        if (isExitKey || isEnterKey || isDeleteKey || isMovementKey)
+            return Clutter.EVENT_PROPAGATE
+
+        // Do nothing if the entry is disabled.
+        if (!this._enabled)
+            return Clutter.EVENT_STOP;
+
+        // Don't allow inserting more digits than required.
+        if (this._code.length >= CODE_REQUIRED_LENGTH_CHARS)
+            return Clutter.EVENT_STOP;
+
+        // Allow digits only
+        let character = event.get_key_unicode();
+        if (GLib.unichar_isdigit(character))
+            this.clutter_text.insert_unichar(character);
+
+        return Clutter.EVENT_STOP;
+    },
+
+    _onTextChanged: function(textActor) {
+        this._code = textActor.text;
+        this.emit('code-changed', this._code);
+    },
+
+    _onButtonPressEvent: function() {
+        if (!this._enabled)
+            return;
+
+        this.grab_key_focus();
+        return false;
+    },
+
+    addCharacter: function(character) {
+        if (!this._enabled || !GLib.unichar_isdigit(character))
+            return;
+
+        this.clutter_text.insert_unichar(character);
+    },
+
+    setEnabled: function(value) {
+        if (this._enabled == value)
+            return;
+
+        this._enabled = value;
+        this.reactive = value;
+        this.can_focus = value;
+        this.clutter_text.reactive = value;
+        this.clutter_text.editable = value;
+        this.clutter_text.cursor_visible = value;
+    },
+
+    reset: function() {
+        this.text = '';
+    },
+
+    get code() {
+        return this._code;
+    },
+
+    get length() {
+        return this._code.length;
+    }
+});
+
+var PaygUnlockDialog = new Lang.Class({
+    Name: 'PaygUnlockDialog',
+
+    _init: function(parentActor) {
+        this._parentActor = parentActor;
+
+        this._entry = null;
+        this._errorMessage = null;
+        this._cancelButton = null;
+        this._nextButton = null;
+        this._spinner = null;
+        this._cancelled = false;
+
+        this._verificationStatus = UnlockStatus.NOT_VERIFYING;
+
+        // Clear the clipboard to make sure nothing can be copied into the entry.
+        St.Clipboard.get_default().set_text(St.ClipboardType.CLIPBOARD, '');
+        St.Clipboard.get_default().set_text(St.ClipboardType.PRIMARY, '');
+
+        this.actor = new St.Widget({ accessible_role: Atk.Role.WINDOW,
+                                     style_class: 'unlock-dialog-payg',
+                                     layout_manager: new Clutter.BoxLayout(),
+                                     visible: false });
+        this.actor.add_constraint(new Monitor.MonitorConstraint({ primary: true }));
+
+        this._parentActor.add_child(this.actor);
+
+        let mainBox = new St.BoxLayout({ vertical: true,
+                                         x_align: Clutter.ActorAlign.FILL,
+                                         y_align: Clutter.ActorAlign.CENTER,
+                                         x_expand: true,
+                                         y_expand: true,
+                                         style_class: 'unlock-dialog-payg-layout'});
+        this.actor.add_child(mainBox)
+
+        let titleLabel = new St.Label({ style_class: 'unlock-dialog-payg-title',
+                                        text: _("Your Endless pay-as-you-go usage credit has expired."),
+                                        x_align: Clutter.ActorAlign.CENTER });
+        mainBox.add_child(titleLabel);
+
+        let promptBox = new St.BoxLayout({ vertical: true,
+                                           x_align: Clutter.ActorAlign.CENTER,
+                                           y_align: Clutter.ActorAlign.CENTER,
+                                           x_expand: true,
+                                           y_expand: true,
+                                           style_class: 'unlock-dialog-payg-promptbox'});
+        promptBox.connect('key-press-event', (actor, event) => {
+            if (event.get_key_symbol() == Clutter.KEY_Escape)
+                this._onCancelled();
+
+            return Clutter.EVENT_PROPAGATE;
+        });
+        mainBox.add_child(promptBox);
+
+        let promptLabel = new St.Label({ style_class: 'unlock-dialog-payg-label',
+                                         text: _("Enter a new code to unlock your computer:"),
+                                         x_align: Clutter.ActorAlign.START });
+        promptBox.add_child(promptLabel);
+
+        this._entry = new PaygUnlockCodeEntry();
+        promptBox.add_child(this._entry);
+
+        this._errorMessage = new St.Label({ opacity: 0,
+                                            styleClass: 'unlock-dialog-payg-message' });
+        this._errorMessage.clutter_text.line_wrap = true;
+        this._errorMessage.clutter_text.ellipsize = Pango.EllipsizeMode.NONE;
+        promptBox.add_child(this._errorMessage);
+
+        this._buttonBox = this._createButtonsArea();
+        promptBox.add_child(this._buttonBox);
+
+        let helpLineMain = new St.Label({ style_class: 'unlock-dialog-payg-help-main',
+                                          text: _("Don’t have an unlock code? That’s OK!"),
+                                          x_align: Clutter.ActorAlign.START });
+        promptBox.add_child(helpLineMain);
+
+        let helpLineSub = new St.Label({ style_class: 'unlock-dialog-payg-help-sub',
+                                         text: _("Talk to your sales representative to purchase a new code."),
+                                         x_align: Clutter.ActorAlign.START });
+        promptBox.add_child(helpLineSub);
+
+        Main.ctrlAltTabManager.addGroup(promptBox, _("Unlock Machine"), 'dialog-password-symbolic');
+
+        this._cancelButton.connect('clicked', () => {
+            this._onCancelled();
+        });
+        this._nextButton.connect('clicked', () => {
+            this._startVerifyingCode();
+        });
+
+        this._entry.connect('code-changed', () => {
+            this._updateNextButtonSensitivity();
+        });
+
+        this._entry.clutter_text.connect('activate', () => {
+            this._startVerifyingCode();
+        });
+
+        this._clearTooManyAttemptsId = 0;
+        this.connect('destroy', this._onDestroy.bind(this));
+
+        this._idleMonitor = Meta.IdleMonitor.get_core();
+        this._idleWatchId = this._idleMonitor.add_idle_watch(IDLE_TIMEOUT_SECS * MSEC_PER_SEC, Lang.bind(this, this._onCancelled));
+
+        this._updateSensitivity();
+        this._entry.grab_key_focus();
+    },
+
+    _onDestroy: function() {
+        if (this._clearTooManyAttemptsId > 0) {
+            Mainloop.source_remove(this._clearTooManyAttemptsId);
+            this._clearTooManyAttemptsId = 0;
+        }
+    },
+
+    _createButtonsArea: function() {
+        let buttonsBox = new St.BoxLayout({ style_class: 'unlock-dialog-payg-button-box',
+                                            vertical: false,
+                                            x_expand: true,
+                                            x_align: Clutter.ActorAlign.FILL,
+                                            y_expand: true,
+                                            y_align: Clutter.ActorAlign.END });
+
+        this._cancelButton = new St.Button({ style_class: 'modal-dialog-button button',
+                                             button_mask: St.ButtonMask.ONE | St.ButtonMask.THREE,
+                                             reactive: true,
+                                             can_focus: true,
+                                             label: _("Cancel"),
+                                             x_align: St.Align.START,
+                                             y_align: St.Align.END });
+        buttonsBox.add_child(this._cancelButton);
+
+        let buttonSpacer = new St.Widget({ layout_manager: new Clutter.BinLayout(),
+                                           x_expand: true,
+                                           x_align: Clutter.ActorAlign.END });
+        buttonsBox.add_child(buttonSpacer);
+
+        // We make the most of the spacer to show the spinner while verifying the code.
+        let spinnerIcon = Gio.File.new_for_uri('resource:///org/gnome/shell/theme/process-working.svg');
+        this._spinner = new Animation.AnimatedIcon(spinnerIcon, SPINNER_ICON_SIZE_PIXELS);
+        this._spinner.actor.opacity = 0;
+        this._spinner.actor.show();
+        buttonSpacer.add_child(this._spinner.actor);
+
+        this._nextButton = new St.Button({ style_class: 'modal-dialog-button button',
+                                           button_mask: St.ButtonMask.ONE | St.ButtonMask.THREE,
+                                           reactive: true,
+                                           can_focus: true,
+                                           label: _("Unlock"),
+                                           x_align: St.Align.END,
+                                           y_align: St.Align.END });
+        this._nextButton.add_style_pseudo_class('default');
+        buttonsBox.add_child(this._nextButton);
+
+        return buttonsBox;
+    },
+
+    _onCancelled: function() {
+        this._cancelled = true;
+        this._reset();
+
+        // The ScreenShield will connect to the 'failed' signal
+        // to know when to cancel the unlock dialog.
+        if (this._verificationStatus != UnlockStatus.SUCCEEDED)
+            this.emit('failed');
+    },
+
+    _validateCurrentCode: function() {
+        // The PaygUnlockCodeEntry widget will only accept valid
+        // characters, so we only need to check the length here.
+        return this._entry.length == CODE_REQUIRED_LENGTH_CHARS;
+    },
+
+    _updateNextButtonSensitivity: function() {
+        let sensitive = this._validateCurrentCode() &&
+            this._verificationStatus != UnlockStatus.VERIFYING &&
+            this._verificationStatus != UnlockStatus.TOO_MANY_ATTEMPTS;
+
+        this._nextButton.reactive = sensitive;
+        this._nextButton.can_focus = sensitive;
+    },
+
+    _updateSensitivity: function() {
+        let shouldEnableEntry = this._verificationStatus != UnlockStatus.VERIFYING &&
+            this._verificationStatus != UnlockStatus.TOO_MANY_ATTEMPTS;
+
+        this._updateNextButtonSensitivity();
+        this._entry.setEnabled(shouldEnableEntry);
+    },
+
+    _setErrorMessage: function(message) {
+        if (message) {
+            this._errorMessage.text = message;
+            this._errorMessage.opacity = 255;
+        } else {
+            this._errorMessage.text = '';
+            this._errorMessage.opacity = 0;
+        }
+    },
+
+    _startSpinning: function() {
+        this._spinner.play();
+        this._spinner.actor.show();
+        Tweener.addTween(this._spinner.actor,
+                         { opacity: 255,
+                           time: SPINNER_ANIMATION_TIME_SECS,
+                           delay: SPINNER_ANIMATION_DELAY_SECS,
+                           transition: 'linear' });
+    },
+
+    _stopSpinning: function() {
+        this._spinner.actor.hide();
+        this._spinner.actor.opacity = 0;
+        this._spinner.stop();
+    },
+
+    _reset: function() {
+        this._stopSpinning();
+        this._entry.reset();
+        this._updateSensitivity();
+    },
+
+    _processError: function(error) {
+        logError(error, 'Error adding PAYG code');
+
+        // The 'too many errors' case is a bit special, and sets a different state.
+        if (error.matches(PaygManager.PaygErrorDomain, PaygManager.PaygError.TOO_MANY_ATTEMPTS)) {
+            let currentTime = GLib.get_real_time() / GLib.USEC_PER_SEC;
+            let secondsLeft = Main.paygManager.rateLimitEndTime - currentTime;
+            if (secondsLeft > 30) {
+                let minutesLeft = Math.max(0, Math.ceil(secondsLeft / 60))
+                this._setErrorMessage(Gettext.ngettext("Too many attempts. Try again in %s minute.",
+                                                       "Too many attempts. Try again in %s minutes.", minutesLeft)
+                                      .format(minutesLeft));
+            } else {
+                this._setErrorMessage(_("Too many attempts. Try again in a few seconds."));
+            }
+
+            // Make sure to clean the status once the time is up (if this dialog is still alive)
+            // and make sure that we install this callback at some point in the future (+1 sec).
+            this._clearTooManyAttemptsId = Mainloop.timeout_add_seconds(secondsLeft + 1, () => {
+                this._verificationStatus = UnlockStatus.NOT_VERIFYING;
+                this._clearError();
+                this._updateSensitivity();
+                this._entry.grab_key_focus()
+                return GLib.SOURCE_REMOVE;
+            });
+
+            this._verificationStatus = UnlockStatus.TOO_MANY_ATTEMPTS;
+            return;
+        }
+
+        // Common errors after this point.
+        if (error.matches(PaygManager.PaygErrorDomain, PaygManager.PaygError.INVALID_CODE)) {
+            this._setErrorMessage(_("Invalid code. Please try again."));
+        } else if (error.matches(PaygManager.PaygErrorDomain, PaygManager.PaygError.CODE_ALREADY_USED)) {
+            this._setErrorMessage(_("Code already used. Please enter a new code."));
+        } else if (error.matches(Gio.IOErrorEnum, Gio.IOErrorEnum.TIMED_OUT)) {
+            this._setErrorMessage(_("Time exceeded while verifying the code"));
+        } else {
+            // We don't consider any other error here (and we don't consider DISABLED explicitly,
+            // since that should not happen), but still we need to show something to the user.
+            this._setErrorMessage(_("Unknown error"));
+        }
+
+        this._verificationStatus = UnlockStatus.FAILED;
+    },
+
+    _clearError: function() {
+        this._setErrorMessage(null);
+    },
+
+    _addCodeCallback: function(error) {
+        // We don't care about the result if we're closing the dialog.
+        if (this._cancelled) {
+            this._verificationStatus = UnlockStatus.NOT_VERIFYING;
+            return;
+        }
+
+        if (error) {
+            this._processError(error);
+        } else {
+            this._verificationStatus = UnlockStatus.SUCCEEDED;
+            this._clearError();
+        }
+
+        this._reset();
+    },
+
+    _startVerifyingCode: function() {
+        if (!this._validateCurrentCode())
+            return;
+
+        this._verificationStatus = UnlockStatus.VERIFYING;
+        this._startSpinning();
+        this._updateSensitivity();
+        this._cancelled = false;
+
+        Main.paygManager.addCode(this._entry.code, this._addCodeCallback.bind(this));
+    },
+
+    addCharacter: function(unichar) {
+        this._entry.addCharacter(unichar);
+    },
+
+    cancel: function() {
+        this._reset();
+        this.destroy();
+    },
+
+    finish: function(onComplete) {
+        // Nothing to do other than calling the callback.
+        if (onComplete)
+            onComplete();
+    },
+
+    open: function(timestamp) {
+        this.actor.show();
+
+        if (this._isModal)
+            return true;
+
+        if (!Main.pushModal(this.actor, { timestamp: timestamp,
+                                          actionMode: Shell.ActionMode.UNLOCK_SCREEN }))
+            return false;
+
+        this._isModal = true;
+
+        return true;
+    },
+
+    popModal: function(timestamp) {
+        if (this._isModal) {
+            Main.popModal(this.actor, timestamp);
+            this._isModal = false;
+        }
+    },
+
+    destroy: function() {
+        this.popModal();
+        this._parentActor.remove_child(this.actor);
+        this.actor.destroy();
+
+        if (this._idleWatchId) {
+            this._idleMonitor.remove_watch(this._idleWatchId);
+            this._idleWatchId = 0;
+        }
+    }
+});
+Signals.addSignalMethods(PaygUnlockDialog.prototype);

--- a/js/ui/screenShield.js
+++ b/js/ui/screenShield.js
@@ -580,6 +580,47 @@ const ScreenShield = new Lang.Class({
         this._cursorTracker = Meta.CursorTracker.get_for_screen(global.screen);
 
         this._syncInhibitor();
+
+        Main.paygManager.connect('code-expired', () => { this.lock(true) });
+        Main.paygManager.connect('expiry-time-changed', () => {
+            let userManager = AccountsService.UserManager.get_default();
+            let user = userManager.get_user(GLib.get_user_name());
+
+            // A new valid code has been introduced but the machine is
+            // not unlocked yet -> Make sure we stay in the locked state.
+            if (Main.paygManager.isLocked) {
+                this.lock(false);
+                return;
+            }
+
+            // A new valid code unlocked the machine and user has no
+            // password set -> Go straight to the user's session.
+            if (user.password_mode == AccountsService.UserPasswordMode.NONE) {
+                this.deactivate(false);
+                return;
+            }
+
+            if (Main.sessionMode.currentMode == 'unlock-dialog-payg') {
+                // This is the most common case.
+                Main.sessionMode.popMode('unlock-dialog-payg');
+            } else if (Main.sessionMode.currentMode == 'lock-screen') {
+                // There's a chance we could be in the screen shield, instead of the
+                // unlock dialog, if the user wend back manually to it (e.g. pressed ESC)
+                // between introducing the code and the actual verification happening.
+                Main.sessionMode.popMode('lock-screen');
+                Main.sessionMode.popMode('unlock-dialog-payg');
+                Main.sessionMode.pushMode('lock-screen');
+            }
+
+            // The machine is unlocked but we still need to unlock the
+            // user's session with the password, so don't deactivate yet.
+            if (this._dialog) {
+                this._dialog.destroy();
+                this._dialog = null;
+            }
+
+            this.showDialog();
+        });
     },
 
     _setActive: function(active) {
@@ -638,7 +679,7 @@ const ScreenShield = new Lang.Class({
             return;
 
         this._dialog.cancel();
-        if (this._isGreeter) {
+        if (this._isGreeter && !Main.paygManager.isLocked) {
             // LoginDialog.cancel() will grab the key focus
             // on its own, so ensure it stays on lock screen
             // instead
@@ -925,6 +966,7 @@ const ScreenShield = new Lang.Class({
         this.actor.show();
         this._isGreeter = Main.sessionMode.isGreeter;
         this._isLocked = true;
+
         if (this._ensureUnlockDialog(true, true))
             this._hideLockScreen(false, 0);
     },
@@ -1233,6 +1275,8 @@ const ScreenShield = new Lang.Class({
 
         if (Main.sessionMode.currentMode == 'lock-screen')
             Main.sessionMode.popMode('lock-screen');
+        if (Main.sessionMode.currentMode == 'unlock-dialog-payg')
+            Main.sessionMode.popMode('unlock-dialog-payg');
         if (Main.sessionMode.currentMode == 'unlock-dialog')
             Main.sessionMode.popMode('unlock-dialog');
 
@@ -1292,6 +1336,10 @@ const ScreenShield = new Lang.Class({
         this._isLocked = false;
         this.emit('locked-changed');
         global.set_runtime_state(LOCKED_STATE_STR, null);
+
+        // Sanity check, in case we made it this far while being locked
+        if (Main.paygManager.isLocked)
+            this.lock(false);
     },
 
     activate: function(animate) {
@@ -1301,10 +1349,19 @@ const ScreenShield = new Lang.Class({
         this.actor.show();
 
         if (Main.sessionMode.currentMode != 'unlock-dialog' &&
+            Main.sessionMode.currentMode != 'unlock-dialog-payg' &&
             Main.sessionMode.currentMode != 'lock-screen') {
             this._isGreeter = Main.sessionMode.isGreeter;
-            if (!this._isGreeter)
-                Main.sessionMode.pushMode('unlock-dialog');
+            if (!this._isGreeter) {
+                let userManager = AccountsService.UserManager.get_default();
+                let user = userManager.get_user(GLib.get_user_name());
+
+                if (user.password_mode != AccountsService.UserPasswordMode.NONE)
+                    Main.sessionMode.pushMode('unlock-dialog');
+
+                if (Main.paygManager.isLocked)
+                    Main.sessionMode.pushMode('unlock-dialog-payg');
+            }
         }
 
         this._resetLockScreen({ animateLockScreen: animate,
@@ -1324,7 +1381,11 @@ const ScreenShield = new Lang.Class({
     },
 
     lock: function(animate) {
-        if (this._lockSettings.get_boolean(DISABLE_LOCK_KEY)) {
+        // This does not make sense outside of the user's session for PAYG
+        if (Main.sessionMode.isGreeter && Main.paygManager.isLocked)
+            return;
+
+        if (this._lockSettings.get_boolean(DISABLE_LOCK_KEY) && !Main.paygManager.isLocked) {
             log('Screen lock is locked down, not locking') // lock, lock - who's there?
             return;
         }
@@ -1348,7 +1409,7 @@ const ScreenShield = new Lang.Class({
         if (this._isGreeter)
             this._isLocked = true;
         else
-            this._isLocked = user.password_mode != AccountsService.UserPasswordMode.NONE;
+            this._isLocked = Main.paygManager.isLocked || (user.password_mode != AccountsService.UserPasswordMode.NONE);
 
         this.activate(animate);
 
@@ -1357,10 +1418,17 @@ const ScreenShield = new Lang.Class({
 
     // If the previous shell crashed, and gnome-session restarted us, then re-lock
     lockIfWasLocked: function() {
-        if (!this._settings.get_boolean(LOCK_ENABLED_KEY))
+        // We need to add some extra checks for PAYG becasue we don't want to
+        // end up loging the screen for not regular sessions (e.g. initial-setup).
+        let shouldLockForPayg = Main.paygManager.isLocked &&
+            (Main.sessionMode.currentMode == 'user' ||
+             Main.sessionMode.currentMode == 'user-coding');
+
+        if (!this._settings.get_boolean(LOCK_ENABLED_KEY) && !shouldLockForPayg)
             return;
-        let wasLocked = global.get_runtime_state('b', LOCKED_STATE_STR);
-        if (wasLocked === null)
+
+        let wasLocked = global.get_runtime_state('b',LOCKED_STATE_STR);
+        if (wasLocked === null && !shouldLockForPayg)
             return;
         Meta.later_add(Meta.LaterType.BEFORE_REDRAW, Lang.bind(this, function() {
             this.lock(false);

--- a/js/ui/screenShield.js
+++ b/js/ui/screenShield.js
@@ -600,15 +600,16 @@ const ScreenShield = new Lang.Class({
                 return;
             }
 
-            if (Main.sessionMode.currentMode == 'unlock-dialog-payg') {
+            let paygExpectedMode = this._isGreeter ? 'gdm-unlock-dialog-payg' : 'unlock-dialog-payg';
+            if (Main.sessionMode.currentMode == paygExpectedMode) {
                 // This is the most common case.
-                Main.sessionMode.popMode('unlock-dialog-payg');
+                Main.sessionMode.popMode(paygExpectedMode);
             } else if (Main.sessionMode.currentMode == 'lock-screen') {
                 // There's a chance we could be in the screen shield, instead of the
                 // unlock dialog, if the user wend back manually to it (e.g. pressed ESC)
                 // between introducing the code and the actual verification happening.
                 Main.sessionMode.popMode('lock-screen');
-                Main.sessionMode.popMode('unlock-dialog-payg');
+                Main.sessionMode.popMode(paygExpectedMode);
                 Main.sessionMode.pushMode('lock-screen');
             }
 
@@ -967,6 +968,9 @@ const ScreenShield = new Lang.Class({
         this._isGreeter = Main.sessionMode.isGreeter;
         this._isLocked = true;
 
+        if (this._isGreeter && Main.paygManager.isLocked)
+            Main.sessionMode.pushMode('gdm-unlock-dialog-payg');
+
         if (this._ensureUnlockDialog(true, true))
             this._hideLockScreen(false, 0);
     },
@@ -1275,6 +1279,8 @@ const ScreenShield = new Lang.Class({
 
         if (Main.sessionMode.currentMode == 'lock-screen')
             Main.sessionMode.popMode('lock-screen');
+        if (Main.sessionMode.currentMode == 'gdm-unlock-dialog-payg')
+            Main.sessionMode.popMode('gdm-unlock-dialog-payg');
         if (Main.sessionMode.currentMode == 'unlock-dialog-payg')
             Main.sessionMode.popMode('unlock-dialog-payg');
         if (Main.sessionMode.currentMode == 'unlock-dialog')

--- a/js/ui/sessionMode.js
+++ b/js/ui/sessionMode.js
@@ -71,7 +71,7 @@ const _modes = {
 
     'unlock-dialog': {
         isLocked: true,
-        unlockDialog: undefined,
+        unlockDialog: imports.ui.unlockDialog.UnlockDialog,
         components: ['polkitAgent', 'telepathyClient'],
         panel: {
             left: [],
@@ -79,6 +79,16 @@ const _modes = {
             right: ['a11y', 'keyboard', 'aggregateMenu']
         },
         panelStyle: 'unlock-screen'
+    },
+
+    'unlock-dialog-payg': {
+        parentMode: 'unlock-dialog',
+        unlockDialog: imports.ui.paygUnlockDialog.PaygUnlockDialog,
+        panel: {
+            left: [],
+            center: [],
+            right: ['a11y', 'keyboard', 'aggregateMenu', 'powerMenu']
+        },
     },
 
     'user': {

--- a/js/ui/sessionMode.js
+++ b/js/ui/sessionMode.js
@@ -56,6 +56,11 @@ const _modes = {
         panelStyle: 'login-screen'
     },
 
+    'gdm-unlock-dialog-payg': {
+        parentMode: 'gdm',
+        unlockDialog: imports.ui.paygUnlockDialog.PaygUnlockDialog,
+    },
+
     'lock-screen': {
         isLocked: true,
         isGreeter: undefined,

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -9,6 +9,7 @@ js/extensionPrefs/main.js
 js/gdm/authPrompt.js
 js/gdm/loginDialog.js
 js/gdm/util.js
+js/misc/paygManager.js
 js/misc/systemActions.js
 js/misc/util.js
 js/portalHelper/main.js

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -42,6 +42,7 @@ js/ui/overviewControls.js
 js/ui/overview.js
 js/ui/padOsd.js
 js/ui/panel.js
+js/ui/paygUnlockDialog.js
 js/ui/popupMenu.js
 js/ui/runDialog.js
 js/ui/screenShield.js

--- a/src/st/st-entry.c
+++ b/src/st/st-entry.c
@@ -309,7 +309,9 @@ st_entry_style_changed (StWidget *self)
     }
 
   theme_node = st_widget_get_theme_node (self);
- 
+
+  _st_set_text_from_style (CLUTTER_TEXT (priv->entry), theme_node);
+
   st_theme_node_get_foreground_color (theme_node, &color);
   clutter_text_set_color (CLUTTER_TEXT (priv->entry), &color);
 

--- a/src/st/st-private.c
+++ b/src/st/st-private.c
@@ -116,6 +116,7 @@ _st_set_text_from_style (ClutterText *text,
   PangoAttrList *attribs = NULL;
   const PangoFontDescription *font;
   StTextAlign align;
+  gdouble spacing;
 
   st_theme_node_get_foreground_color (theme_node, &color);
   clutter_text_set_color (text, &color);
@@ -123,11 +124,11 @@ _st_set_text_from_style (ClutterText *text,
   font = st_theme_node_get_font (theme_node);
   clutter_text_set_font_description (text, (PangoFontDescription *) font);
 
+  attribs = pango_attr_list_new ();
+
   decoration = st_theme_node_get_text_decoration (theme_node);
   if (decoration)
     {
-      attribs = pango_attr_list_new ();
-
       if (decoration & ST_TEXT_DECORATION_UNDERLINE)
         {
           PangoAttribute *underline = pango_attr_underline_new (PANGO_UNDERLINE_SINGLE);
@@ -142,6 +143,11 @@ _st_set_text_from_style (ClutterText *text,
        * skip BLINK (for now...)
        */
     }
+
+  if (st_theme_node_lookup_length (theme_node, "letter-spacing", TRUE, &spacing)) {
+    PangoAttribute *letter_spacing = pango_attr_letter_spacing_new ((int)(.5 + spacing) * PANGO_SCALE);
+    pango_attr_list_insert (attribs, letter_spacing);
+  }
 
   clutter_text_set_attributes (text, attribs);
 


### PR DESCRIPTION
This PR brings all the bits developed for the following tickets, onto the eos3.3 branch:

  * Shell: Implement component to wrap the functionality of the eos-payg daemon (T21607)
  * Shell: Add mechanism to unlock machine from the lock-screen session mode (T21608)
  * Shell: Add screen to unlock machine from the GDM session mode (T21609)
  * Shell: Automatically lock the user's session when a PAYG code expires (T21611)
  * Shell: Add a timeout to the code verification process (T21806)
  * Shell: Gracefully handle com.endlessm.Payg1.Error.TooManyAttempts (T21808)
  * Shell: Implement design for the PAYG unlock dialog (T21811)
  * Shell: Integrate PAYG with the FBE (T21830)
  * Shell: Use the right text strings for the PAYG unlock dialog (T21841)
  * Shell: Don't unnecessarily start the eos-paygd daemon (T21844)
  * Shell: Show notifications as reminders for PAY expiration time (T21848)

https://phabricator.endlessm.com/T21731