### PR TITLE
T23208: Drop libwobbly dependency, switch to libwobbly-glib-0.3

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -110,8 +110,8 @@ m_dep = cc.find_library('m', required: false)
 eosmetrics_dep = dependency('eosmetrics-0')
 
 # Endless-specific: Wobbly windows
-libwobbly_dep = dependency('libwindowfx_wobbly')
-libeos_shell_fx_deps = [mutter_dep, gdk_pixbuf_dep, libwobbly_dep]
+libwobbly_glib_dep = dependency('libwindowfx_wobbly_glib-0.3')
+libeos_shell_fx_deps = [mutter_dep, gdk_pixbuf_dep, libwobbly_glib_dep, m_dep]
 
 # Endless-specific: Required for keyboard layout switcher in password entries
 xkbcommon_dep = dependency('xkbcommon')

--- a/src/meson.build
+++ b/src/meson.build
@@ -55,7 +55,7 @@ gnome_shell_deps = [
   gcr_dep,
   systemd_dep,
   eosmetrics_dep,
-  libwobbly_dep,
+  libwobbly_glib_dep,
   xkbcommon_dep
 ]
 
@@ -190,7 +190,7 @@ if enable_recorder
 endif
 
 libeos_shell_fx_sources = [
-  'wobbly-effect.cpp',
+  'wobbly-effect.c',
   'wobbly-effect.h'
 ]
 
@@ -198,7 +198,6 @@ libeos_shell_fx = library('eos-shell-fx',
   sources: libeos_shell_fx_sources,
   dependencies: libeos_shell_fx_deps,
   include_directories: conf_inc,
-  cpp_args: ['-std=c++11'],
   build_rpath: mutter_typelibdir,
   install_rpath: mutter_typelibdir,
   install_dir: pkglibdir,


### PR DESCRIPTION
This PR drops the dependency on libwobbly's C++ API and moves to using libwobbly-glib (the C API). Amongst other things, using this API means that we no longer have a single C++ file cluttering up the build.

https://phabricator.endlessm.com/T23208