### PR TITLE
window-tracker: check WM_CLASS for sandboxed apps before the app's ID

### DIFF
--- a/src/shell-window-tracker.c
+++ b/src/shell-window-tracker.c
@@ -421,13 +421,6 @@ get_app_for_window (ShellWindowTracker    *tracker,
   if (meta_window_is_remote (window))
     return _shell_app_new_for_window (window);
 
-  /* Check if the window was opened from within a Flatpak sandbox; if this
-   * is the case, a corresponding .desktop file is guaranteed to match;
-   */
-  result = get_app_from_flatpak_id (window);
-  if (result != NULL)
-    return result;
-
   /* Check if the window has a GApplication ID attached; this is
    * canonical if it does
    */
@@ -439,6 +432,13 @@ get_app_for_window (ShellWindowTracker    *tracker,
    * canonical if it does.
    */
   result = get_app_from_window_wmclass (window);
+  if (result != NULL)
+    return result;
+
+  /* Check if the window was opened from within a Flatpak sandbox; if this
+   * is the case, a corresponding .desktop file is guaranteed to match;
+   */
+  result = get_app_from_flatpak_id (window);
   if (result != NULL)
     return result;
 


### PR DESCRIPTION
For sandboxed apps, the shell needs to consider the app's ID when
matching its windows against the right .desktop file, but that
check can't be done before having attempted to match using the
WM_CLASS property of the app's window, otherwise apps installing
multiple desktop files (e.g. LibreOffice) will always match every
single window against the same .desktop file, ignoring hints such
as the StartupWMClass key.

This commit moves the call to get_app_from_sandboxed_app_id() after
get_app_from_window_wmclass() and before get_app_from_window_pid(),
so that we only rely on the sandboxed app's ID when no match has
succeed using the WM_CLASS property, but before checking by PID to
prevent wrong groups that could be created when the PID of the app
inside the sandbox matches the one from a process outside of it.

Closes: https://gitlab.gnome.org/GNOME/gnome-shell/issues/219

https://phabricator.endlessm.com/T22113