### PR TITLE
appIconBar: use the right method to specify packing properties

### DIFF
--- a/js/ui/appIconBar.js
+++ b/js/ui/appIconBar.js
@@ -77,7 +77,7 @@ const WindowMenuItem = new Lang.Class({
 
         this.cloneBin = new St.Bin({ child: clone,
                                      style_class: 'panel-window-menu-item-clone' });
-        this.actor.add_child(this.cloneBin, { align: St.Align.MIDDLE });
+        this.actor.add(this.cloneBin, { align: St.Align.MIDDLE });
 
         this.label = new St.Label({ text: window.title,
                                     style_class: 'panel-window-menu-item-label',


### PR DESCRIPTION
ClutterContainer.add() is patched in js/ui/environment.js to allow passing
child properties. We use ClutterActor.add_child() though, which doesn't
allow that, and causes warnings on the terminal when that code is
reached.

https://phabricator.endlessm.com/T21741