### PR TITLE
layout: Null-check for this._viewsClone in case it's not ready yet.

### DIFF
--- a/js/ui/layout.js
+++ b/js/ui/layout.js
@@ -330,6 +330,9 @@ var LayoutManager = new Lang.Class({
     },
 
     _animateViewsClone: function(targetOpacity, targetSaturation) {
+        if (!this._viewsClone)
+            return;
+
         // Don't unnecessarily tween the clone's saturation & opacity.
         if (this._viewsClone.opacity == targetOpacity && this._viewsClone.saturation == targetSaturation)
             return;


### PR DESCRIPTION
It doesn't make sense to animate the clone if it hasn't been created
yet, which is something that can sometimes happen during startup, leading
to useless and confusing warnings on the journal.

This should be squashed with commit cb01f13f in future rebases.

https://phabricator.endlessm.com/T21739