### PR TITLE
network: Update the icon in the panel whenever NM's state changes

### DIFF
--- a/js/ui/status/network.js
+++ b/js/ui/status/network.js
@@ -1954,6 +1954,7 @@ var NMApplet = new Lang.Class({
         this.indicators.visible = this._client.nm_running;
         this.menu.actor.visible = this._client.networking_enabled;
 
+        this._updateIcon();
         this._syncConnectivity();
     },
 


### PR DESCRIPTION
Similar to what it's done when the main connection changes, we need
to make sure that the icon in the panel gets updated before calling
_syncConnectivity(), so that the icon gets always updated if needed,
regardless of whether there's an active connetion or not.

This is needed because there's at least one case when an icon should
be shown with the computer is not connected to any network: when a
hotspot has been enabled, which can be useful even if there's not
an internet connection to share (e.g. to easily allow connecting
other devices to the computer.

Closes: https://gitlab.gnome.org/GNOME/gnome-shell/issues/214

https://phabricator.endlessm.com/T22041