### PR TITLE
Support alternative PAYG code formats

### DIFF
--- a/data/theme/gnome-shell-sass/_endless.scss
+++ b/data/theme/gnome-shell-sass/_endless.scss
@@ -881,8 +881,8 @@ popup-separator-menu-item {
 
       .unlock-dialog-payg-promptbox {
           spacing: 6px;
-          min-width: 370px;
-          max-width: 370px;
+          min-width: 400px;
+          max-width: 400px;
       }
 
       .unlock-dialog-payg-label {
@@ -895,7 +895,7 @@ popup-separator-menu-item {
           font-size: 24px;
           padding-left: 12px;
           padding-right: 12px;
-          letter-spacing: 12px;
+          letter-spacing: 6px;
       }
 
       .unlock-dialog-payg-session-list-button {

--- a/js/misc/paygManager.js
+++ b/js/misc/paygManager.js
@@ -85,34 +85,6 @@ const notificationAlertTimesSecs = [
     30,           // 30 seconds
 ];
 
-// This function checks the configuration file of PAYG directly
-// from the expected locations on disk, on an attempt to figure
-// out whether the feature is enabled, so that we don't wake up
-// the D-Bus service and keep it running when it's disabled.
-function _isPaygEnabled() {
-    // See man page eos-payg.conf(5)
-    let searchDirs = [
-        '/etc/eos-payg',
-        '/usr/local/share/eos-payg',
-        '/usr/share/eos-payg',
-    ];
-
-    let configFileName = 'eos-payg.conf'
-    let keyfile = new GLib.KeyFile();
-    try {
-        keyfile.load_from_dirs(configFileName,
-                               searchDirs,
-                               GLib.KeyFileFlags.NONE);
-        return keyfile.get_boolean('PAYG', 'Enabled');
-    } catch (e) {
-        // A non-existent file is a perfectly normal use case.
-        if (!e.matches(GLib.KeyFileError, GLib.KeyFileError.NOT_FOUND))
-            logError(e, "Error reading PAYG configuration file from " + configFileName);
-    }
-
-    return false;
-}
-
 // Takes an UNIX timestamp (in seconds) and returns a string
 // with a precision level appropriate to show to the user.
 //
@@ -175,13 +147,6 @@ var PaygManager = new Lang.Class({
         this._expiryTime = 0;
         this._rateLimitEndTime = 0;
         this._notification = null;
-
-        if (!_isPaygEnabled()) {
-            // Consider this manager initialized if PAYG is not
-            // enabled, and skip all the D-Bus related bits.
-            this._initialized = true;
-            return;
-        }
 
         // Keep track of clock changes to update notifications.
 

--- a/js/misc/paygManager.js
+++ b/js/misc/paygManager.js
@@ -45,6 +45,7 @@ const EOS_PAYG_IFACE = '<node> \
 <property name="ExpiryTime" type="t" access="read"/> \
 <property name="Enabled" type="b" access="read"/> \
 <property name="RateLimitEndTime" type="t" access="read"/> \
+<property name="CodeFormat" type="s" access="read"/> \
 </interface> \
 </node>';
 
@@ -146,6 +147,8 @@ var PaygManager = new Lang.Class({
         this._enabled = false;
         this._expiryTime = 0;
         this._rateLimitEndTime = 0;
+        this._codeFormat = '';
+        this._codeFormatRegex = null;
         this._notification = null;
 
         // Keep track of clock changes to update notifications.
@@ -189,6 +192,7 @@ var PaygManager = new Lang.Class({
             this._enabled = this._proxy.Enabled;
             this._expiryTime = this._proxy.ExpiryTime;
             this._rateLimitEndTime = this._proxy.RateLimitEndTime;
+            this._setCodeFormat(this._proxy.CodeFormat || "^[0-9]{8}$");
 
             this._propertiesChangedId = this._proxy.connect('g-properties-changed', this._onPropertiesChanged.bind(this));
             this._codeExpiredId = this._proxy.connectSignal('Expired', this._onCodeExpired.bind(this));
@@ -211,6 +215,9 @@ var PaygManager = new Lang.Class({
 
         if (propsDict.hasOwnProperty('RateLimitEndTime'))
             this._setRateLimitEndTime(this._proxy.RateLimitEndTime);
+
+        if (propsDict.hasOwnProperty('CodeFormat'))
+            this._setCodeFormat(this._proxy.CodeFormat, true);
     },
 
     _setEnabled: function(value) {
@@ -237,6 +244,24 @@ var PaygManager = new Lang.Class({
 
         this._rateLimitEndTime = value;
         this.emit('rate-limit-end-time-changed', this._rateLimitEndTime);
+    },
+
+    _setCodeFormat(value, notify=false) {
+        if (this._codeFormat === value)
+            return;
+
+        this._codeFormat = value;
+        try {
+            this._codeFormatRegex = new GLib.Regex(this._codeFormat,
+                                                   GLib.RegexCompileFlags.DOLLAR_ENDONLY,
+                                                   GLib.RegexMatchFlags.PARTIAL);
+        } catch (e) {
+            logError(e, `Error compiling CodeFormat regex "${this._codeFormat}"`);
+            this._codeFormatRegex = null;
+        }
+
+        if (notify)
+            this.emit('code-format-changed');
     },
 
     _onCodeExpired: function(proxy) {
@@ -348,6 +373,16 @@ var PaygManager = new Lang.Class({
         }
 
         this._proxy.ClearCodeRemote();
+    },
+
+    validateCode(code, partial=false) {
+        if (!this._codeFormatRegex) {
+            log("Unable to validate PAYG code: no regex")
+            return false;
+        }
+
+        let [is_match, match_info] = this._codeFormatRegex.match(code, 0);
+        return is_match || (partial && match_info.is_partial_match());
     },
 
     get initialized() {

--- a/js/ui/paygUnlockDialog.js
+++ b/js/ui/paygUnlockDialog.js
@@ -128,18 +128,12 @@ var PaygUnlockCodeEntry = new Lang.Class({
         if (isExitKey || isEnterKey || isDeleteKey || isMovementKey)
             return Clutter.EVENT_PROPAGATE
 
-        // Do nothing if the entry is disabled.
-        if (!this._enabled)
-            return Clutter.EVENT_STOP;
-
         // Don't allow inserting more digits than required.
         if (this._code.length >= CODE_REQUIRED_LENGTH_CHARS)
             return Clutter.EVENT_STOP;
 
-        // Allow digits only
         let character = event.get_key_unicode();
-        if (GLib.unichar_isdigit(character))
-            this.clutter_text.insert_unichar(character);
+        this.addCharacter(character);
 
         return Clutter.EVENT_STOP;
     },

--- a/js/ui/paygUnlockDialog.js
+++ b/js/ui/paygUnlockDialog.js
@@ -45,8 +45,6 @@ const MSEC_PER_SEC = 1000
 // The timeout before going back automatically to the lock screen
 const IDLE_TIMEOUT_SECS = 2 * 60;
 
-const CODE_REQUIRED_LENGTH_CHARS = 8;
-
 const SPINNER_ICON_SIZE_PIXELS = 16;
 const SPINNER_ANIMATION_DELAY_SECS = 1.0;
 const SPINNER_ANIMATION_TIME_SECS = 0.3;
@@ -128,10 +126,6 @@ var PaygUnlockCodeEntry = new Lang.Class({
         if (isExitKey || isEnterKey || isDeleteKey || isMovementKey)
             return Clutter.EVENT_PROPAGATE
 
-        // Don't allow inserting more digits than required.
-        if (this._code.length >= CODE_REQUIRED_LENGTH_CHARS)
-            return Clutter.EVENT_STOP;
-
         let character = event.get_key_unicode();
         this.addCharacter(character);
 
@@ -152,7 +146,15 @@ var PaygUnlockCodeEntry = new Lang.Class({
     },
 
     addCharacter: function(character) {
-        if (!this._enabled || !GLib.unichar_isdigit(character))
+        if (!this._enabled || !GLib.unichar_isprint(character))
+            return;
+
+        let pos = this.clutter_text.get_cursor_position();
+        let before = pos === -1 ? this._code : this._code.slice(0, pos);
+        let after = pos === -1 ? "" : this._code.slice(pos);
+        let newCode = before + character + after;
+
+        if (!Main.paygManager.validateCode(newCode, true))
             return;
 
         this.clutter_text.insert_unichar(character);
@@ -379,9 +381,7 @@ var PaygUnlockDialog = new Lang.Class({
     },
 
     _validateCurrentCode: function() {
-        // The PaygUnlockCodeEntry widget will only accept valid
-        // characters, so we only need to check the length here.
-        return this._entry.length == CODE_REQUIRED_LENGTH_CHARS;
+        return Main.paygManager.validateCode(this._entry.code);
     },
 
     _updateNextButtonSensitivity: function() {


### PR DESCRIPTION
There are four parts to this:

* Always ask the daemon if it's enabled, rather than reading its config file (https://github.com/endlessm/eos-payg/pull/24 teaches the daemon to time out after 30 seconds if PAYG is disabled, and in any case its resource usage is minimal)
* Pick up the CodeFormat property introduced in https://github.com/endlessm/eos-payg/pull/24
* Rework code validation to use that property, rather than assuming all codes must be 8 digits
* Adjust the CSS a bit so that the longer codes used by the provider plugin at https://github.com/endlessm/eos-payg-nonfree/pull/1 fit in the available space

https://phabricator.endlessm.com/T23965