### PR TITLE
popupMenu: Fix wrong call to clutter_actor_add_child()

### DIFF
--- a/js/ui/popupMenu.js
+++ b/js/ui/popupMenu.js
@@ -394,8 +394,9 @@ var PopupImageMenuItem = new Lang.Class({
     _init: function (text, icon, params) {
         this.parent(params);
 
-        this._icon = new St.Icon({ style_class: 'popup-menu-icon' });
-        this.actor.add_child(this._icon, { align: St.Align.END });
+        this._icon = new St.Icon({ style_class: 'popup-menu-icon',
+                                   x_align: Clutter.ActorAlign.END });
+        this.actor.add_child(this._icon);
         this.label = new St.Label({ text: text });
         this.actor.add_child(this.label);
         this.actor.label_actor = this.label;


### PR DESCRIPTION
Specify the horizontal alignment via the x_align property when creating
the StIcon, since this function expects one argument, not two.

https://phabricator.endlessm.com/T21741