### PR TITLE
shell-app-system: obey X-Flatpak-RenamedFrom

### DIFF
--- a/src/shell-app-system.c
+++ b/src/shell-app-system.c
@@ -25,11 +25,26 @@
  */
 #define SHELL_APP_IS_OPEN_EVENT "b5e11a3d-13f8-4219-84fd-c9ba0bf3d1f0"
 
-/* Additional key used to map a renamed desktop file to its previous name;
- * for instance, org.gnome.Totem.desktop would use this key to point to
- * 'totem.desktop'
+/* Additional key used to map a renamed desktop file to its previous name.
+ * For instance, org.gnome.Totem.desktop contains:
+ *
+ *   X-Endless-Alias=totem
+ *
+ * (without the .desktop suffix).
  */
 #define X_ENDLESS_ALIAS_KEY     "X-Endless-Alias"
+
+/* Additional key listing 0 or more previous names for an application. This is
+ * added by flatpak-builder when the manifest contains a rename-desktop-file
+ * key, and by Endless-specific tools to migrate from an app in our eos-apps
+ * repository to the same app with a different ID on Flathub. For example,
+ * org.inkscape.Inkscape.desktop contains:
+ *
+ *   X-Flatpak-RenamedFrom=inkscape.desktop;
+ *
+ * (with the .desktop suffix).
+ */
+#define X_FLATPAK_RENAMED_FROM_KEY "X-Flatpak-RenamedFrom"
 
 /* Vendor prefixes are something that can be preprended to a .desktop
  * file name.  Undo this.
@@ -113,12 +128,37 @@ add_aliases (ShellAppSystem  *self,
 {
   ShellAppSystemPrivate *priv = self->priv;
   const char *alias;
+  g_autofree char *renamed_from = NULL;
 
   alias = g_desktop_app_info_get_string (info, X_ENDLESS_ALIAS_KEY);
   if (alias != NULL)
     {
       char *desktop_alias = g_strconcat (alias, ".desktop", NULL);
       g_hash_table_insert (priv->alias_to_id, desktop_alias, g_strdup (id));
+    }
+
+  /* GDesktopAppInfo does not provide a way to get a string list from the
+   * .desktop file. Open-code it for now.
+   *
+   * https://gitlab.gnome.org/GNOME/glib/merge_requests/339
+   */
+  renamed_from = g_desktop_app_info_get_string (info, X_FLATPAK_RENAMED_FROM_KEY);
+  if (renamed_from != NULL)
+    {
+      gchar **renamed_from_list = g_strsplit (renamed_from, ";",  -1);
+      size_t i;
+
+      for (i = 0; renamed_from_list[i] != NULL; i++)
+        {
+          if (renamed_from_list[i] != '\0')
+            g_hash_table_insert (priv->alias_to_id,
+                                 g_steal_pointer (&renamed_from_list[i]),
+                                 g_strdup (id));
+          else
+            g_free (renamed_from_list[i]);
+        }
+
+      g_free (renamed_from_list);
     }
 }
 


### PR DESCRIPTION
Tested as follows:

* Installed Pidgin from Flathub (it has `X-Flatpak-RenamedFrom=pidgin.desktop;`)
* Manually edited the `icon-grid-layout` property to replace `org.libreoffice.LibreOffice-writer.desktop` with `libreoffice-writer.desktop` (this has `X-Endless-Alias`) and `im.pidgin.Pidgin.desktop` with `pidgin.desktop`
* Restarted the unmodified shell: Writer was still shown on the desktop but Pidgin disappeared
* Started the modified shell: both were shown on the desktop

https://phabricator.endlessm.com/T22596