### PR TITLE
Improve .desktop file change detection

### DIFF
--- a/js/ui/appDisplay.js
+++ b/js/ui/appDisplay.js
@@ -282,6 +282,20 @@ var BaseAppView = new Lang.Class({
             // The icon image changed
             if (newIconInfo && !newIconInfo.equal(oldIconInfo))
                 return true;
+
+            if (item instanceof Shell.App) {
+                if (!(currentIcon instanceof AppIcon) || !currentIcon.app) {
+                    // Should not happen: the IDs are the same so if the new
+                    // item is an app, so should be the existing icon.
+                    return true;
+                }
+
+                if (!Shell.AppSystem.app_info_equal(item.get_app_info(),
+                                                    currentIcon.app.get_app_info()))
+                    return true;
+            }
+            // TODO: deep equality for folders; at present the miniature icons
+            // will not update until the folder is next opened.
         }
 
         return false;

--- a/js/ui/appIconBar.js
+++ b/js/ui/appIconBar.js
@@ -627,7 +627,9 @@ const ScrolledIconList = new Lang.Class({
                              app: app });
         }
 
-        let favorites = AppFavorites.getAppFavorites().getFavorites();
+        let appFavorites = AppFavorites.getAppFavorites();
+        appFavorites.connect('changed', this._onAppFavoritesChanged.bind(this));
+        let favorites = appFavorites.getFavorites();
         for (let i = 0; i < favorites.length; i++) {
             this._addButtonAnimated(favorites[i]);
         }
