### PR TITLE
Flip To Hack

### DIFF
--- a/data/theme/gnome-shell-sass/_endless.scss
+++ b/data/theme/gnome-shell-sass/_endless.scss
@@ -759,8 +759,8 @@ popup-separator-menu-item {
   opacity: 0.902;
   box-shadow: 0px 1px 3px 0px rgba(36, 34, 34, 0.6);
   border-radius: 9px 0px 0px 9px;
-  width: 35px;
-  height: 35px;
+  width: 64px;
+  height: 64px;
 
   .view-source-icon {
       color: #222;

--- a/js/ui/codeView.js
+++ b/js/ui/codeView.js
@@ -405,6 +405,7 @@ var CodingSession = new Lang.Class({
 
     _init: function(params) {
         this._app = null;
+        this._button = null;
         this._toolbox = null;
         this._appRemovedActor = null;
         this.appRemovedByFlipBack = false;
@@ -429,7 +430,6 @@ var CodingSession = new Lang.Class({
                                     '/com/endlessm/HackToolbox');
         this._toolboxAppActionGroup.list_actions();
 
-        this.button.connect('clicked', this._switchWindows.bind(this));
         this._windowsRestackedId = Main.overview.connect('windows-restacked',
                                                          this._windowsRestacked.bind(this));
         this._windowMinimizedId = global.window_manager.connect('minimize',
@@ -458,6 +458,16 @@ var CodingSession = new Lang.Class({
 
     get toolbox() {
         return this._toolbox;
+    },
+
+    set button(value) {
+        this._button = value;
+        if (this._button)
+            this._button.connect('clicked', this._switchWindows.bind(this));
+    },
+
+    get button() {
+        return this._button;
     },
 
     _setupAnimation: function(targetState, src, oldDst, newDst, direction) {

--- a/js/ui/codeView.js
+++ b/js/ui/codeView.js
@@ -723,10 +723,6 @@ var CodingSession = new Lang.Class({
                                   Gtk.DirectionType.LEFT);
             this._state = STATE_TOOLBOX;
         }
-
-        // Support a 'flip' action in the app too, if it exposes it
-        if (this._appActionProxy.has_action('flip'))
-            this._appActionProxy.activate_action('flip', new GLib.Variant('b', true));
     },
 
     _switchToApp: function() {
@@ -743,10 +739,6 @@ var CodingSession = new Lang.Class({
                                   Gtk.DirectionType.RIGHT);
             this._state = STATE_APP;
         }
-
-        // Support a 'flip' action in the app too, if it exposes it
-        if (this._appActionProxy.has_action('flip'))
-            this._appActionProxy.activate_action('flip', new GLib.Variant('b', false));
     },
 
     // Given some recently-focused actor, switch to it without
@@ -976,6 +968,11 @@ var CodingSession = new Lang.Class({
     },
 
     _rotateOutToMidpointCompleted: function(src, direction) {
+        // Support a 'flip' action in the app too, if it exposes it
+        const flipState = (this._state == STATE_TOOLBOX);
+        if (this._appActionProxy.has_action('flip'))
+            this._appActionProxy.activate_action('flip', new GLib.Variant('b', flipState));
+
         Tweener.addTween(src, {
             rotation_angle_y: direction == Gtk.DirectionType.RIGHT ? 180 : -180,
             time: WINDOW_ANIMATION_TIME * 2,

--- a/js/ui/codeView.js
+++ b/js/ui/codeView.js
@@ -48,9 +48,6 @@ function _createIcon() {
 //
 // Synchronize geometry of MetaWindowActor src to dst by
 // applying both the physical geometry and maximization state.
-//
-// The return value signifies whether the maximization state changed,
-// which may cause the hidden window to be shown.
 function _synchronizeMetaWindowActorGeometries(src, dst) {
     let srcGeometry = src.meta_window.get_frame_rect();
     let dstGeometry = dst.meta_window.get_frame_rect();
@@ -72,16 +69,13 @@ function _synchronizeMetaWindowActorGeometries(src, dst) {
     if (srcIsMaximized && !dstIsMaximized)
         dst.meta_window.maximize(Meta.MaximizeFlags.BOTH);
 
-    if (srcGeometry.equal(dstGeometry))
-        return maximizationStateChanged;
 
-    dst.meta_window.move_resize_frame(false,
-                                      srcGeometry.x,
-                                      srcGeometry.y,
-                                      srcGeometry.width,
-                                      srcGeometry.height);
-
-    return maximizationStateChanged;
+    if (!srcGeometry.equal(dstGeometry))
+        dst.meta_window.move_resize_frame(false,
+                                          srcGeometry.x,
+                                          srcGeometry.y,
+                                          srcGeometry.width,
+                                          srcGeometry.height);
 }
 
 function _synchronizeViewSourceButtonToRectCorner(button, rect) {

--- a/js/ui/codeView.js
+++ b/js/ui/codeView.js
@@ -590,6 +590,12 @@ var CodingSession = new Lang.Class({
         this._constrainGeometryAppId =
             this.app.meta_window.connect('geometry-allocate',
                                          this._constrainGeometry.bind(this));
+
+        this._appActionProxy =
+            Gio.DBusActionGroup.get(Gio.DBus.session,
+                                    this.app.meta_window.gtk_application_id,
+                                    this.app.meta_window.gtk_application_object_path);
+        this._appActionProxy.list_actions();
     },
 
     _cleanupAppWindow: function() {
@@ -605,6 +611,8 @@ var CodingSession = new Lang.Class({
             this.app.meta_window.disconnect(this._constrainGeometryAppId);
             this._constrainGeometryAppId = 0;
         }
+
+        this._appActionProxy = null;
     },
 
     removeAppWindow: function() {
@@ -705,6 +713,10 @@ var CodingSession = new Lang.Class({
                                   Gtk.DirectionType.LEFT);
             this._state = STATE_TOOLBOX;
         }
+
+        // Support a 'flip' action in the app too, if it exposes it
+        if (this._appActionProxy.has_action('flip'))
+            this._appActionProxy.activate_action('flip', new GLib.Variant('b', true));
     },
 
     _switchToApp: function() {
@@ -721,6 +733,10 @@ var CodingSession = new Lang.Class({
                                   Gtk.DirectionType.RIGHT);
             this._state = STATE_APP;
         }
+
+        // Support a 'flip' action in the app too, if it exposes it
+        if (this._appActionProxy.has_action('flip'))
+            this._appActionProxy.activate_action('flip', new GLib.Variant('b', false));
     },
 
     // Given some recently-focused actor, switch to it without

--- a/js/ui/codeView.js
+++ b/js/ui/codeView.js
@@ -596,6 +596,9 @@ var CodingSession = new Lang.Class({
                                     this.app.meta_window.gtk_application_id,
                                     this.app.meta_window.gtk_application_object_path);
         this._appActionProxy.list_actions();
+
+        let windowTracker = Shell.WindowTracker.get_default();
+        this._shellApp = windowTracker.get_window_app(this.app.meta_window);
     },
 
     _cleanupAppWindow: function() {
@@ -649,6 +652,7 @@ var CodingSession = new Lang.Class({
         }
 
         this.app = null;
+        this._shellApp = null;
 
         // Destroy the button too
         this.button.destroy();

--- a/js/ui/codeView.js
+++ b/js/ui/codeView.js
@@ -998,6 +998,11 @@ var CodingSession = new Lang.Class({
     }
 });
 
+const SessionLookupFlags = {
+    SESSION_LOOKUP_APP: 1 << 0,
+    SESSION_LOOKUP_TOOLBOX: 1 << 1,
+};
+
 var CodeViewManager = new Lang.Class({
     Name: 'CodeViewManager',
 
@@ -1046,7 +1051,7 @@ var CodeViewManager = new Lang.Class({
         if (!_isCodingApp(window.get_flatpak_id()))
             return false;
 
-        let session = this._getSession(actor);
+        let session = this._getSession(actor, SessionLookupFlags.SESSION_LOOKUP_APP);
         if (!session)
             return false;
 
@@ -1069,7 +1074,7 @@ var CodeViewManager = new Lang.Class({
             !isSpeedwagonForToolbox)
             return false;
 
-        let session = this._getSession(actor);
+        let session = this._getSession(actor, SessionLookupFlags.SESSION_LOOKUP_TOOLBOX);
         if (!session)
             return false;
 
@@ -1080,15 +1085,18 @@ var CodeViewManager = new Lang.Class({
     },
 
     killEffectsOnActor: function(actor) {
-        let session = this._getSession(actor);
+        let session = this._getSession(actor,
+                                       SessionLookupFlags.SESSION_LOOKUP_APP |
+                                       SessionLookupFlags.SESSION_LOOKUP_TOOLBOX);
         if (session)
             session.killEffects();
     },
 
-    _getSession: function(actor) {
+    _getSession: function(actor, flags) {
         for (let i = 0; i < this._sessions.length; i++) {
             let session = this._sessions[i];
-            if (session.app === actor || session.toolbox === actor)
+            if (((session.app === actor) && (flags & SessionLookupFlags.SESSION_LOOKUP_APP)) ||
+                ((session.toolbox === actor) && (flags & SessionLookupFlags.SESSION_LOOKUP_TOOLBOX)))
                 return session;
         }
 

--- a/js/ui/codeView.js
+++ b/js/ui/codeView.js
@@ -552,6 +552,22 @@ var CodingSession = new Lang.Class({
         return true;
     },
 
+    _completeRemoveWindow: function() {
+        let actor;
+        if (this._state == STATE_APP)
+            actor = this.app;
+        else
+            actor = this.toolbox;
+
+        if (actor) {
+            actor.rotation_angle_y = 0;
+            actor.show();
+            actor.meta_window.activate(global.get_current_time());
+        } else {
+            this.destroy();
+        }
+    },
+
     _setupToolboxWindow: function() {
         this._positionChangedIdToolbox =
             this.toolbox.meta_window.connect('position-changed',
@@ -593,8 +609,7 @@ var CodingSession = new Lang.Class({
         this.button.toolbox_window = null;
         this._state = STATE_APP;
 
-        this.app.meta_window.activate(global.get_current_time());
-        this.app.show();
+        this._completeRemoveWindow();
     },
 
     _setupAppWindow: function() {
@@ -639,8 +654,7 @@ var CodingSession = new Lang.Class({
         this.button.window = null;
         this._state = STATE_TOOLBOX;
 
-        this.toolbox.meta_window.activate(global.get_current_time());
-        this.toolbox.show();
+        this._completeRemoveWindow();
     },
 
     // Eject out of this session and remove all pairings.

--- a/js/ui/codeView.js
+++ b/js/ui/codeView.js
@@ -679,8 +679,14 @@ var CodingSession = new Lang.Class({
         }
     },
 
+    _windowsNeedSync: function() {
+        // Synchronization is only needed when we have both an app and
+        // a toolbox
+        return this.app && this.toolbox;
+    },
+
     _constrainGeometry: function(window) {
-        if (!this.toolbox)
+        if (!this._windowsNeedSync())
             return;
 
         // Get the minimum size of both the app and the toolbox window
@@ -778,8 +784,7 @@ var CodingSession = new Lang.Class({
     },
 
     _synchronizeWindows: function(window) {
-        // No synchronization if toolbox has not been set here
-        if (!this.toolbox)
+        if (!this._windowsNeedSync())
             return;
 
         let [src, dst] = this._srcAndDstPairFromWindow(window);
@@ -787,10 +792,6 @@ var CodingSession = new Lang.Class({
     },
 
     _applyWindowMinimizationState: function(shellwm, actor) {
-        // No synchronization if toolbox has not been set here
-        if (!this.toolbox)
-            return;
-
         let toMini = this._isActorFromSession(actor);
 
         // Only want to minimize if we weren't already minimized.
@@ -799,10 +800,6 @@ var CodingSession = new Lang.Class({
     },
 
     _applyWindowUnminimizationState: function(shellwm, actor) {
-        // No synchronization if toolbox has not been set here
-        if (!this.toolbox)
-            return;
-
         let toUnMini = this._isActorFromSession(actor);
 
         // We only want to unminimize a window here if it was previously

--- a/js/ui/codeView.js
+++ b/js/ui/codeView.js
@@ -714,7 +714,6 @@ var CodingSession = new Lang.Class({
                 new GLib.Variant('(ss)', [this.app.meta_window.gtk_application_id,
                                           this.app.meta_window.gtk_window_object_path]));
         } else {
-            this.toolbox.meta_window.activate(global.get_current_time());
             this._prepareAnimate(this.app,
                                  this.toolbox,
                                  Gtk.DirectionType.LEFT);
@@ -730,7 +729,6 @@ var CodingSession = new Lang.Class({
             this._toolboxActionGroup.activate_action('flip-back', null);
             this.appRemovedByFlipBack = true;
         } else {
-            this.app.meta_window.activate(global.get_current_time());
             this._prepareAnimate(this.toolbox,
                                  this.app,
                                  Gtk.DirectionType.RIGHT);
@@ -982,6 +980,9 @@ var CodingSession = new Lang.Class({
     },
 
     _rotateInToMidpointCompleted: function(dst, direction) {
+        // Now bring to front the other side
+        dst.meta_window.activate(global.get_current_time());
+
         Tweener.addTween(dst, {
             rotation_angle_y: 0,
             time: WINDOW_ANIMATION_TIME * 2,

--- a/js/ui/codeView.js
+++ b/js/ui/codeView.js
@@ -358,8 +358,7 @@ var CodingSession = new Lang.Class({
         'app': GObject.ParamSpec.object('app',
                                         '',
                                         '',
-                                        GObject.ParamFlags.READWRITE |
-                                        GObject.ParamFlags.CONSTRUCT_ONLY,
+                                        GObject.ParamFlags.READWRITE,
                                         Meta.WindowActor),
         'toolbox': GObject.ParamSpec.object('toolbox',
                                             '',
@@ -429,8 +428,49 @@ var CodingSession = new Lang.Class({
     },
 
     admitAppWindowActor: function(actor) {
-        // TODO: handle the flip-back window being mapped here
-        return false;
+        // If there is a currently bound window then we can't admit this window.
+        if (this.app)
+            return false;
+
+        // We can admit this window. Wire up signals and synchronize
+        // geometries now.
+        this.app = actor;
+
+        //FIXME: take care of updating the button...
+        //this.button.toolbox_window = actor.meta_window;
+
+        _synchronizeMetaWindowActorGeometries(this.toolbox, this.app);
+
+        // Now, if we're not already on the app window, we want to start
+        // animating to it here. This is different from just calling
+        // _switchToApp - we already have the window and we want to
+        // rotate to it as soon as its first frame appears
+        if (this._state === STATE_TOOLBOX) {
+            this._prepareAnimate(this.toolbox,
+                                 this.app,
+                                 Gtk.DirectionType.RIGHT);
+            this._state = STATE_APP;
+
+            // We wait until the first frame of the window has been drawn
+            // and damage updated in the compositor before we start rotating.
+            //
+            // This way we don't get ugly artifacts when rotating if
+            // a window is slow to draw.
+            if (!this.app._drawnFirstFrame) {
+                let firstFrameConnection = this.app.connect('first-frame', () => {
+                    this.app.disconnect(firstFrameConnection);
+                    this._completeAnimate(this.toolbox,
+                                          this.app,
+                                          Gtk.DirectionType.RIGHT);
+                });
+            } else {
+                this._completeAnimate(this.toolbox,
+                                      this.app,
+                                      Gtk.DirectionType.RIGHT);
+            }
+        }
+
+        return true;
     },
 
     // Maybe admit this actor if it is the kind of actor that we want

--- a/js/ui/codeView.js
+++ b/js/ui/codeView.js
@@ -1002,7 +1002,6 @@ var CodingSession = new Lang.Class({
 
         Tweener.removeTweens(actor);
         actor.hide();
-        actor.rotation_angle_y = 0;
         this._rotatingOutActor = null;
     },
 

--- a/js/ui/codeView.js
+++ b/js/ui/codeView.js
@@ -402,13 +402,6 @@ var CodingSession = new Lang.Class({
                                                                     this._constrainGeometry.bind(this));
     },
 
-    _toolboxWindowIsReady: function() {
-        this._animate(this.app,
-                      this.toolbox,
-                      Gtk.DirectionType.LEFT);
-        this.button.switchAnimation(Gtk.DirectionType.LEFT);
-    },
-
     // Maybe admit this actor if it is the kind of actor that we want
     admitToolboxWindowActor: function(actor) {
         // If there is a currently bound window then we can't admit this window.
@@ -451,10 +444,14 @@ var CodingSession = new Lang.Class({
             if (!this.toolbox._drawnFirstFrame) {
                 let firstFrameConnection = this.toolbox.connect('first-frame', () => {
                     this.toolbox.disconnect(firstFrameConnection);
-                    this._toolboxWindowIsReady();
-                });
+                    this._completeAnimate(this.app,
+                                          this.toolbox,
+                                          Gtk.DirectionType.LEFT);
+                }));
             } else {
-                this._toolboxWindowIsReady();
+                this._completeAnimate(this.app,
+                                      this.toolbox,
+                                      Gtk.DirectionType.LEFT);
             }
         }
 
@@ -587,10 +584,9 @@ var CodingSession = new Lang.Class({
             this._prepareAnimate(this.app,
                                  this.toolbox,
                                  Gtk.DirectionType.LEFT);
-            this._animate(this.app,
-                          this.toolbox,
-                          Gtk.DirectionType.LEFT);
-            this.button.switchAnimation(Gtk.DirectionType.LEFT);
+            this._completeAnimate(this.app,
+                                  this.toolbox,
+                                  Gtk.DirectionType.LEFT);
             this._state = STATE_TOOLBOX;
         }
     },
@@ -600,10 +596,9 @@ var CodingSession = new Lang.Class({
         this._prepareAnimate(this.toolbox,
                              this.app,
                              Gtk.DirectionType.RIGHT);
-        this._animate(this.toolbox,
-                      this.app,
-                      Gtk.DirectionType.RIGHT);
-        this.button.switchAnimation(Gtk.DirectionType.RIGHT);
+        this._completeAnimate(this.toolbox,
+                              this.app,
+                              Gtk.DirectionType.RIGHT);
         this._state = STATE_APP;
     },
 
@@ -795,6 +790,13 @@ var CodingSession = new Lang.Class({
         src.rotation_angle_y = 0;
         dst.pivot_point = new Clutter.Point({ x: 0.5, y: 0.5 });
         src.pivot_point = new Clutter.Point({ x: 0.5, y: 0.5 });
+    },
+
+    _completeAnimate: function(src, dst, direction) {
+        this._animate(src,
+                      dst,
+                      direction);
+        this.button.switchAnimation(direction);
     },
 
     _animate: function(src, dst, direction) {

--- a/js/ui/codeView.js
+++ b/js/ui/codeView.js
@@ -1022,10 +1022,6 @@ var CodeViewManager = new Lang.Class({
     },
 
     _removeAppWindow: function(actor) {
-        let window = actor.meta_window;
-        if (!_isCodingApp(window.get_flatpak_id()))
-            return false;
-
         let session = this._getSession(actor, SessionLookupFlags.SESSION_LOOKUP_APP);
         if (!session)
             return false;

--- a/js/ui/codeView.js
+++ b/js/ui/codeView.js
@@ -189,23 +189,25 @@ var WindowTrackingButton = new Lang.Class({
     Name: 'WindowTrackingButton',
     Extends: GObject.Object,
     Properties: {
-        window: GObject.ParamSpec.object('window',
-                                         '',
-                                         '',
-                                         GObject.ParamFlags.READWRITE |
-                                         GObject.ParamFlags.CONSTRUCT_ONLY,
-                                         Meta.Window),
-        toolbox_window: GObject.ParamSpec.object('toolbox-window',
-                                                 '',
-                                                 '',
-                                                 GObject.ParamFlags.READWRITE,
-                                                 Meta.Window)
+        'window': GObject.ParamSpec.object('window',
+                                           '',
+                                           '',
+                                           GObject.ParamFlags.READWRITE |
+                                           GObject.ParamFlags.CONSTRUCT_ONLY,
+                                           Meta.Window),
+        'toolbox_window': GObject.ParamSpec.object('toolbox-window',
+                                                   '',
+                                                   '',
+                                                   GObject.ParamFlags.READWRITE,
+                                                   Meta.Window)
     },
     Signals: {
         'clicked': {}
     },
 
     _init: function(params) {
+        this._toolbox_window = null;
+
         this.parent(params);
 
         // The button will be auto-added to the manager. Note that in order to
@@ -335,6 +337,18 @@ var WindowTrackingButton = new Lang.Class({
                 animationButton.destroy();
             }
         });
+    },
+
+    set toolbox_window(value) {
+        // It's possible that the toolbox window got focused before
+        // the toolbox window was set, so do the check again
+        // here, too.
+        this._toolbox_window = value;
+        this._showIfWindowVisible();
+    },
+
+    get toolbox_window() {
+        return this._toolbox_window;
     },
 
     _updatePosition: function() {

--- a/js/ui/codeView.js
+++ b/js/ui/codeView.js
@@ -989,13 +989,7 @@ var CodingSession = new Lang.Class({
             rotation_angle_y: 0,
             time: WINDOW_ANIMATION_TIME * 2,
             transition: 'easeOutQuad',
-            onComplete: () => {
-                this._rotateInCompleted(dst);
-
-                // Failed. Remove the toolbox window and rotate back
-                if (this.cancelled)
-                    this.removeToolboxWindow();
-            }
+            onComplete: this._rotateInCompleted.bind(this)
         });
     },
 

--- a/js/ui/codeView.js
+++ b/js/ui/codeView.js
@@ -976,7 +976,8 @@ var CodingSession = new Lang.Class({
             rotation_angle_y: direction == Gtk.DirectionType.RIGHT ? 180 : -180,
             time: WINDOW_ANIMATION_TIME * 2,
             transition: 'easeOutQuad',
-            onComplete: this._rotateOutCompleted.bind(this)
+            onComplete: this._rotateOutCompleted.bind(this),
+            onCompleteParams: [false]
         });
     },
 
@@ -1002,21 +1003,24 @@ var CodingSession = new Lang.Class({
 
         Tweener.removeTweens(actor);
         actor.rotation_angle_y = 0;
+        actor.opacity = 255;
         this._rotatingInActor = null;
     },
 
-    _rotateOutCompleted: function() {
+    _rotateOutCompleted: function(resetRotation) {
         let actor = this._rotatingOutActor;
         if (!actor)
             return;
 
         Tweener.removeTweens(actor);
+        if (resetRotation)
+            actor.rotation_angle_y = 0;
         this._rotatingOutActor = null;
     },
 
     killEffects: function() {
         this._rotateInCompleted();
-        this._rotateOutCompleted();
+        this._rotateOutCompleted(true);
     }
 });
 

--- a/js/ui/codeView.js
+++ b/js/ui/codeView.js
@@ -435,6 +435,13 @@ var CodingSession = new Lang.Class({
         this._watchdogId = 0;
     },
 
+    _toolboxWindowIsReady: function() {
+        this._animate(this.app,
+                      this.toolbox,
+                      Gtk.DirectionType.LEFT);
+        this.button.switchAnimation(Gtk.DirectionType.LEFT);
+    },
+
     // Maybe admit this actor if it is the kind of actor that we want
     admitToolboxWindowActor: function(actor) {
         // If there is a currently bound window and it is not a speedwagon,
@@ -491,12 +498,8 @@ var CodingSession = new Lang.Class({
             // This way we don't get ugly artifacts when rotating if
             // a window is slow to draw.
             let firstFrameConnection = this.toolbox.connect('first-frame', () => {
-                this._animate(this.app,
-                              this.toolbox,
-                              Gtk.DirectionType.LEFT);
-
                 this.toolbox.disconnect(firstFrameConnection);
-                this.button.switchAnimation(Gtk.DirectionType.LEFT);
+                this._toolboxWindowIsReady();
 
                 return false;
             });

--- a/js/ui/codeView.js
+++ b/js/ui/codeView.js
@@ -833,11 +833,8 @@ var CodingSession = new Lang.Class({
         if (!focusedWindow)
             return;
 
-        if (!this.toolbox)
-            return;
-
-        let appWindow = this.app.meta_window;
-        let toolboxWindow = this.toolbox.meta_window;
+        let appWindow = this.app ? this.app.meta_window : null;
+        let toolboxWindow = this.toolbox ? this.toolbox.meta_window : null;
         let nextState = null;
 
         // Determine if we need to change the state of this session by

--- a/js/ui/codeView.js
+++ b/js/ui/codeView.js
@@ -1046,24 +1046,23 @@ var CodeViewManager = new Lang.Class({
 
     _addAppWindow: function(actor) {
         if (!global.settings.get_boolean('enable-code-view'))
-            return false;
+            return;
 
         let window = actor.meta_window;
         if (!_isCodingApp(window.get_flatpak_id()))
-            return false;
+            return;
 
         this._sessions.push(new CodingSession({
             app: actor,
             toolbox: null,
             button: new WindowTrackingButton({ window: window })
         }));
-        return true;
     },
 
     _removeAppWindow: function(actor) {
         let session = this._getSession(actor, SessionLookupFlags.SESSION_LOOKUP_APP);
         if (!session)
-            return false;
+            return;
 
         if (session.appRemovedByFlipBack) {
             session.removeAppWindow();
@@ -1073,23 +1072,20 @@ var CodeViewManager = new Lang.Class({
 
             let idx = this._sessions.indexOf(session);
             if (idx === -1)
-                return false;
+                return;
 
             this._sessions.splice(idx, 1);
         }
-
-        return true;
     },
 
     _removeToolboxWindow: function(actor) {
         let session = this._getSession(actor, SessionLookupFlags.SESSION_LOOKUP_TOOLBOX);
         if (!session)
-            return false;
+            return;
 
         // We can remove the normal toolbox window.
         // That window will be registered in the session at this point.
         session.removeToolboxWindow();
-        return true;
     },
 
     handleDestroyWindow: function(actor) {

--- a/js/ui/codeView.js
+++ b/js/ui/codeView.js
@@ -744,31 +744,16 @@ var CodingSession = new Lang.Class({
     // or left the overview. This will cause the state to instantly change
     // and prevent things from being flipped later in _windowRestacked
     _switchToWindowWithoutFlipping: function(actor) {
-        // Neither the app window nor the toolbox, return
-        if (actor !== this.app && actor !== this.toolbox)
-            return;
-
         // We need to do a few housekeeping things here:
         // 1. Change the _state variable to indicate whether we are now
         //    on the app, or the toolbox window.
-        // 2. Depending on that state, hide and show windows. We might have
-        //    hidden windows during the flip animation, so we need to show
-        //    any relevant windows and hide any irrelevant ones
-        // 3. Ensure that the relevant window is activated (usually just
+        // 2. Ensure that the relevant window is activated (usually just
         //    by activating it again). For instance, in the unminimize case,
         //    unminimizing the sibling window will cause it to activate
         //    which then breaks the user's expectations (it should unminimize
         //    but not activate). Re-activating ensures that we present
         //    the right story to the user.
         this._state = (actor === this.app ? STATE_APP : STATE_TOOLBOX);
-        if (this._state === STATE_APP) {
-            this.toolbox.hide();
-            this.app.show();
-        } else {
-            this.app.hide();
-            this.toolbox.show();
-        }
-
         actor.meta_window.activate(global.get_current_time());
     },
 
@@ -798,17 +783,7 @@ var CodingSession = new Lang.Class({
             return;
 
         let [src, dst] = this._srcAndDstPairFromWindow(window);
-        let maximizationStateChanged = _synchronizeMetaWindowActorGeometries(src, dst);
-
-        // If the maximization state changed, we may end up with windows that
-        // are shown. Use the current state to determine which window to hide.
-        if (!maximizationStateChanged)
-            return;
-
-        if (this._state === STATE_TOOLBOX)
-            this.app.hide();
-        else
-            this.toolbox.hide();
+        _synchronizeMetaWindowActorGeometries(src, dst);
     },
 
     _applyWindowMinimizationState: function(shellwm, actor) {

--- a/js/ui/codeView.js
+++ b/js/ui/codeView.js
@@ -769,6 +769,9 @@ var CodingSession = new Lang.Class({
         if (!this._isActorFromSession(actor))
             return;
 
+        if (!this._isCurrentWindow(actor.meta_window))
+            return;
+
         this._button.hide();
 
         let toMini = this._getOtherActor(actor);
@@ -780,6 +783,9 @@ var CodingSession = new Lang.Class({
 
     _applyWindowUnminimizationState: function(shellwm, actor) {
         if (!this._isActorFromSession(actor))
+            return;
+
+        if (!this._isCurrentWindow(actor.meta_window))
             return;
 
         this._button.show();

--- a/js/ui/codeView.js
+++ b/js/ui/codeView.js
@@ -26,7 +26,8 @@ const STATE_TOOLBOX = 1;
 
 const _CODING_APPS = [
     // FIXME: this should be extended with a more complex lookup
-    'com.endlessm.dinosaurs.en'
+    'com.endlessm.dinosaurs.en',
+    'com.endlessm.hackybird'
 ];
 
 function _isCodingApp(flatpakID) {

--- a/js/ui/codeView.js
+++ b/js/ui/codeView.js
@@ -479,10 +479,7 @@ var CodingSession = new Lang.Class({
         return true;
     },
 
-    // Remove the toolbox window from this session. Disconnect
-    // any signals that we have connected to the toolbox window
-    // and show the app window
-    removeToolboxWindow: function() {
+    _cleanupToolboxWindow: function() {
         if (this._positionChangedIdToolbox) {
             this.toolbox.meta_window.disconnect(this._positionChangedIdToolbox);
             this._positionChangedIdToolbox = 0;
@@ -497,6 +494,13 @@ var CodingSession = new Lang.Class({
             this.toolbox.meta_window.disconnect(this._constrainGeometryToolboxId);
             this._constrainGeometryToolboxId = 0;
         }
+    },
+
+    // Remove the toolbox window from this session. Disconnect
+    // any signals that we have connected to the toolbox window
+    // and show the app window
+    removeToolboxWindow: function() {
+        this._cleanupToolboxWindow();
 
         // Remove the toolbox_window reference from the button. There's no
         // need to disconnect any signals here since the button doesn't
@@ -510,8 +514,7 @@ var CodingSession = new Lang.Class({
     },
 
     // Eject out of this session and remove all pairings.
-    // Remove all connected signals and show the toolbox window if we have
-    // one.
+    // Remove all connected signals and close the toolbox as well, if we have one.
     //
     // The assumption here is that the session will be removed immediately
     // after destruction.
@@ -542,29 +545,15 @@ var CodingSession = new Lang.Class({
             this._constrainGeometryAppId = 0;
         }
 
-        if (this._constrainGeometryToolboxId) {
-            this.toolbox.meta_window.disconnect(this._constrainGeometryToolboxId);
-            this._constrainGeometryToolboxId = 0;
-        }
-
         // Destroy the button too
         this.button.destroy();
 
-        // If we have a toolbox window, disconnect any signals,
-        // show it and activate it now
+        // If we have a toolbox window, disconnect any signals and destroy it.
         if (this.toolbox) {
-            if (this._positionChangedIdToolbox) {
-                this.toolbox.meta_window.disconnect(this._positionChangedIdToolbox);
-                this._positionChangedIdToolbox = 0;
-            }
+            this._cleanupToolboxWindow();
 
-            if (this._sizeChangedIdToolbox) {
-                this.toolbox.meta_window.disconnect(this._sizeChangedIdToolbox);
-                this._sizeChangedIdToolbox = 0;
-            }
-
-            this.toolbox.meta_window.activate(global.get_current_time());
-            this.toolbox.show();
+            // Destroy the toolbox window now
+            this.toolbox.meta_window.delete(global.get_current_time());
 
             // Note that we do not set this._state to STATE_APP here. Any
             // further usage of this session is undefined and it should

--- a/js/ui/codeView.js
+++ b/js/ui/codeView.js
@@ -687,6 +687,7 @@ var CodingSession = new Lang.Class({
                 'flip',
                 new GLib.Variant('(ss)', [this.app.meta_window.gtk_application_id,
                                           this.app.meta_window.gtk_window_object_path]));
+            this._button.reactive = false;
         } else {
             this._setupAnimation(STATE_TOOLBOX,
                                  this.app,
@@ -699,6 +700,7 @@ var CodingSession = new Lang.Class({
         if (this._toolboxActionGroup.has_action('flip-back')) {
             this._toolboxActionGroup.activate_action('flip-back', null);
             this.appRemovedByFlipBack = true;
+            this._button.reactive = false;
         } else {
             this._setupAnimation(STATE_APP,
                                  this.toolbox,
@@ -919,6 +921,8 @@ var CodingSession = new Lang.Class({
         actor.rotation_angle_y = 0;
         actor.opacity = 255;
         this._rotatingInActor = null;
+
+        this._button.reactive = true;
     },
 
     _rotateOutCompleted: function(resetRotation) {

--- a/js/ui/codeView.js
+++ b/js/ui/codeView.js
@@ -959,7 +959,7 @@ var CodeViewManager = new Lang.Class({
         this._sessions.push(new CodingSession({
             app: actor,
             toolbox: null,
-            button: new WindowTrackingButton({ window: actor.meta_window })
+            button: new WindowTrackingButton({ window: window })
         }));
         return true;
     },

--- a/js/ui/codeView.js
+++ b/js/ui/codeView.js
@@ -1001,7 +1001,6 @@ var CodingSession = new Lang.Class({
             return;
 
         Tweener.removeTweens(actor);
-        actor.hide();
         this._rotatingOutActor = null;
     },
 

--- a/js/ui/codeView.js
+++ b/js/ui/codeView.js
@@ -793,16 +793,9 @@ var CodingSession = new Lang.Class({
         let toUnMini = this._getOtherActor(actor);
 
         // We only want to unminimize a window here if it was previously
-        // unminimized. Unminimizing it again and switching to it without
-        // flipping will cause the secondary unminimized window to be
-        // activated and flipped to.
-        if (toUnMini && toUnMini.meta_window.minimized) {
+        // minimized.
+        if (toUnMini && toUnMini.meta_window.minimized)
             toUnMini.meta_window.unminimize();
-
-            // Window was unminimized. Ensure that this actor is focused
-            // and switch to it instantly
-            this._switchToWindowWithoutFlipping(actor);
-        }
     },
 
     _windowsRestacked: function() {

--- a/js/ui/codeView.js
+++ b/js/ui/codeView.js
@@ -23,7 +23,7 @@ const BUTTON_OFFSET_X = 33;
 const BUTTON_OFFSET_Y = 40;
 
 const STATE_APP = 0;
-const STATE_BUILDER = 1;
+const STATE_TOOLBOX = 1;
 
 const _CODING_APPS = [
     'com.endlessm.Helloworld',
@@ -34,11 +34,11 @@ function _isCodingApp(flatpakID) {
     return _CODING_APPS.indexOf(flatpakID) != -1;
 }
 
-function _isBuilder(flatpakID) {
+function _isToolbox(flatpakID) {
     return flatpakID === 'org.gnome.Builder';
 }
 
-function _isBuilderSpeedwagon(window) {
+function _isToolboxSpeedwagon(window) {
     let tracker = Shell.WindowTracker.get_default();
     let correspondingApp = tracker.get_window_app(window);
     return (Shell.WindowTracker.is_speedwagon_window(window) &&
@@ -195,7 +195,7 @@ var WindowTrackingButton = new Lang.Class({
                                          GObject.ParamFlags.READWRITE |
                                          GObject.ParamFlags.CONSTRUCT_ONLY,
                                          Meta.Window),
-        builder_window: GObject.ParamSpec.object('builder-window',
+        toolbox_window: GObject.ParamSpec.object('toolbox-window',
                                                  '',
                                                  '',
                                                  GObject.ParamFlags.READWRITE,
@@ -220,7 +220,7 @@ var WindowTrackingButton = new Lang.Class({
         // hide, and show the button. Note that WindowTrackingButton is
         // constructed with the primary app window and we listen for signals
         // on that. This is because of the assumption that both the app
-        // window and builder window are completely synchronized.
+        // window and toolbox window are completely synchronized.
         this._positionChangedId = this.window.connect('position-changed',
                                                       this._updatePosition.bind(this));
         this._sizeChangedId = this.window.connect('size-changed',
@@ -351,10 +351,10 @@ var WindowTrackingButton = new Lang.Class({
         // Don't show if the screen is locked
         let locked = Main.sessionMode.isLocked;
 
-        // Show only if either this window or the builder window
+        // Show only if either this window or the toolbox window
         // is in focus
         if ((focusedWindow === this.window ||
-             focusedWindow === this.builder_window) &&
+             focusedWindow === this.toolbox_window) &&
             !locked)
             this._show();
         else
@@ -385,7 +385,7 @@ var CodingSession = new Lang.Class({
                                         GObject.ParamFlags.READWRITE |
                                         GObject.ParamFlags.CONSTRUCT_ONLY,
                                         Meta.WindowActor),
-        'builder': GObject.ParamSpec.object('builder',
+        'toolbox': GObject.ParamSpec.object('toolbox',
                                             '',
                                             '',
                                             GObject.ParamFlags.READWRITE,
@@ -422,27 +422,27 @@ var CodingSession = new Lang.Class({
     },
 
     // Maybe admit this actor if it is the kind of actor that we want
-    admitBuilderWindowActor: function(actor) {
+    admitToolboxWindowActor: function(actor) {
         // If there is a currently bound window and it is not a speedwagon,
         // then we can't admit this window. Return false.
-        if (this.builder &&
-            !Shell.WindowTracker.is_speedwagon_window(this.builder.meta_window))
+        if (this.toolbox &&
+            !Shell.WindowTracker.is_speedwagon_window(this.toolbox.meta_window))
             return false;
 
         // We can admit this window. Wire up signals and synchronize
         // geometries now.
-        this.builder = actor;
-        this.button.builder_window = actor.meta_window;
+        this.toolbox = actor;
+        this.button.toolbox_window = actor.meta_window;
 
         // The assumption here is that if we connect a new window, we
-        // are connecting a builder window (potentially 'on top') of the
+        // are connecting a toolbox window (potentially 'on top') of the
         // speedwagon window, so there is no need to disconnect
         // signals
-        this._positionChangedIdBuilder = this.builder.meta_window.connect('position-changed',
+        this._positionChangedIdToolbox = this.toolbox.meta_window.connect('position-changed',
                                                                           this._synchronizeWindows.bind(this));
-        this._sizeChangedIdBuilder = this.builder.meta_window.connect('size-changed',
+        this._sizeChangedIdToolbox = this.toolbox.meta_window.connect('size-changed',
                                                                       this._synchronizeWindows.bind(this));
-        _synchronizeMetaWindowActorGeometries(this.app, this.builder);
+        _synchronizeMetaWindowActorGeometries(this.app, this.toolbox);
 
         if (Shell.WindowTracker.is_speedwagon_window(actor.meta_window)) {
             // If we are animating to a speedwagon window, we'll want to
@@ -450,25 +450,25 @@ var CodingSession = new Lang.Class({
             // appear over everything else.
             actor.meta_window.unmake_above();
         } else {
-            // Connect the real builder window to the geometry-allocate
+            // Connect the real toolbox window to the geometry-allocate
             // signal
-            this._constrainGeometryBuilderId = this.builder.meta_window.connect('geometry-allocate',
+            this._constrainGeometryToolboxId = this.toolbox.meta_window.connect('geometry-allocate',
                                                                                 this._constrainGeometry.bind(this));
 
             // We only want to untrack the coding app window at this
             // point and not at the point we show the speedwagon. This
             // will ensure that the shell window tracker is still
-            // watching for the builder window to appear.
-            this._stopWatchingForBuilderWindowToComeOnline();
+            // watching for the toolbox window to appear.
+            this._stopWatchingForToolboxWindowToComeOnline();
 
             // We also only want to hide the speedwagon window at this
             // point, since the other window has arrived.
             this.splash.rampOut();
         }
 
-        // Now, if we're not already on the builder window, we want to start
+        // Now, if we're not already on the toolbox window, we want to start
         // animating to it here. This is different from just calling
-        // _switchToBuilder - we already have the window and we want to
+        // _switchToToolbox - we already have the window and we want to
         // rotate to it as soon as its first frame appears
         if (this._state === STATE_APP) {
             // We wait until the first frame of the window has been drawn
@@ -476,49 +476,49 @@ var CodingSession = new Lang.Class({
             //
             // This way we don't get ugly artifacts when rotating if
             // a window is slow to draw.
-            let firstFrameConnection = this.builder.connect('first-frame', () => {
+            let firstFrameConnection = this.toolbox.connect('first-frame', () => {
                 this._animate(this.app,
-                              this.builder,
+                              this.toolbox,
                               Gtk.DirectionType.LEFT);
 
-                this.builder.disconnect(firstFrameConnection);
+                this.toolbox.disconnect(firstFrameConnection);
                 this.button.switchAnimation(Gtk.DirectionType.LEFT);
 
                 return false;
             });
             this._prepareAnimate(this.app,
-                                 this.builder,
+                                 this.toolbox,
                                  Gtk.DirectionType.LEFT);
-            this._state = STATE_BUILDER;
+            this._state = STATE_TOOLBOX;
         }
 
         return true;
     },
 
-    // Remove the builder window from this session. Disconnect
-    // any signals that we have connected to the builder window
+    // Remove the toolbox window from this session. Disconnect
+    // any signals that we have connected to the toolbox window
     // and show the app window
-    removeBuilderWindow: function() {
-        if (this._positionChangedIdBuilder) {
-            this.builder.meta_window.disconnect(this._positionChangedIdBuilder);
-            this._positionChangedIdBuilder = 0;
+    removeToolboxWindow: function() {
+        if (this._positionChangedIdToolbox) {
+            this.toolbox.meta_window.disconnect(this._positionChangedIdToolbox);
+            this._positionChangedIdToolbox = 0;
         }
 
-        if (this._sizeChangedIdBuilder) {
-            this.builder.meta_window.disconnect(this._sizeChangedIdBuilder);
-            this._sizeChangedIdBuilder = 0;
+        if (this._sizeChangedIdToolbox) {
+            this.toolbox.meta_window.disconnect(this._sizeChangedIdToolbox);
+            this._sizeChangedIdToolbox = 0;
         }
 
-        if (this._constrainGeometryBuilderId) {
-            this.builder.meta_window.disconnect(this._constrainGeometryBuilderId);
-            this._constrainGeometryBuilderId = 0;
+        if (this._constrainGeometryToolboxId) {
+            this.toolbox.meta_window.disconnect(this._constrainGeometryToolboxId);
+            this._constrainGeometryToolboxId = 0;
         }
 
-        // Remove the builder_window reference from the button. There's no
+        // Remove the toolbox_window reference from the button. There's no
         // need to disconnect any signals here since the button doesn't
-        // care about signals on builder.
-        this.button.builder_window = null;
-        this.builder = null;
+        // care about signals on the toolbox.
+        this.button.toolbox_window = null;
+        this.toolbox = null;
         this._state = STATE_APP;
 
         this.app.meta_window.activate(global.get_current_time());
@@ -526,7 +526,7 @@ var CodingSession = new Lang.Class({
     },
 
     // Eject out of this session and remove all pairings.
-    // Remove all connected signals and show the builder window if we have
+    // Remove all connected signals and show the toolbox window if we have
     // one.
     //
     // The assumption here is that the session will be removed immediately
@@ -558,32 +558,32 @@ var CodingSession = new Lang.Class({
             this._constrainGeometryAppId = 0;
         }
 
-        if (this._constrainGeometryBuilderId) {
-            this.builder.meta_window.disconnect(this._constrainGeometryBuilderId);
-            this._constrainGeometryBuilderId = 0;
+        if (this._constrainGeometryToolboxId) {
+            this.toolbox.meta_window.disconnect(this._constrainGeometryToolboxId);
+            this._constrainGeometryToolboxId = 0;
         }
 
         // Destroy the button too
         this.button.destroy();
 
-        // If we have a builder window, disconnect any signals,
+        // If we have a toolbox window, disconnect any signals,
         // show it and activate it now
         //
-        // For whatever reason, this.builder.meta_window seems to be
+        // For whatever reason, this.toolbox.meta_window seems to be
         // undefined on speedwagon windows, so handle that case here.
-        if (this.builder && this.builder.meta_window) {
-            if (this._positionChangedIdBuilder) {
-                this.builder.meta_window.disconnect(this._positionChangedIdBuilder);
-                this._positionChangedIdBuilder = 0;
+        if (this.toolbox && this.toolbox.meta_window) {
+            if (this._positionChangedIdToolbox) {
+                this.toolbox.meta_window.disconnect(this._positionChangedIdToolbox);
+                this._positionChangedIdToolbox = 0;
             }
 
-            if (this._sizeChangedIdBuilder) {
-                this.builder.meta_window.disconnect(this._sizeChangedIdBuilder);
-                this._sizeChangedIdBuilder = 0;
+            if (this._sizeChangedIdToolbox) {
+                this.toolbox.meta_window.disconnect(this._sizeChangedIdToolbox);
+                this._sizeChangedIdToolbox = 0;
             }
 
-            this.builder.meta_window.activate(global.get_current_time());
-            this.builder.show();
+            this.toolbox.meta_window.activate(global.get_current_time());
+            this.toolbox.show();
 
             // Note that we do not set this._state to STATE_APP here. Any
             // further usage of this session is undefined and it should
@@ -592,30 +592,30 @@ var CodingSession = new Lang.Class({
     },
 
     _constrainGeometry: function(window) {
-        if (!this.builder)
+        if (!this.toolbox)
             return;
 
-        // Get the minimum size of both the app and the builder window
+        // Get the minimum size of both the app and the toolbox window
         // and then determine the maximum of the two. We won't permit
         // either window to get any smaller.
         let [minAppWidth, minAppHeight] = this.app.meta_window.get_minimum_size_hints();
-        let [minBuilderWidth, minBuilderHeight] = this.builder.meta_window.get_minimum_size_hints();
+        let [minToolboxWidth, minToolboxHeight] = this.toolbox.meta_window.get_minimum_size_hints();
 
-        let minWidth = Math.max(minAppWidth, minBuilderWidth);
-        let minHeight = Math.max(minAppHeight, minBuilderHeight);
+        let minWidth = Math.max(minAppWidth, minToolboxWidth);
+        let minHeight = Math.max(minAppHeight, minToolboxHeight);
 
         window.expand_allocated_geometry(minWidth, minHeight);
     },
 
     _switchWindows: function(actor, event) {
-        // Switch to builder if the app is active. Otherwise switch to the app.
+        // Switch to toolbox if the app is active. Otherwise switch to the app.
         if (this._state === STATE_APP)
-            this._switchToBuilder();
+            this._switchToToolbox();
         else
             this._switchToApp();
     },
 
-    _startBuilderForFlatpak: function(loadFlatpakValue) {
+    _startToolboxForFlatpak: function(loadFlatpakValue) {
         let params = new GLib.Variant('(sava{sv})', ['load-flatpak', [new GLib.Variant('s', loadFlatpakValue)], {}]);
         Gio.DBus.session.call('org.gnome.Builder',
                               '/org/gnome/Builder',
@@ -633,25 +633,25 @@ var CodingSession = new Lang.Class({
                                       // Failed. Mark the session as cancelled
                                       // and wait for the flip animation
                                       // to complete, where we will
-                                      // remove the builder window.
+                                      // remove the toolbox window.
                                       this.cancelled = true;
                                       logError(e, 'Failed to start gnome-builder');
                                   }
                               });
     },
 
-    // Switch to a builder window, launching it if we haven't yet launched it.
+    // Switch to a toolbox window, launching it if we haven't yet launched it.
     //
     // Note that this is not the same as just rotating to the window - we
-    // need to either launch the builder window if we don't have a reference
+    // need to either launch the toolbox window if we don't have a reference
     // to it (and show a speedwagon) or we just need to switch to an existing
-    // builder window.
+    // toolbox window.
     //
     // This function and the one below do not check this._state to determine
     // if a flip animation should be played. That is the responsibility of
     // the caller.
-    _switchToBuilder: function() {
-        if (!this.builder) {
+    _switchToToolbox: function() {
+        if (!this.toolbox) {
             // get the manifest of the application
             // return early before we setup anything
             this._appManifest = _getAppManifest(this.app.meta_window.get_flatpak_id());
@@ -662,39 +662,39 @@ var CodingSession = new Lang.Class({
 
             let tracker = Shell.WindowTracker.get_default();
             tracker.track_coding_app_window(this.app.meta_window);
-            this._watchdogId = Mainloop.timeout_add(WATCHDOG_TIME, this._stopWatchingForBuilderWindowToComeOnline.bind(this));
+            this._watchdogId = Mainloop.timeout_add(WATCHDOG_TIME, this._stopWatchingForToolboxWindowToComeOnline.bind(this));
 
-            // We always show a splash screen, even if builder is running. We
+            // We always show a splash screen, even if toolbox is running. We
             // know when the window comes online so we can hide it accordingly.
-            let builderShellApp = Shell.AppSystem.get_default().lookup_app('org.gnome.Builder.desktop');
+            let toolboxShellApp = Shell.AppSystem.get_default().lookup_app('org.gnome.Builder.desktop');
             // Right now we don't connect the close button - clicking on
             // it will just do nothing. We expect the user to just click on
             // the CodeView button in order to get back to the main
             // window.
-            this.splash = new AppActivation.SpeedwagonSplash(builderShellApp);
+            this.splash = new AppActivation.SpeedwagonSplash(toolboxShellApp);
             this.splash.show();
 
-            this._startBuilderForFlatpak(_constructLoadFlatpakValue(this.app,
+            this._startToolboxForFlatpak(_constructLoadFlatpakValue(this.app,
                                                                     this._appManifest));
         } else {
-            this.builder.meta_window.activate(global.get_current_time());
+            this.toolbox.meta_window.activate(global.get_current_time());
             this._prepareAnimate(this.app,
-                                 this.builder,
+                                 this.toolbox,
                                  Gtk.DirectionType.LEFT);
             this._animate(this.app,
-                          this.builder,
+                          this.toolbox,
                           Gtk.DirectionType.LEFT);
             this.button.switchAnimation(Gtk.DirectionType.LEFT);
-            this._state = STATE_BUILDER;
+            this._state = STATE_TOOLBOX;
         }
     },
 
     _switchToApp: function() {
         this.app.meta_window.activate(global.get_current_time());
-        this._prepareAnimate(this.builder,
+        this._prepareAnimate(this.toolbox,
                              this.app,
                              Gtk.DirectionType.RIGHT);
-        this._animate(this.builder,
+        this._animate(this.toolbox,
                       this.app,
                       Gtk.DirectionType.RIGHT);
         this.button.switchAnimation(Gtk.DirectionType.RIGHT);
@@ -707,13 +707,13 @@ var CodingSession = new Lang.Class({
     // or left the overview. This will cause the state to instantly change
     // and prevent things from being flipped later in _windowRestacked
     _switchToWindowWithoutFlipping: function(actor) {
-        // Neither the app window nor the builder, return
-        if (actor !== this.app && actor !== this.builder)
+        // Neither the app window nor the toolbox, return
+        if (actor !== this.app && actor !== this.toolbox)
             return;
 
         // We need to do a few housekeeping things here:
         // 1. Change the _state variable to indicate whether we are now
-        //    on the app, or the builder window.
+        //    on the app, or the toolbox window.
         // 2. Depending on that state, hide and show windows. We might have
         //    hidden windows during the flip animation, so we need to show
         //    any relevant windows and hide any irrelevant ones
@@ -723,41 +723,41 @@ var CodingSession = new Lang.Class({
         //    which then breaks the user's expectations (it should unminimize
         //    but not activate). Re-activating ensures that we present
         //    the right story to the user.
-        this._state = (actor === this.app ? STATE_APP : STATE_BUILDER);
+        this._state = (actor === this.app ? STATE_APP : STATE_TOOLBOX);
         if (this._state === STATE_APP) {
-            this.builder.hide();
+            this.toolbox.hide();
             this.app.show();
         } else {
             this.app.hide();
-            this.builder.show();
+            this.toolbox.show();
         }
 
         actor.meta_window.activate(global.get_current_time());
     },
 
-    // Assuming that we are only listening to some signal on app and builder,
+    // Assuming that we are only listening to some signal on app and toolbox,
     // given some window, determine which MetaWindowActor instance is the
     // source and which is the destination, such that the source is where
     // the signal occurred and the destination is where changes should be
     // applied.
     _srcAndDstPairFromWindow: function(window) {
-        let src = (window === this.app.meta_window ? this.app : this.builder);
-        let dst = (window === this.app.meta_window ? this.builder : this.app);
+        let src = (window === this.app.meta_window ? this.app : this.toolbox);
+        let dst = (window === this.app.meta_window ? this.toolbox : this.app);
 
         return [src, dst];
     },
 
     _isActorFromSession: function(actor) {
-        if (actor === this.app && this.builder)
-            return this.builder;
-        else if (actor === this.builder && this.app)
+        if (actor === this.app && this.toolbox)
+            return this.toolbox;
+        else if (actor === this.toolbox && this.app)
             return this.app;
         return null;
     },
 
     _synchronizeWindows: function(window) {
-        // No synchronization if builder has not been set here
-        if (!this.builder)
+        // No synchronization if toolbox has not been set here
+        if (!this.toolbox)
             return;
 
         let [src, dst] = this._srcAndDstPairFromWindow(window);
@@ -768,15 +768,15 @@ var CodingSession = new Lang.Class({
         if (!maximizationStateChanged)
             return;
 
-        if (this._state === STATE_BUILDER)
+        if (this._state === STATE_TOOLBOX)
             this.app.hide();
         else
-            this.builder.hide();
+            this.toolbox.hide();
     },
 
     _applyWindowMinimizationState: function(shellwm, actor) {
-        // No synchronization if builder has not been set here
-        if (!this.builder)
+        // No synchronization if toolbox has not been set here
+        if (!this.toolbox)
             return;
 
         let toMini = this._isActorFromSession(actor);
@@ -787,8 +787,8 @@ var CodingSession = new Lang.Class({
     },
 
     _applyWindowUnminimizationState: function(shellwm, actor) {
-        // No synchronization if builder has not been set here
-        if (!this.builder)
+        // No synchronization if toolbox has not been set here
+        if (!this.toolbox)
             return;
 
         let toUnMini = this._isActorFromSession(actor);
@@ -811,19 +811,19 @@ var CodingSession = new Lang.Class({
         if (!focusedWindow)
             return;
 
-        if (!this.builder)
+        if (!this.toolbox)
             return;
 
         let appWindow = this.app.meta_window;
-        let builderWindow = this.builder.meta_window;
+        let toolboxWindow = this.toolbox.meta_window;
         let nextState = null;
 
         // Determine if we need to change the state of this session by
         // examining the focused window
-        if (appWindow === focusedWindow && this._state === STATE_BUILDER)
+        if (appWindow === focusedWindow && this._state === STATE_TOOLBOX)
             nextState = STATE_APP;
-        else if (builderWindow === focusedWindow && this._state === STATE_APP)
-            nextState = STATE_BUILDER;
+        else if (toolboxWindow === focusedWindow && this._state === STATE_APP)
+            nextState = STATE_TOOLBOX;
 
         // No changes to be made, so return directly
         if (nextState === null)
@@ -834,7 +834,7 @@ var CodingSession = new Lang.Class({
         // make no sense, immediately change the state and show the
         // recently activated window.
         if (Main.overview.visible || Main.overview.animationInProgress) {
-            let actor = (nextState === STATE_APP ? this.app : this.builder);
+            let actor = (nextState === STATE_APP ? this.app : this.toolbox);
             this._switchToWindowWithoutFlipping(actor);
             return;
         }
@@ -848,7 +848,7 @@ var CodingSession = new Lang.Class({
         if (nextState === STATE_APP)
             this._switchToApp();
         else
-            this._switchToBuilder();
+            this._switchToToolbox();
     },
 
     _prepareAnimate: function(src, dst, direction) {
@@ -913,8 +913,8 @@ var CodingSession = new Lang.Class({
                 // screens.
                 if (this.cancelled) {
                     this.splash.rampOut();
-                    this._stopWatchingForBuilderWindowToComeOnline();
-                    this.removeBuilderWindow();
+                    this._stopWatchingForToolboxWindowToComeOnline();
+                    this.removeToolboxWindow();
                 }
             }
         });
@@ -946,9 +946,9 @@ var CodingSession = new Lang.Class({
         this._rotatingInActor = null;
 
         // If we just finished rotating in the speedwagon
-        // for builder, launch builder now
-        if (_isBuilderSpeedwagon(actor.meta_window))
-           this._startBuilderForFlatpak(_constructLoadFlatpakValue(this.app,
+        // for toolbox, launch toolbox now
+        if (_isToolboxSpeedwagon(actor.meta_window))
+           this._startToolboxForFlatpak(_constructLoadFlatpakValue(this.app,
                                                                    this._appManifest));
     },
 
@@ -964,7 +964,7 @@ var CodingSession = new Lang.Class({
         this._rotatingOutActor = null;
     },
 
-    _stopWatchingForBuilderWindowToComeOnline: function() {
+    _stopWatchingForToolboxWindowToComeOnline: function() {
         let tracker = Shell.WindowTracker.get_default();
         tracker.untrack_coding_app_window();
         if (this._watchdogId !== 0) {
@@ -998,30 +998,30 @@ var CodeViewManager = new Lang.Class({
 
         this._sessions.push(new CodingSession({
             app: actor,
-            builder: null,
+            toolbox: null,
             button: new WindowTrackingButton({ window: actor.meta_window })
         }));
         return true;
     },
 
-    addBuilderWindow: function(actor) {
+    addToolboxWindow: function(actor) {
         if (!global.settings.get_boolean('enable-code-view'))
             return false;
 
         let window = actor.meta_window;
-        let isSpeedwagonForBuilder = _isBuilderSpeedwagon(window);
+        let isSpeedwagonForToolbox = _isToolboxSpeedwagon(window);
 
-        if (!_isBuilder(window.get_flatpak_id()) &&
-            !isSpeedwagonForBuilder)
+        if (!_isToolbox(window.get_flatpak_id()) &&
+            !isSpeedwagonForToolbox)
             return false;
 
         // Get the last session in the list - we assume that we are
-        // adding a builder to this window
+        // adding a toolbox to this window
         let session = this._sessions[this._sessions.length - 1];
         if (!session)
             return false;
 
-        return session.admitBuilderWindowActor(actor);
+        return session.admitToolboxWindowActor(actor);
     },
 
     removeAppWindow: function(actor) {
@@ -1044,21 +1044,21 @@ var CodeViewManager = new Lang.Class({
         return true;
     },
 
-    removeBuilderWindow: function(actor) {
+    removeToolboxWindow: function(actor) {
         let window = actor.meta_window;
-        let isSpeedwagonForBuilder = _isBuilderSpeedwagon(window);
+        let isSpeedwagonForToolbox = _isToolboxSpeedwagon(window);
 
-        if (!_isBuilder(window.get_flatpak_id()) &&
-            !isSpeedwagonForBuilder)
+        if (!_isToolbox(window.get_flatpak_id()) &&
+            !isSpeedwagonForToolbox)
             return false;
 
         let session = this._getSession(actor);
         if (!session)
             return false;
 
-        // We can remove either a speedwagon window or a normal builder window.
+        // We can remove either a speedwagon window or a normal toolbox window.
         // That window will be registered in the session at this point.
-        session.removeBuilderWindow();
+        session.removeToolboxWindow();
         return true;
     },
 
@@ -1071,7 +1071,7 @@ var CodeViewManager = new Lang.Class({
     _getSession: function(actor) {
         for (let i = 0; i < this._sessions.length; i++) {
             let session = this._sessions[i];
-            if (session.app === actor || session.builder === actor)
+            if (session.app === actor || session.toolbox === actor)
                 return session;
         }
 

--- a/js/ui/codeView.js
+++ b/js/ui/codeView.js
@@ -890,31 +890,17 @@ var CodingSession = new Lang.Class({
         // We want to do this _first_ before setting up any animations.
         // Synchronising windows could cause kill-window-effects to
         // be emitted, which would undo some of the preparation
-        // that we would have done such as setting backface culling
-        // or rotation angles.
+        // that we would have done such as setting rotation angles.
         _synchronizeMetaWindowActorGeometries(src, dst);
 
         this._rotatingInActor = dst;
         this._rotatingOutActor = src;
 
-        // We set backface culling to be enabled here so that we can
-        // smootly animate between the two windows. Without expensive
-        // vector projections, there's no way to determine whether a
-        // window's front-face is completely invisible to the user
-        // (this cannot be done just by looking at the angle of the
-        // window because the same angle may show a different visible
-        // face depending on its position in the view frustum).
-        //
-        // What we do here is enable backface culling and rotate both
-        // windows by 180degrees. The effect of this is that the front
-        // and back window will be at opposite rotations at each point
-        // in time and so the exact point at which the first window
-        // becomes invisible is the same point at which the second
-        // window becomes visible. Because no back faces are drawn
-        // there are no visible artifacts in the animation */
-        src.set_cull_back_face(true);
-        dst.set_cull_back_face(true);
-
+        // What we do here is rotate both windows by 180degrees.
+        // The effect of this is that the front and back window will be at
+        // opposite rotations at each point in time and so the exact point
+        // at which the first window is brought to front, is the same point
+        // at which the second window is brought to back.
         src.show();
         dst.show();
         dst.opacity = 0;
@@ -934,9 +920,8 @@ var CodingSession = new Lang.Class({
     },
 
     _animateToMidpoint: function(src, dst, direction) {
-        // Tween both windows in a rotation animation at the same time
-        // with backface culling enabled on both. This will allow for
-        // a smooth transition.
+        // Tween both windows in a rotation animation at the same time.
+        // This will allow for a smooth transition.
         Tweener.addTween(src, {
             rotation_angle_y: direction == Gtk.DirectionType.RIGHT ? 90 : -90,
             time: WINDOW_ANIMATION_TIME * 2,
@@ -1007,7 +992,6 @@ var CodingSession = new Lang.Class({
         Tweener.removeTweens(actor);
         actor.opacity = 255;
         actor.rotation_angle_y = 0;
-        actor.set_cull_back_face(false);
         this._rotatingInActor = null;
     },
 
@@ -1019,7 +1003,6 @@ var CodingSession = new Lang.Class({
         Tweener.removeTweens(actor);
         actor.hide();
         actor.rotation_angle_y = 0;
-        actor.set_cull_back_face(false);
         this._rotatingOutActor = null;
     },
 

--- a/js/ui/codeView.js
+++ b/js/ui/codeView.js
@@ -597,14 +597,18 @@ var CodingSession = new Lang.Class({
     },
 
     _switchToApp: function() {
-        this.app.meta_window.activate(global.get_current_time());
-        this._prepareAnimate(this.toolbox,
-                             this.app,
-                             Gtk.DirectionType.RIGHT);
-        this._completeAnimate(this.toolbox,
-                              this.app,
-                              Gtk.DirectionType.RIGHT);
-        this._state = STATE_APP;
+        if (this._toolboxActionGroup.has_action('flip-back')) {
+            this._toolboxActionGroup.activate_action('flip-back', null);
+        } else {
+            this.app.meta_window.activate(global.get_current_time());
+            this._prepareAnimate(this.toolbox,
+                                 this.app,
+                                 Gtk.DirectionType.RIGHT);
+            this._completeAnimate(this.toolbox,
+                                  this.app,
+                                  Gtk.DirectionType.RIGHT);
+            this._state = STATE_APP;
+        }
     },
 
     // Given some recently-focused actor, switch to it without

--- a/js/ui/codeView.js
+++ b/js/ui/codeView.js
@@ -417,14 +417,15 @@ var CodingSession = new Lang.Class({
         this.parent(params);
 
         this._state = STATE_APP;
+        this._toolboxActionGroup = null;
 
         // FIXME: this should be extended to make it possible to launch
         // arbitrary toolboxes in the future, depending on the application
-        this._toolboxActionGroup =
+        this._toolboxAppActionGroup =
             Gio.DBusActionGroup.get(Gio.DBus.session,
                                     'com.endlessm.HackToolbox',
                                     '/com/endlessm/HackToolbox');
-        this._toolboxActionGroup.list_actions();
+        this._toolboxAppActionGroup.list_actions();
 
         this.button.connect('clicked', this._switchWindows.bind(this));
         this._windowsRestackedId = Main.overview.connect('windows-restacked',
@@ -511,6 +512,11 @@ var CodingSession = new Lang.Class({
         // geometries now.
         this.toolbox = actor;
         this.button.toolbox_window = actor.meta_window;
+        this._toolboxActionGroup =
+            Gio.DBusActionGroup.get(Gio.DBus.session,
+                                    this.toolbox.meta_window.gtk_application_id,
+                                    this.toolbox.meta_window.gtk_window_object_path);
+        this._toolboxActionGroup.list_actions();
 
         _synchronizeMetaWindowActorGeometries(this.app, this.toolbox);
 
@@ -710,7 +716,7 @@ var CodingSession = new Lang.Class({
     // the caller.
     _switchToToolbox: function() {
         if (!this.toolbox) {
-            this._toolboxActionGroup.activate_action(
+            this._toolboxAppActionGroup.activate_action(
                 'flip',
                 new GLib.Variant('(ss)', [this.app.meta_window.gtk_application_id,
                                           this.app.meta_window.gtk_window_object_path]));

--- a/js/ui/codeView.js
+++ b/js/ui/codeView.js
@@ -25,8 +25,8 @@ const STATE_APP = 0;
 const STATE_TOOLBOX = 1;
 
 const _CODING_APPS = [
-    'com.endlessm.Helloworld',
-    'org.gnome.Weather'
+    // FIXME: this should be extended with a more complex lookup
+    'com.endlessm.dinosaurs.en'
 ];
 
 function _isCodingApp(flatpakID) {

--- a/js/ui/codeView.js
+++ b/js/ui/codeView.js
@@ -27,7 +27,8 @@ const STATE_TOOLBOX = 1;
 const _CODING_APPS = [
     // FIXME: this should be extended with a more complex lookup
     'com.endlessm.dinosaurs.en',
-    'com.endlessm.hackybird'
+    'com.endlessm.hackybird',
+    'com.endlessm.hackyballs'
 ];
 
 function _isCodingApp(flatpakID) {

--- a/js/ui/codeView.js
+++ b/js/ui/codeView.js
@@ -498,7 +498,6 @@ var CodingSession = new Lang.Class({
         this.app = actor;
         this.button.window = actor.meta_window;
 
-        _synchronizeMetaWindowActorGeometries(this.toolbox, this.app);
         this._setupAnimation(STATE_APP,
                              this.toolbox,
                              appRemovedActor, this.app,
@@ -522,7 +521,6 @@ var CodingSession = new Lang.Class({
                                     this.toolbox.meta_window.gtk_window_object_path);
         this._toolboxActionGroup.list_actions();
 
-        _synchronizeMetaWindowActorGeometries(this.app, this.toolbox);
         this._setupAnimation(STATE_TOOLBOX,
                              this.app,
                              null, this.toolbox,

--- a/js/ui/codeView.js
+++ b/js/ui/codeView.js
@@ -803,15 +803,9 @@ var CodingSession = new Lang.Class({
         if (!focusedWindow)
             return;
 
-        let appWindow = this.app ? this.app.meta_window : null;
-        let toolboxWindow = this.toolbox ? this.toolbox.meta_window : null;
-
-        // Determine if we need to change the state of this session by
-        // examining the focused window
-        if (focusedWindow != appWindow && focusedWindow != toolboxWindow)
-            return;
-
         let focusedActor = focusedWindow.get_compositor_private();
+        if (!this._isActorFromSession(focusedActor))
+            return;
 
         // If the overview is still showing or animating out, we probably
         // selected this window from the overview. In that case, flipping

--- a/js/ui/windowManager.js
+++ b/js/ui/windowManager.js
@@ -2237,11 +2237,10 @@ var WindowManager = new Lang.Class({
             actor._animatableSurface.attach_animation_effect_with_server_priority('move',
                                                                                   this._wobblyEffect);
 
-        if (this._codeViewManager.addToolboxWindow(actor)) {
+        if (this._codeViewManager.handleMapWindow(actor)) {
             shellwm.completed_map(actor);
             return;
         }
-        this._codeViewManager.addAppWindow(actor);
 
         let metaWindow = actor.meta_window;
         let isSplashWindow = Shell.WindowTracker.is_speedwagon_window(metaWindow);
@@ -2388,8 +2387,7 @@ var WindowManager = new Lang.Class({
     _destroyWindow : function(shellwm, actor) {
         let window = actor.meta_window;
 
-        this._codeViewManager.removeAppWindow(actor);
-        this._codeViewManager.removeToolboxWindow(actor);
+        this._codeViewManager.handleDestroyWindow(actor);
 
         if (actor._notifyWindowTypeSignalId) {
             window.disconnect(actor._notifyWindowTypeSignalId);

--- a/js/ui/windowManager.js
+++ b/js/ui/windowManager.js
@@ -2228,6 +2228,15 @@ var WindowManager = new Lang.Class({
                     this._checkDimming(parent);
         }));
 
+        // Endless libanimation extension
+        if (this._animationsServer)
+            actor._animatableSurface = this._animationsServer.register_surface(new ShellWindowManagerAnimatableSurface(actor));
+
+        // Add the wobbly effect if it is enabled
+        if (this._wobblyEffect)
+            actor._animatableSurface.attach_animation_effect_with_server_priority('move',
+                                                                                  this._wobblyEffect);
+
         if (this._codeViewManager.addToolboxWindow(actor)) {
             shellwm.completed_map(actor);
             return;
@@ -2262,16 +2271,6 @@ var WindowManager = new Lang.Class({
 
             shellwm.completed_map(actor);
             return;
-        }
-
-        // Endless libanimation extension
-        if (this._animationsServer)
-            actor._animatableSurface = this._animationsServer.register_surface(new ShellWindowManagerAnimatableSurface(actor));
-
-        // Add the wobbly effect if it is enabled
-        if (this._wobblyEffect) {
-            actor._animatableSurface.attach_animation_effect_with_server_priority('move',
-                                                                                  this._wobblyEffect);
         }
 
         if (SideComponent.isSideComponentWindow(actor.meta_window)) {

--- a/js/ui/windowManager.js
+++ b/js/ui/windowManager.js
@@ -2310,10 +2310,8 @@ var WindowManager = new Lang.Class({
                                    onOverwriteParams: [shellwm, actor]
                                  });
             } else {
-                if (this._codeViewManager.handleMapWindow(actor)) {
-                    shellwm.completed_map(actor);
+                if (this._codeViewManager.handleMapWindow(actor))
                     return;
-                }
 
                 actor.set_pivot_point(0.5, 1.0);
                 actor.scale_x = 0.01;

--- a/js/ui/windowManager.js
+++ b/js/ui/windowManager.js
@@ -2228,7 +2228,7 @@ var WindowManager = new Lang.Class({
                     this._checkDimming(parent);
         }));
 
-        if (this._codeViewManager.addBuilderWindow(actor)) {
+        if (this._codeViewManager.addToolboxWindow(actor)) {
             shellwm.completed_map(actor);
             return;
         }
@@ -2390,7 +2390,7 @@ var WindowManager = new Lang.Class({
         let window = actor.meta_window;
 
         this._codeViewManager.removeAppWindow(actor);
-        this._codeViewManager.removeBuilderWindow(actor);
+        this._codeViewManager.removeToolboxWindow(actor);
 
         if (actor._notifyWindowTypeSignalId) {
             window.disconnect(actor._notifyWindowTypeSignalId);

--- a/js/ui/windowManager.js
+++ b/js/ui/windowManager.js
@@ -1846,7 +1846,6 @@ var WindowManager = new Lang.Class({
             Tweener.removeTweens(actor);
             actor.set_scale(1.0, 1.0);
             actor.set_opacity(255);
-            actor.set_pivot_point(0, 0);
 
             shellwm.completed_minimize(actor);
         }
@@ -1913,7 +1912,6 @@ var WindowManager = new Lang.Class({
             Tweener.removeTweens(actor);
             actor.set_scale(1.0, 1.0);
             actor.set_opacity(255);
-            actor.set_pivot_point(0, 0);
 
             shellwm.completed_unminimize(actor);
         }

--- a/js/ui/windowManager.js
+++ b/js/ui/windowManager.js
@@ -2432,7 +2432,8 @@ var WindowManager = new Lang.Class({
 
         switch (actor.meta_window.window_type) {
         case Meta.WindowType.NORMAL:
-            this._codeViewManager.handleDestroyWindow(actor);
+            if (this._codeViewManager.handleDestroyWindow(actor))
+                return;
 
             actor.set_pivot_point(0.5, 0.5);
             this._destroying.push(actor);

--- a/js/ui/windowManager.js
+++ b/js/ui/windowManager.js
@@ -2237,11 +2237,6 @@ var WindowManager = new Lang.Class({
             actor._animatableSurface.attach_animation_effect_with_server_priority('move',
                                                                                   this._wobblyEffect);
 
-        if (this._codeViewManager.handleMapWindow(actor)) {
-            shellwm.completed_map(actor);
-            return;
-        }
-
         let metaWindow = actor.meta_window;
         let isSplashWindow = Shell.WindowTracker.is_speedwagon_window(metaWindow);
 
@@ -2315,6 +2310,11 @@ var WindowManager = new Lang.Class({
                                    onOverwriteParams: [shellwm, actor]
                                  });
             } else {
+                if (this._codeViewManager.handleMapWindow(actor)) {
+                    shellwm.completed_map(actor);
+                    return;
+                }
+
                 actor.set_pivot_point(0.5, 1.0);
                 actor.scale_x = 0.01;
                 actor.scale_y = 0.05;
@@ -2387,8 +2387,6 @@ var WindowManager = new Lang.Class({
     _destroyWindow : function(shellwm, actor) {
         let window = actor.meta_window;
 
-        this._codeViewManager.handleDestroyWindow(actor);
-
         if (actor._notifyWindowTypeSignalId) {
             window.disconnect(actor._notifyWindowTypeSignalId);
             actor._notifyWindowTypeSignalId = 0;
@@ -2434,6 +2432,8 @@ var WindowManager = new Lang.Class({
 
         switch (actor.meta_window.window_type) {
         case Meta.WindowType.NORMAL:
+            this._codeViewManager.handleDestroyWindow(actor);
+
             actor.set_pivot_point(0.5, 0.5);
             this._destroying.push(actor);
 

--- a/src/shell-window-tracker.c
+++ b/src/shell-window-tracker.c
@@ -33,8 +33,6 @@
 #define SIDE_COMPONENT_ROLE "eos-side-component"
 #define SPEEDWAGON_ROLE "eos-speedwagon"
 
-#define BUILDER_WINDOW "org.gnome.Builder"
-
 /**
  * SECTION:shell-window-tracker
  * @short_description: Associate windows with applications
@@ -53,8 +51,6 @@ struct _ShellWindowTracker
 
   /* <MetaWindow * window, ShellApp *app> */
   GHashTable *window_to_app;
-
-  MetaWindow *coding_app;
 };
 
 G_DEFINE_TYPE (ShellWindowTracker, shell_window_tracker, G_TYPE_OBJECT);
@@ -474,21 +470,6 @@ get_app_for_window (ShellWindowTracker    *tracker,
   /* Side components don't have an associated app */
   if (g_strcmp0 (meta_window_get_role (window), SIDE_COMPONENT_ROLE) == 0)
     return NULL;
-
-  /* We do want to associate the GNOME Builder window with
-   * an open app of a coding session */
-  if (g_strcmp0 (meta_window_get_flatpak_id (window), BUILDER_WINDOW) == 0 &&
-      tracker->coding_app)
-    {
-      result = g_hash_table_lookup (tracker->window_to_app, tracker->coding_app);
-      shell_window_tracker_untrack_coding_app_window (tracker);
-
-      if (result != NULL)
-        {
-          g_object_ref (result);
-          return result;
-        }
-    }
 
   /* Check if the window is a HackToolbox and if so
    * associate it with the corresponding target application.
@@ -983,34 +964,6 @@ GDBusProxy *
 shell_window_tracker_get_hack_toolbox_proxy (MetaWindow *window)
 {
   return g_object_get_data (G_OBJECT (window), "hack-toolbox-proxy");
-}
-
-/**
- * shell_window_tracker_track_coding_app_window:
- * @tracker: An app monitor instance
- * @app_window: A #MetaWindow
- *
- * Track a coding app to pair with an associated GNOME Builder window.
- *
- */
-void
-shell_window_tracker_track_coding_app_window (ShellWindowTracker *tracker,
-                                              MetaWindow *app_window)
-{
-  tracker->coding_app = app_window;
-}
-
-/**
- * shell_window_tracker_untrack_coding_app_window:
- * @tracker: An app monitor instance
- *
- * Untrack the coding app.
- *
- */
-void
-shell_window_tracker_untrack_coding_app_window (ShellWindowTracker *tracker)
-{
-  tracker->coding_app = NULL;
 }
 
 /* sn_startup_sequence_ref returns void, so make a

--- a/src/shell-window-tracker.c
+++ b/src/shell-window-tracker.c
@@ -9,6 +9,7 @@
 #include <X11/Xatom.h>
 #include <gdk/gdk.h>
 #include <gdk/gdkx.h>
+#include <gio/gio.h>
 #include <meta/display.h>
 #include <meta/group.h>
 #include <meta/util.h>
@@ -364,6 +365,95 @@ get_app_from_window_pid (ShellWindowTracker  *tracker,
   return result;
 }
 
+static ShellApp *
+maybe_find_target_app_for_toolbox (ShellWindowTracker  *tracker,
+                                   MetaWindow          *window)
+{
+  g_autoptr(GError) local_error = NULL;
+  g_autoptr(GDBusProxy) proxy = NULL;
+  g_autoptr(GVariant) target_property_variant = NULL;
+  GSettings *settings;
+  const gchar *window_app_id = NULL;
+  const gchar *window_object_path = NULL;
+  const gchar *target_bus_name = NULL;
+  const gchar *target_object_path = NULL;
+  GHashTableIter iter;
+  gpointer key, value;
+
+  /* If code view is disabled globally, do nothing here */
+  settings = shell_global_get_settings (shell_global_get ());
+  if (!g_settings_get_boolean (settings, "enable-code-view"))
+    return NULL;
+
+  /* Check if there is a set application id and object path
+   * on this window. If not, then it can't be a toolbox. */
+  window_app_id = meta_window_get_gtk_application_id (window);
+  window_object_path = meta_window_get_gtk_window_object_path (window);
+
+  if (window_app_id == NULL ||
+      window_object_path == NULL)
+    return NULL;
+
+  /* Not a bus name, no way that this could be a toolbox */
+  if (!g_dbus_is_name (window_app_id))
+    return NULL;
+
+  proxy = g_dbus_proxy_new_for_bus_sync (G_BUS_TYPE_SESSION,
+                                         G_DBUS_PROXY_FLAGS_DO_NOT_AUTO_START |
+                                         G_DBUS_PROXY_FLAGS_DO_NOT_CONNECT_SIGNALS,
+                                         NULL,
+                                         window_app_id,
+                                         window_object_path,
+                                         "com.endlessm.HackToolbox.Toolbox",
+                                         NULL,
+                                         &local_error);
+
+  if (proxy == NULL)
+    {
+      if (!g_error_matches (local_error, G_DBUS_ERROR, G_DBUS_ERROR_UNKNOWN_INTERFACE))
+        g_warning ("Error in finding candidate app for potential Hack Toolbox: %s",
+                   local_error->message);
+      return NULL;
+    }
+
+  target_property_variant = g_dbus_proxy_get_cached_property (proxy, "Target");
+  if (target_property_variant == NULL)
+    return NULL;
+
+  g_variant_get (target_property_variant, "(&s&s)",
+                 &target_bus_name,
+                 &target_object_path);
+
+  if (target_bus_name == NULL || target_object_path == NULL)
+    {
+      g_warning ("Invalid Target property on Hack Toolbox: %s %s",
+                 target_bus_name, target_object_path);
+      return NULL;
+    }
+
+  g_object_set_data_full (G_OBJECT (window), "hack-toolbox-proxy",
+                          g_object_ref (proxy), g_object_unref);
+
+  /* Now that we have the target bus name and object path, we need to look
+   * up the corresponding app for the bus name by enumerating all the
+   * windows on the window tracker */
+  g_hash_table_iter_init (&iter, tracker->window_to_app);
+
+  while (g_hash_table_iter_next (&iter, &key, &value))
+    {
+      MetaWindow *window = key;
+      ShellApp *app = value;
+      const char *candidate_app_id = meta_window_get_gtk_application_id (window);
+      const char *candidate_object_path = meta_window_get_gtk_window_object_path (window);
+
+      if (g_strcmp0 (candidate_app_id, target_bus_name) == 0 &&
+          g_strcmp0 (candidate_object_path, target_object_path) == 0)
+        return app;
+    }
+
+  return NULL;
+}
+
 /**
  * get_app_for_window:
  *
@@ -399,6 +489,15 @@ get_app_for_window (ShellWindowTracker    *tracker,
           return result;
         }
     }
+
+  /* Check if the window is a HackToolbox and if so
+   * associate it with the corresponding target application.
+   * It is definitely not ideal that this has to happen
+   * synchronously for each window that gets opened, but
+   * that's just the way that this function happens to work. */
+  result = maybe_find_target_app_for_toolbox (tracker, window);
+  if (result != NULL)
+    return g_object_ref (result);
 
   transient_for = meta_window_get_transient_for (window);
   if (transient_for != NULL)
@@ -871,6 +970,19 @@ gboolean
 shell_window_tracker_is_speedwagon_window (MetaWindow *window)
 {
   return g_strcmp0 (meta_window_get_role (window), SPEEDWAGON_ROLE) == 0;
+}
+
+/**
+ * shell_window_tracker_get_hack_toolbox_proxy:
+ *
+ * Gets the #GDBusProxy for the hack toolbox represented by this window.
+ *
+ * Returns: (transfer none): a #GDBusProy, or %NULL
+ */
+GDBusProxy *
+shell_window_tracker_get_hack_toolbox_proxy (MetaWindow *window)
+{
+  return g_object_get_data (G_OBJECT (window), "hack-toolbox-proxy");
 }
 
 /**

--- a/src/shell-window-tracker.h
+++ b/src/shell-window-tracker.h
@@ -29,10 +29,6 @@ gboolean shell_window_tracker_is_window_interesting (MetaWindow *window);
 
 gboolean shell_window_tracker_is_speedwagon_window (MetaWindow *window);
 
-void shell_window_tracker_track_coding_app_window (ShellWindowTracker *tracker, MetaWindow *app_window);
-
-void shell_window_tracker_untrack_coding_app_window (ShellWindowTracker *tracker);
-
 GDBusProxy * shell_window_tracker_get_hack_toolbox_proxy (MetaWindow *window);
 
 /* Hidden typedef for SnStartupSequence */

--- a/src/shell-window-tracker.h
+++ b/src/shell-window-tracker.h
@@ -33,6 +33,8 @@ void shell_window_tracker_track_coding_app_window (ShellWindowTracker *tracker, 
 
 void shell_window_tracker_untrack_coding_app_window (ShellWindowTracker *tracker);
 
+GDBusProxy * shell_window_tracker_get_hack_toolbox_proxy (MetaWindow *window);
+
 /* Hidden typedef for SnStartupSequence */
 typedef struct _ShellStartupSequence ShellStartupSequence;
 #define SHELL_TYPE_STARTUP_SEQUENCE (shell_startup_sequence_get_type ())


### PR DESCRIPTION
This is a preliminary PR for the current implementation of flip to hack, generalizing what was already in place to flip between GNOME Weather and Builder. We now have the concept of a "toolbox" which sits on the other side of a hackable window. 
The canonical implementation of toolboxes for the apps we care about so far is developed in https://github.com/endlessm/hack-toolbox-app

It has a couple of known issues:
- There's an odd behavior when the toolbox is minimized; the window behind it is also minimized but it becomes transparent. 
- The animation probably needs to flip back when the toolbox is closed directly.

And a few FIXMEs in the code where things need to become more generic. However, this is ready for a round of review, as it's a sizable branch. I split the work in many commits that reflect the way the feature was actually developed, but can squash some of them if preferred.

I also structured the code so that everything related to the feature is in `codeView.js` and disabled when the "hack mode" gsetting is off (which will be for regular Endless OS), so these changes should be relatively low risk for non-hack images.

@GeorgesStavracas It would be awesome if you could take a look. @ptomato or @erikos could also be interested in helping out. I am also open to suggestions for how we want to assign responsibility and maintenance of this piece of code moving forward, as the Hack team is happy to help with that too.

https://phabricator.endlessm.com/T23632