### PR TITLE
fixup! networkAgent: Add switch button for metered connections

### DIFF
--- a/data/theme/gnome-shell-sass/_endless.scss
+++ b/data/theme/gnome-shell-sass/_endless.scss
@@ -923,3 +923,9 @@ popup-separator-menu-item {
   }
 }
 
+.metered-data-switch {
+  width: 48px;
+  background-image: url("resource:///org/gnome/shell/theme/toggle-off-hc.svg");
+  &:checked { background-image: url("resource:///org/gnome/shell/theme/toggle-on-hc.svg"); }
+}
+

--- a/js/ui/dialog.js
+++ b/js/ui/dialog.js
@@ -183,6 +183,18 @@ var MessageDialogContent = new Lang.Class({
             this[`_${prop}`].add_style_class_name(`message-dialog-${prop}`);
         });
 
+        if (params.center_title) {
+            let titleParams = { x_expand: true,
+                                x_align: Clutter.ActorAlign.CENTER };
+
+            Object.assign(this._title, titleParams);
+            Object.assign(this._title.clutter_text, titleParams);
+
+            this._title.clutter_text.line_alignment = Pango.Alignment.CENTER;
+
+            delete params['center_title'];
+        }
+
         let textProps = { ellipsize_mode: Pango.EllipsizeMode.NONE,
                           line_wrap: true };
         Object.assign(this._subtitle.clutter_text, textProps);


### PR DESCRIPTION
Per new design direction, we want the dialog labels to be centered
and use the High-Contrast toggle asset instead of the on|off switcher.

https://phabricator.endlessm.com/T22420