### PR TITLE
windowManager: let codeview handle windows while speedwagon is up

### DIFF
--- a/js/ui/windowManager.js
+++ b/js/ui/windowManager.js
@@ -2246,7 +2246,8 @@ var WindowManager = new Lang.Class({
                 return Shell.WindowTracker.is_speedwagon_window(w);
             }));
             if (hasSplashWindow) {
-                shellwm.completed_map(actor);
+                if (!this._codeViewManager.handleMapWindow(actor))
+                    shellwm.completed_map(actor);
                 return;
             }
         }


### PR DESCRIPTION
We have a second code path to account for windows mapped while the
speedwagon is up. Make sure CodeViewManager handles that case too.

https://phabricator.endlessm.com/T24057