### PR TITLE
payg: Round down seconds to the nearest lower integer for notifications

### DIFF
--- a/js/misc/paygManager.js
+++ b/js/misc/paygManager.js
@@ -135,7 +135,7 @@ function _isPaygEnabled() {
 //   - 172800 seconds => "2 days"
 function timeToString(seconds) {
     if (seconds < 60)
-        return Gettext.ngettext("%s second", "%s seconds", seconds).format(seconds);
+        return Gettext.ngettext("%s second", "%s seconds", seconds).format(Math.floor(seconds));
 
     let minutes = Math.floor(seconds / 60);
     if (minutes < 120)


### PR DESCRIPTION
Silly mistake, I forgot to call Math.floor() when printing a number of
seconds in the notification bubble, as it's done when the amount of time
remaining is more than a minute. Do it now to fix this.

https://phabricator.endlessm.com/T22590