### PR TITLE
clubhouse: Don't stop a quest when the notification is withdrawn

### DIFF
--- a/js/ui/components/clubhouse.js
+++ b/js/ui/components/clubhouse.js
@@ -177,7 +177,8 @@ var ClubhouseComponent = new Lang.Class({
 
     _onNotify: function(source, notification) {
         notification.connect('destroy', (notification, reason) => {
-            if (reason != MessageTray.NotificationDestroyedReason.REPLACED)
+            if (reason != MessageTray.NotificationDestroyedReason.REPLACED &&
+                reason != MessageTray.NotificationDestroyedReason.SOURCE_CLOSED)
                 this._dismissQuest();
 
             this._clearBanner();


### PR DESCRIPTION
The Clubhouse may choose to withdraw a notification (in order to stop
the Shell Quest View) without having the quest being stopped (so it may
keep showing the quest inside its window).

To accomplish that, this patch checks what's the reason for closing the
notification, and doesn't dismiss the quest if the reason is "source
closed".

https://phabricator.endlessm.com/T24105