### PR TITLE
fixup! messageTray: Hide the overview when activating notifications

### DIFF
--- a/js/ui/notificationDaemon.js
+++ b/js/ui/notificationDaemon.js
@@ -374,7 +374,6 @@ var FdoNotificationDaemon = new Lang.Class({
         if (hasDefaultAction) {
             notification.connect('activated', Lang.bind(this, function() {
                 this._emitActionInvoked(ndata.id, 'default');
-                Main.overview.hide();
             }));
         } else {
             notification.connect('activated', Lang.bind(this, function() {
@@ -455,6 +454,7 @@ var FdoNotificationDaemon = new Lang.Class({
     },
 
     _emitActionInvoked: function(id, action) {
+        Main.overview.hide();
         this._dbusImpl.emit_signal('ActionInvoked',
                                    GLib.Variant.new('(us)', [id, action]));
     }


### PR DESCRIPTION
This was the change I always wanted to propose in the previous PR,
but for some reason the updated branch didn't left my laptop and
never made it to github. Sorry about that.

https://phabricator.endlessm.com/T22100