### PR TITLE
fixup! shell-app-system: refactor duplicated X-Endless-Alias code

### DIFF
--- a/src/shell-app-system.c
+++ b/src/shell-app-system.c
@@ -413,7 +413,7 @@ shell_app_system_lookup_app (ShellAppSystem   *self,
 {
   ShellAppSystemPrivate *priv = self->priv;
   ShellApp *app;
-  GDesktopAppInfo *info;
+  g_autoptr(GDesktopAppInfo) info = NULL;
   g_autofree char *alias = NULL;
 
   app = g_hash_table_lookup (priv->id_to_app, id);
@@ -426,9 +426,7 @@ shell_app_system_lookup_app (ShellAppSystem   *self,
 
   app = _shell_app_new (info);
   g_hash_table_insert (priv->id_to_app, (char *) shell_app_get_id (app), app);
-  g_object_unref (info);
-
-  add_aliases (self, id, app);
+  add_aliases (self, id, info);
 
   return app;
 }


### PR DESCRIPTION
The original version of this code was incorrect. The third argument to
add_aliases() is a GDesktopAppInfo *, but shell_app_system_lookup_app()
passed the ShellApp * instead. (The compiler warns about this, but it's
not fatal and I missed it.)

This is presumably the cause of this repeated warning I spotted in the
journal:

  g_desktop_app_info_get_string: assertion 'G_IS_DESKTOP_APP_INFO (info)' failed

https://phabricator.endlessm.com/T22596