### PR TITLE
shell-app-system: fix use-after-free in alias logic

### DIFF
--- a/src/shell-app-system.c
+++ b/src/shell-app-system.c
@@ -430,7 +430,6 @@ shell_app_system_lookup_app (ShellAppSystem   *self,
 
   app = _shell_app_new (info);
   g_hash_table_insert (priv->id_to_app, (char *) shell_app_get_id (app), app);
-  add_aliases (self, id, info);
 
   return app;
 }

--- a/src/shell-app-system.c
+++ b/src/shell-app-system.c
@@ -123,10 +123,10 @@ static void shell_app_system_class_init(ShellAppSystemClass *klass)
 
 static void
 add_aliases (ShellAppSystem  *self,
-             const char      *id,
              GDesktopAppInfo *info)
 {
   ShellAppSystemPrivate *priv = self->priv;
+  const char *id = g_app_info_get_id (G_APP_INFO (info));
   const char *alias;
   g_autofree char *renamed_from = NULL;
 
@@ -172,12 +172,7 @@ scan_alias_to_id (ShellAppSystem *self)
 
   apps = g_app_info_get_all ();
   for (l = apps; l != NULL; l = l->next)
-    {
-      GAppInfo *info = l->data;
-      const char *id = g_app_info_get_id (info);
-
-      add_aliases (self, id, G_DESKTOP_APP_INFO (info));
-    }
+    add_aliases (self, G_DESKTOP_APP_INFO (l->data));
 
   g_list_free_full (apps, g_object_unref);
 }

--- a/src/shell-app-system.c
+++ b/src/shell-app-system.c
@@ -150,7 +150,7 @@ add_aliases (ShellAppSystem  *self,
 
       for (i = 0; renamed_from_list[i] != NULL; i++)
         {
-          if (renamed_from_list[i] != '\0')
+          if (renamed_from_list[i][0] != '\0')
             g_hash_table_insert (priv->alias_to_id,
                                  g_steal_pointer (&renamed_from_list[i]),
                                  g_strdup (id));


### PR DESCRIPTION
This was a nice combination of three factors:

* a premature optimization where add_aliases() received the desktop file ID as an argument, even though it can be derived from its GDesktopAppInfo argument, for the benefit of one call-site which already has the ID
* that call-site being reached when looking an app up by alias, meaning that finding an app by its alias caused its aliases to be re-scanned for the lookup table we just found it in, freeing the passed-in ID on the way through, so that any app with >1 alias would lead to a use-after-free of the ID
* a missing dereference in lovingly hand-crafted desktop file string list parser, causing every app with any X-Flatpak-RenamedFrom entry to be also associated with the empty-string alias (last one wins!)

The fun part is that, since none of these .desktop files actually have >1 X-Flatpak-RenamedFrom alias right after the migration, without the last point the use-after-free would have been deferred to the next time an app whose Flathub .desktop file already includes X-Flatpak-RenamedFrom was updated. We would append the (local) previous ID to that list; then, if the Shell hasn't got around to updating its icon-grid-layout to use the new name rather than the alias, we'd get a use-after-free on next login.

I am not certain that this is the cause of the hard-to-reproduce crashes seen after the app migration, since I can't reproduce it, but Valgrind would reliably complain about this bug, and is silent (on this point) with these patches.

https://phabricator.endlessm.com/T23973