### PR TITLE
wobbly: Use the paint box offsets to compute the right paint volume

### DIFF
--- a/src/wobbly-effect.c
+++ b/src/wobbly-effect.c
@@ -64,6 +64,12 @@ G_DEFINE_TYPE_WITH_PRIVATE (EndlessShellFXWobbly,
                             endless_shell_fx_wobbly,
                             CLUTTER_TYPE_DEFORM_EFFECT)
 
+/* Forward declaration so that we can set the function pointer
+ * in enforce_no_effects_paint_box_cleanup below */
+static gboolean
+endless_shell_fx_wobbly_get_paint_volume (ClutterEffect    *effect,
+                                          ClutterPaintVolume *volume);
+
 static gboolean
 endless_shell_fx_wobbly_lie_about_paint_volume (ClutterEffect    *effect,
                                                 ClutterPaintVolume *volume)

--- a/src/wobbly-effect.c
+++ b/src/wobbly-effect.c
@@ -167,7 +167,8 @@ static gboolean
 endless_shell_fx_wobbly_get_paint_volume (ClutterEffect    *effect,
                                           ClutterPaintVolume *volume)
 {
-  ClutterActor *actor = clutter_actor_meta_get_actor (CLUTTER_ACTOR_META (effect));
+  ClutterActorMeta *meta = CLUTTER_ACTOR_META (effect);
+  ClutterActor *actor = clutter_actor_meta_get_actor (meta);
   EndlessShellFXWobbly *wobbly_effect = ENDLESS_SHELL_FX_WOBBLY (effect);
   EndlessShellFXWobblyPrivate *priv =
     endless_shell_fx_wobbly_get_instance_private (wobbly_effect);
@@ -176,7 +177,7 @@ endless_shell_fx_wobbly_get_paint_volume (ClutterEffect    *effect,
    * TRUE here. */
   CLUTTER_EFFECT_CLASS (endless_shell_fx_wobbly_parent_class)->get_paint_volume (effect, volume);
 
-  if (priv->model)
+  if (priv->model && clutter_actor_meta_get_enabled (meta))
     {
       float actor_x, actor_y;
       float actor_paint_box_x, actor_paint_box_y;
@@ -227,11 +228,17 @@ endless_shell_fx_wobbly_get_paint_volume (ClutterEffect    *effect,
 static gboolean
 endless_shell_fx_wobbly_pre_paint (ClutterEffect *effect)
 {
+  ClutterActorMeta *meta = CLUTTER_ACTOR_META (effect);
   EndlessShellFXWobbly *wobbly_effect = ENDLESS_SHELL_FX_WOBBLY (effect);
   EndlessShellFXWobblyClass *klass = ENDLESS_SHELL_FX_WOBBLY_GET_CLASS (wobbly_effect);
   ClutterEffectClass *effect_class = CLUTTER_EFFECT_CLASS (klass);
 
-  g_auto(EnforcedPaintBox) forced_client_paint_box = enforce_no_effects_paint_box (effect_class);
+  if (clutter_actor_meta_get_enabled (meta))
+    {
+      g_auto(EnforcedPaintBox) forced_client_paint_box = enforce_no_effects_paint_box (effect_class);
+
+      return CLUTTER_EFFECT_CLASS (endless_shell_fx_wobbly_parent_class)->pre_paint (effect);
+    }
 
   return CLUTTER_EFFECT_CLASS (endless_shell_fx_wobbly_parent_class)->pre_paint (effect);
 }

--- a/src/wobbly-effect.c
+++ b/src/wobbly-effect.c
@@ -167,6 +167,7 @@ static gboolean
 endless_shell_fx_wobbly_get_paint_volume (ClutterEffect    *effect,
                                           ClutterPaintVolume *volume)
 {
+  ClutterActor *actor = clutter_actor_meta_get_actor (CLUTTER_ACTOR_META (effect));
   EndlessShellFXWobbly *wobbly_effect = ENDLESS_SHELL_FX_WOBBLY (effect);
   EndlessShellFXWobblyPrivate *priv =
     endless_shell_fx_wobbly_get_instance_private (wobbly_effect);
@@ -177,6 +178,17 @@ endless_shell_fx_wobbly_get_paint_volume (ClutterEffect    *effect,
 
   if (priv->model)
     {
+      float actor_x, actor_y;
+      float actor_paint_box_x, actor_paint_box_y;
+      endless_shell_fx_get_actor_only_paint_box_rect (wobbly_effect,
+                                                      actor,
+                                                      &actor_paint_box_x,
+                                                      &actor_paint_box_y,
+                                                      NULL,
+                                                      NULL);
+      clutter_actor_get_position (actor, &actor_x, &actor_y);
+
+      WobblyVector offset = { actor_paint_box_x - actor_x, actor_paint_box_y - actor_y };
       WobblyVector extremes[4];
 
       wobbly_model_query_extremes (priv->model,
@@ -192,10 +204,10 @@ endless_shell_fx_wobbly_get_paint_volume (ClutterEffect    *effect,
 
       ClutterActorBox const extremesBox =
         {
-          floor (x1),
-          floor (y1),
-          ceil (x2),
-          ceil (y2)
+          floor (x1 + offset.x),
+          floor (y1 + offset.y),
+          ceil (x2 + offset.x),
+          ceil (y2 + offset.x)
         };
 
       clutter_paint_volume_union_box (volume, &extremesBox);


### PR DESCRIPTION
Since the model is computed from the actor only paint box which
will be in the [0, model_geometry] space, this doesn't include
the top and left shadow offsets, so we need to apply them after
the fact. This corrects the computed paint volume so that there are
no shadow artifacts.

https://phabricator.endlessm.com/T23039