@@ -800,7 +802,7 @@ const ScrolledIconList = new Lang.Class({
         return -1;
     },
 
-    _addButtonAnimated: function(app) {
+    _addButtonAnimated: function(app, oldChild) {
         if (this._taskbarApps.has(app) || !this._isAppInteresting(app))
             return;
 
@@ -815,19 +817,57 @@ const ScrolledIconList = new Lang.Class({
         });
         newChild.connect('app-icon-unpinned', () => {
             favorites.removeFavorite(app.get_id());
-            if (app.state == Shell.AppState.STOPPED) {
-                newChild.destroy();
-                this._taskbarApps.delete(app);
-                this._updatePage();
-            }
         });
         this._taskbarApps.set(app, newChild);
 
-        this._container.add_actor(newChild);
+        if (oldChild)
+            this._container.replace_child(oldChild, newChild);
+        else
+            this._container.add_actor(newChild);
     },
 
     _addButton: function(app) {
         this._addButtonAnimated(app);
+    },
+
+    _onAppFavoritesChanged(appFavorites) {
+        let favoriteMap = appFavorites.getFavoriteMap();
+        var changed = false;
+
+        // Update existing favorites, and add new ones.
+        for (let id in favoriteMap) {
+            let app = favoriteMap[id];
+            if (!this._taskbarApps.has(app)) {
+                var childToReplace = null;
+
+                for (let [oldApp, oldChild] of this._taskbarApps) {
+                    if (oldApp.get_id() === id) {
+                        this._taskbarApps.delete(oldApp);
+                        childToReplace = oldChild;
+                        break;
+                    }
+                }
+
+                // TODO: in the case where no existing app matches, put the new
+                // app at the right position, not the end.
+                this._addButtonAnimated(app, childToReplace);
+                if (childToReplace)
+                    childToReplace.destroy();
+                changed = true;
+            }
+        }
+
+        // Get rid of any removed favorites
+        for (let [oldApp, oldChild] of this._taskbarApps) {
+            if (!this._isAppInteresting(oldApp)) {
+                oldChild.destroy();
+                this._taskbarApps.delete(oldApp);
+                changed = true;
+            }
+        }
+
+        if (changed)
+            this._updatePage();
     },
 
     _onAppStateChanged: function(appSys, app) {

--- a/js/ui/appIconBar.js
+++ b/js/ui/appIconBar.js
@@ -643,6 +643,7 @@ const ScrolledIconList = new Lang.Class({
             this._addButtonAnimated(app);
         }
 
+        appSys.connect('installed-changed', this._onInstalledChanged.bind(this));
         appSys.connect('app-state-changed', this._onAppStateChanged.bind(this));
     },
 
@@ -868,6 +869,12 @@ const ScrolledIconList = new Lang.Class({
 
         if (changed)
             this._updatePage();
+    },
+
+    _onInstalledChanged(appSys) {
+        let appFavorites = AppFavorites.getAppFavorites();
+        appFavorites.reload();
+        this._onAppFavoritesChanged(appFavorites);
     },
 
     _onAppStateChanged: function(appSys, app) {

--- a/js/ui/appIconBar.js
+++ b/js/ui/appIconBar.js
@@ -892,8 +892,7 @@ const ScrolledIconList = new Lang.Class({
 
             let oldChild = this._taskbarApps.get(app);
             if (oldChild) {
-                let oldButton = this._taskbarApps.get(app);
-                this._container.remove_actor(oldButton);
+                this._container.remove_actor(oldChild);
                 this._taskbarApps.delete(app);
             }
 

--- a/src/shell-app-system.c
+++ b/src/shell-app-system.c
@@ -214,10 +214,40 @@ scan_startup_wm_class_to_id (ShellAppSystem *self)
 }
 
 static gboolean
+shell_app_system_app_info_equal (GDesktopAppInfo *one,
+                                 GDesktopAppInfo *two)
+{
+  GAppInfo *one_info, *two_info;
+
+  g_return_val_if_fail (G_IS_DESKTOP_APP_INFO (one), FALSE);
+  g_return_val_if_fail (G_IS_DESKTOP_APP_INFO (two), FALSE);
+
+  one_info = G_APP_INFO (one);
+  two_info = G_APP_INFO (two);
+
+  return
+    g_app_info_equal (one_info, two_info) &&
+    g_app_info_should_show (one_info) == g_app_info_should_show (two_info) &&
+    g_strcmp0 (g_desktop_app_info_get_filename (one),
+               g_desktop_app_info_get_filename (two)) == 0 &&
+    g_strcmp0 (g_app_info_get_executable (one_info),
+               g_app_info_get_executable (two_info)) == 0 &&
+    g_strcmp0 (g_app_info_get_commandline (one_info),
+               g_app_info_get_commandline (two_info)) == 0 &&
+    g_strcmp0 (g_app_info_get_name (one_info),
+               g_app_info_get_name (two_info)) == 0 &&
+    g_strcmp0 (g_app_info_get_description (one_info),
+               g_app_info_get_description (two_info)) == 0 &&
+    g_strcmp0 (g_app_info_get_display_name (one_info),
+               g_app_info_get_display_name (two_info)) == 0 &&
+    g_icon_equal (g_app_info_get_icon (one_info),
+                  g_app_info_get_icon (two_info));
+}
+
+static gboolean
 app_is_stale (ShellApp *app)
 {
   GDesktopAppInfo *info, *old;
-  GAppInfo *old_info, *new_info;
   gboolean is_unchanged;
 
   if (shell_app_is_window_backed (app))
@@ -228,25 +258,8 @@ app_is_stale (ShellApp *app)
     return TRUE;
 
   old = shell_app_get_app_info (app);
-  old_info = G_APP_INFO (old);
-  new_info = G_APP_INFO (info);
 
-  is_unchanged =
-    g_app_info_should_show (old_info) == g_app_info_should_show (new_info) &&
-    strcmp (g_desktop_app_info_get_filename (old),
-            g_desktop_app_info_get_filename (info)) == 0 &&
-    g_strcmp0 (g_app_info_get_executable (old_info),
-               g_app_info_get_executable (new_info)) == 0 &&
-    g_strcmp0 (g_app_info_get_commandline (old_info),
-               g_app_info_get_commandline (new_info)) == 0 &&
-    strcmp (g_app_info_get_name (old_info),
-            g_app_info_get_name (new_info)) == 0 &&
-    g_strcmp0 (g_app_info_get_description (old_info),
-               g_app_info_get_description (new_info)) == 0 &&
-    strcmp (g_app_info_get_display_name (old_info),
-            g_app_info_get_display_name (new_info)) == 0 &&
-    g_icon_equal (g_app_info_get_icon (old_info),
-                  g_app_info_get_icon (new_info));
+  is_unchanged = shell_app_system_app_info_equal (old, info);
 
   g_object_unref (info);
   return !is_unchanged;
@@ -276,33 +289,12 @@ get_new_desktop_app_info_from_app (ShellApp *app)
 static gboolean
 app_info_changed (ShellApp *app, GDesktopAppInfo *desk_new_info)
 {
-  GIcon *app_icon;
-  GIcon *new_icon;
   GDesktopAppInfo *desk_app_info = shell_app_get_app_info (app);
-  GAppInfo *app_info = G_APP_INFO (desk_app_info);
-  GAppInfo *new_info = G_APP_INFO (desk_new_info);
 
-  if (!app_info)
+  if (!desk_app_info)
     return TRUE;
 
-  app_icon = g_app_info_get_icon (app_info);
-  new_icon = g_app_info_get_icon (new_info);
-
-  return !(g_app_info_equal (app_info, new_info) &&
-           g_icon_equal (app_icon, new_icon) &&
-           g_app_info_should_show (app_info) == g_app_info_should_show (new_info) &&
-           strcmp (g_desktop_app_info_get_filename (desk_app_info),
-                   g_desktop_app_info_get_filename (desk_new_info)) == 0 &&
-           g_strcmp0 (g_app_info_get_executable (app_info),
-                      g_app_info_get_executable (new_info)) == 0 &&
-           g_strcmp0 (g_app_info_get_commandline (app_info),
-                      g_app_info_get_commandline (new_info)) == 0 &&
-           strcmp (g_app_info_get_name (app_info),
-                   g_app_info_get_name (new_info)) == 0 &&
-           strcmp (g_app_info_get_display_name (app_info),
-                   g_app_info_get_display_name (new_info)) == 0 &&
-           g_strcmp0 (g_app_info_get_description (app_info),
-                      g_app_info_get_description (new_info)) == 0);
+  return !shell_app_system_app_info_equal (desk_app_info, desk_new_info);
 }
 
 static void

--- a/src/shell-app-system.c
+++ b/src/shell-app-system.c
@@ -213,7 +213,19 @@ scan_startup_wm_class_to_id (ShellAppSystem *self)
   g_list_free_full (apps, g_object_unref);
 }
 
-static gboolean
+/**
+ * shell_app_system_app_info_equal:
+ * @one: (transfer none): a #GDesktopAppInfo
+ * @two: (transfer none): a possibly-different #GDesktopAppInfo
+ *
+ * Returns %TRUE if @one and @two can be treated as equal. Compared to
+ * g_app_info_equal(), which just compares app IDs, this function also compares
+ * fields of interest to the shell: icon, name, description, executable, and
+ * should_show().
+ *
+ * Returns: %TRUE if @one and @two are equivalent; %FALSE otherwise
+ */
+gboolean
 shell_app_system_app_info_equal (GDesktopAppInfo *one,
                                  GDesktopAppInfo *two)
 {

--- a/src/shell-app-system.h
+++ b/src/shell-app-system.h
@@ -31,4 +31,6 @@ char         ***shell_app_system_search                    (const char *search_s
 
 gboolean        shell_app_system_has_starting_apps         (ShellAppSystem  *self);
 
+gboolean        shell_app_system_app_info_equal            (GDesktopAppInfo *one,
+                                                            GDesktopAppInfo *two);
 #endif /* __SHELL_APP_SYSTEM_H__ */


### PR DESCRIPTION
Superset of #303 with a fix for this bug:

* Foo is on the desktop; `org.foo.Foo.desktop` contains the line `Exec=zenity --info --text Foo`
* During the session, the user (or automatic updates) installs an update for Foo; `org.foo.Foo.desktop` now contains the line `Exec=zenity --info --text FooBar`
* User clicks the Foo icon on the desktop; the old `Exec=` line is still used

In practice, this bug manifests itself when migrating from the KDE 4 version of ktuberling in eos-apps (which uses `-caption %c` in its desktop file) to the KDE 5 version on Flathub (which uses `-qwindowtitle %c`). The `-caption` syntax is not supported by the Flathub version; as a result, the app can't be launched from the desktop 

**TODO**:
* [x] the same stale-.desktop-file bug for apps pinned to the taskbar (this is because it doesn't monitor ::installed-changed; the upstream logic in dash.js does) (fixed in this branch)
* [x] the taskbar not updating when the favorite-apps gsetting is modified externally (fixed in this branch)
* [x] if an app is in a folder, and its .desktop file's Icon= key changes while the folder is collapsed, the preview will not be updated until the folder is opened (deferred https://phabricator.endlessm.com/T23905)
* [x] if an app is in a folder, and it's updated while the folder is open, changes to `Exec=` will be ignored until the folder is closed (deferred https://phabricator.endlessm.com/T23905)
* [x] Test this code on master

https://phabricator.endlessm.com/T23877