### PR TITLE
Finish startup sequence for process that exit too early

### DIFF
--- a/src/shell-app.c
+++ b/src/shell-app.c
@@ -1254,11 +1254,36 @@ app_child_setup (gpointer user_data)
 #endif
 
 static void
+_shell_app_watch_callback (GPid      pid,
+                           gint      status,
+                           ShellApp *app)
+{
+  if (app->state == SHELL_APP_STATE_STARTING)
+    {
+      ShellWindowTracker *tracker = shell_window_tracker_get_default ();
+      GSList *startup_sequences = shell_window_tracker_get_startup_sequences (tracker);
+      GSList *iter = NULL;
+
+      for (iter = startup_sequences; iter; iter = g_slist_next (iter))
+        {
+          ShellStartupSequence *sequence = (ShellStartupSequence*) iter->data;
+          ShellApp *startup_app = shell_startup_sequence_get_app (sequence);
+          if (startup_app == app)
+            shell_startup_sequence_complete (sequence);
+        }
+
+      shell_app_state_transition (app, SHELL_APP_STATE_STOPPED);
+    }
+
+  g_spawn_close_pid (pid);
+}
+
+static void
 wait_pid (GDesktopAppInfo *appinfo,
           GPid             pid,
-          gpointer         user_data)
+          ShellApp        *app)
 {
-  g_child_watch_add (pid, (GChildWatchFunc) g_spawn_close_pid, NULL);
+  g_child_watch_add (pid, (GChildWatchFunc) _shell_app_watch_callback, app);
 }
 
 /**
@@ -1305,7 +1330,8 @@ shell_app_launch (ShellApp     *app,
 #else
                                                    NULL, NULL,
 #endif
-                                                   wait_pid, NULL,
+                                                   (GDesktopAppLaunchCallback) wait_pid,
+                                                   app,
                                                    error);
   g_object_unref (context);
 

--- a/src/shell-window-tracker.c
+++ b/src/shell-window-tracker.c
@@ -1008,6 +1008,11 @@ shell_startup_sequence_create_icon (ShellStartupSequence *sequence, guint size)
   return texture;
 }
 
+void
+shell_startup_sequence_complete (ShellStartupSequence *sequence)
+{
+  sn_startup_sequence_complete ((SnStartupSequence*)sequence);
+}
 
 /**
  * shell_window_tracker_get_default:

--- a/src/shell-window-tracker.h
+++ b/src/shell-window-tracker.h
@@ -44,6 +44,7 @@ const char *shell_startup_sequence_get_name (ShellStartupSequence *sequence);
 gboolean shell_startup_sequence_get_completed (ShellStartupSequence *sequence);
 int shell_startup_sequence_get_workspace (ShellStartupSequence *sequence);
 ClutterActor *shell_startup_sequence_create_icon (ShellStartupSequence *sequence, guint size);
+void shell_startup_sequence_complete (ShellStartupSequence *sequence);
 
 G_END_DECLS
 


### PR DESCRIPTION
Add a new public method in ShellWindowTracker to wrap sn_startup_sequence_complete() and use that to make sure that these kind of applications get their startup sequences completed, and then properly moved to STOPPED.

https://phabricator.endlessm.com/T22416