### PR TITLE
bluetooth: Use more descriptive on/off label

### DIFF
--- a/js/ui/status/bluetooth.js
+++ b/js/ui/status/bluetooth.js
@@ -139,9 +139,9 @@ var Indicator = new Lang.Class({
             /* Translators: this is the number of connected bluetooth devices */
             this._item.label.text = ngettext("%d Connected", "%d Connected", nConnectedDevices).format(nConnectedDevices);
         else if (isBluetoothOff)
-            this._item.label.text = _("Off");
+            this._item.label.text = _("Bluetooth Off");
         else
-            this._item.label.text = _("On");
+            this._item.label.text = _("Bluetooth On");
 
         this._toggleItem.label.text = isBluetoothOff ? _("Turn On") : _("Turn Off");
     },


### PR DESCRIPTION
Many users don't know the bluetooth symbol, so it is helpful
if the menu label includes the word "Bluetooth".

https://phabricator.endlessm.com/T17492