### PR TITLE
messageTray: Hide the overview when activating notifications

### DIFF
--- a/js/ui/notificationDaemon.js
+++ b/js/ui/notificationDaemon.js
@@ -374,6 +374,7 @@ var FdoNotificationDaemon = new Lang.Class({
         if (hasDefaultAction) {
             notification.connect('activated', Lang.bind(this, function() {
                 this._emitActionInvoked(ndata.id, 'default');
+                Main.overview.hide();
             }));
         } else {
             notification.connect('activated', Lang.bind(this, function() {


### PR DESCRIPTION
In Endless, we normally enter the Overview when the last window
gets hidden by minimizing it, which would cause issues if we try
to indirectly interact with such applications while in that state
(e.g. via a notification) since, even if minimized, such application
is not expected to be invisible if the Overview is visible, since
in upstream GNOME Shell we'd be in the Window Picker mode.

Therefore, we need to make sure to hide the Overview whenever we
activate a notification with an action associated to it, similar
to what we do already in FdoNotificationDaemonSource::OpenApp(),
but for actions activated remotely in the source app via D-Bus.

https://phabricator.endlessm.com/T22100