### PR TITLE
discoveryFeed: Revert accidental change to callHide

### DIFF
--- a/js/ui/components/discoveryFeed.js
+++ b/js/ui/components/discoveryFeed.js
@@ -47,8 +47,8 @@ var DiscoveryFeed = new Lang.Class({
         this.proxy.showRemote(timestamp);
     },
 
-    callHide: function() {
-        this.proxy.hideRemote();
+    callHide: function(timestamp) {
+        this.proxy.hideRemote(timestamp);
     }
 });
 var Component = DiscoveryFeed;


### PR DESCRIPTION
We removed the "timestamp" argument to callHide, but this
was unintentional.

https://phabricator.endlessm.com/T22488