### PR TITLE
Fix sorting App Center below other apps when searching for "app"

### DIFF
--- a/js/ui/appDisplay.js
+++ b/js/ui/appDisplay.js
@@ -1599,8 +1599,8 @@ var AppSearchProvider = new Lang.Class({
 
         // resort to keep results on the desktop grid before the others
         results = results.sort(function(a, b) {
-            let hasA = IconGridLayout.layout.hasIcon(a);
-            let hasB = IconGridLayout.layout.hasIcon(b);
+            let hasA = a === EOS_APP_CENTER_ID || IconGridLayout.layout.hasIcon(a);
+            let hasB = b === EOS_APP_CENTER_ID || IconGridLayout.layout.hasIcon(b);
 
             if (hasA)
                 return -1;

--- a/js/ui/appDisplay.js
+++ b/js/ui/appDisplay.js
@@ -1602,12 +1602,7 @@ var AppSearchProvider = new Lang.Class({
             let hasA = a === EOS_APP_CENTER_ID || IconGridLayout.layout.hasIcon(a);
             let hasB = b === EOS_APP_CENTER_ID || IconGridLayout.layout.hasIcon(b);
 
-            if (hasA)
-                return -1;
-            if (hasB)
-                return 1;
-
-            return 0;
+            return hasB - hasA;
         });
 
         // perform replacements by removing replaceable apps


### PR DESCRIPTION
The app center is special, since it's always pinned to the end of the grid
and is not part of the IconGridLayout.

The visible symptom of this is that searching for 'app' would rank other
apps (on my system, Steam, D-Feet and KeepAssXC, whose descriptions happen
to contain 'app') above the app center, which is correctly returned in the
highest-ranked group of results from g_desktop_app_info_search() since its
name matches the search.

I also noticed that this comparison function is poorly behaved; while that
wasn't the cause of this bug, it is worth fixing.

https://phabricator.endlessm.com/T23669