### PR TITLE
Fix unbounded recursion bug & some unrelated warnings

### DIFF
--- a/js/ui/appFavorites.js
+++ b/js/ui/appFavorites.js
@@ -83,7 +83,7 @@ var AppFavorites = new Lang.Class({
                 return newId;
             }
             let newApp = appSys.lookup_alias(id);
-            if (newApp) {
+            if (newApp && newApp.get_id() !== id) {
                 updated = true;
                 return newApp.get_id();
             }

--- a/js/ui/endSessionDialog.js
+++ b/js/ui/endSessionDialog.js
@@ -799,7 +799,7 @@ var EndSessionDialog = new Lang.Class({
         let updatePrepared = this._pkOfflineProxy ? this._pkOfflineProxy.UpdatePrepared : false;
         let updatesAllowed = this._updatesPermission && this._updatesPermission.allowed;
 
-        _setCheckBoxLabel(this._checkBox, dialogContent.checkBoxText);
+        _setCheckBoxLabel(this._checkBox, dialogContent.checkBoxText || '');
         this._checkBox.actor.visible = (dialogContent.checkBoxText && updatePrepared && updatesAllowed);
         this._checkBox.actor.checked = (updatePrepared && updateTriggered);
 

--- a/js/ui/workspacesView.js
+++ b/js/ui/workspacesView.js
@@ -476,6 +476,7 @@ var WorkspacesDisplay = new Lang.Class({
         this._switchWorkspaceNotifyId = 0;
 
         this._notifyOpacityId = 0;
+        this._restackedNotifyId = 0;
         this._scrollEventId = 0;
         this._keyPressEventId = 0;
 


### PR DESCRIPTION
The first patch fixes a regression introduced in #299. My (weak) claim is that I missed it in testing because the shell routinely prints warnings, including during startup where the bug would be triggered; as penance, I fixed a few "undefined property" warnings upstream and cherry-picked the fixes here as the middle 2 patches.

https://phabricator.endlessm.com/T22596