### PR TITLE
discoveryFeed: Tell the Discovery Feed when its window is fully hidden

### DIFF
--- a/js/ui/components/discoveryFeed.js
+++ b/js/ui/components/discoveryFeed.js
@@ -10,6 +10,7 @@ const DISCOVERY_FEED_PATH = '/com/endlessm/DiscoveryFeed';
 
 const DiscoveryFeedIface = '<node> \
 <interface name="' + DISCOVERY_FEED_NAME + '"> \
+<method name="notifyHideAnimationCompleted" /> \
 <method name="show"> \
   <arg type="u" direction="in" name="timestamp"/> \
 </method> \
@@ -38,12 +39,16 @@ var DiscoveryFeed = new Lang.Class({
         Main.discoveryFeed = null;
     },
 
+    notifyHideAnimationCompleted: function() {
+        this.proxy.notifyHideAnimationCompletedRemote();
+    },
+
     callShow: function(timestamp) {
         this.proxy.showRemote(timestamp);
     },
 
-    callHide: function(timestamp) {
-        this.proxy.hideRemote(timestamp);
+    callHide: function() {
+        this.proxy.hideRemote();
     }
 });
 var Component = DiscoveryFeed;

--- a/js/ui/windowManager.js
+++ b/js/ui/windowManager.js
@@ -2232,6 +2232,11 @@ var WindowManager = new Lang.Class({
                     this._showOtherWindows(actor, false);
             }
 
+            /* If this is the Discovery Feed, notify it that it has
+             * finished closing now */
+            if (SideComponent.isDiscoveryFeedWindow(actor.meta_window))
+                Main.discoveryFeed.notifyHideAnimationCompleted();
+
             shellwm.completed_destroy(actor);
         }
     },


### PR DESCRIPTION
The discovery feed window animates in and out and the overview is
only shown once the discovery feed window is fully hidden (if the
overview was showing before). The Discovery Feed needs to know
when its window is fully hidden, since then it can launch the
relevant app (which will ensure that the overview is not shown
part-way through a speedwagon window being shown).

https://phabricator.endlessm.com/T22448