### PR TITLE
appFavorites: respect X-Endless-Alias and X-Flatpak-RenamedFrom

### DIFF
--- a/js/ui/appFavorites.js
+++ b/js/ui/appFavorites.js
@@ -82,6 +82,11 @@ var AppFavorites = new Lang.Class({
                 updated = true;
                 return newId;
             }
+            let newApp = appSys.lookup_alias(id);
+            if (newApp) {
+                updated = true;
+                return newApp.get_id();
+            }
             return id;
         });
         // ... and write back the updated desktop file names


### PR DESCRIPTION
Previously, we handled renamed apps on the icon grid, but not on the
taskbar.

There is some clear overlap with the RENAMED_DESKTOP_IDS in this file,
which is inherited from upstream;
https://gitlab.gnome.org/GNOME/gnome-shell/issues/593 filed to discuss
upstreaming our approach.

Tested as follows:

* `gsettings set org.gnome.shell favorite-apps "['org.gnome.Software.desktop', 'google-chrome.desktop', 'org.gnome.Nautilus.desktop', 'org.gnome.Terminal.desktop', 'libreoffice-writer.desktop', 'pidgin.desktop']"`
* Restart the unmodified shell: neither LibreOffice nor Pidgin show on the taskbar
* Start the modified shell: both LibreOffice (X-Endless-Alias) and Pidgin (X-Flatpak-RenamedFrom) show on the taskbar

https://phabricator.endlessm.com/T22596