### PR TITLE
iconGridLayout: Pass the right parameters to Gio.File.load_contents()

### DIFF
--- a/js/ui/iconGridLayout.js
+++ b/js/ui/iconGridLayout.js
@@ -117,8 +117,7 @@ var IconGridLayout = new Lang.Class({
             })
             .some(function(defaultsFile) {
                 try {
-                    let [success, data] = defaultsFile.load_contents(null, null,
-                                                                     null);
+                    let [success, data] = defaultsFile.load_contents(null);
                     jsonString = data.toString();
                     return true;
                 } catch (e) {


### PR DESCRIPTION
For some reason, we've been passing extra null parameters to this
function since forever, and keeping those wrong bits in past rebases.

This should be squashed along with 41cc7c26ef in future rebases.

https://phabricator.endlessm.com/T21738