### PR TITLE
Fix icons misalignment and two-line labels in a11y's Large Text mode

### DIFF
--- a/data/theme/gnome-shell-sass/_endless.scss
+++ b/data/theme/gnome-shell-sass/_endless.scss
@@ -807,9 +807,9 @@ popup-separator-menu-item {
 // Editable Labels
 
 .overview-icon-label {
-    padding: 4px 0 4px 0;
+    padding: 0;
     width: 118px;
-    height: 40px;
+    height: 46px;
     text-shadow: black 0px 2px 2px;
 
     border: none;

--- a/data/theme/gnome-shell-sass/_endless.scss
+++ b/data/theme/gnome-shell-sass/_endless.scss
@@ -488,8 +488,12 @@ popup-separator-menu-item {
 }
 
 %overview-icon {
+    width: 118px;
+    height: 118px;
     icon-size: 64px;
-    spacing: 0px;
+    spacing: 4px;
+    padding-top: 12px;
+    padding-bottom: 0px;
     border-radius: 15px;
     font-weight: bold;
     text-align: center;


### PR DESCRIPTION
https://phabricator.endlessm.com/T22226