### PR TITLE
power: Label the PENDING_CHARGING state as Fully Charged

### DIFF
--- a/js/ui/status/power.js
+++ b/js/ui/status/power.js
@@ -73,13 +73,14 @@ var Indicator = new Lang.Class({
     _getStatus: function() {
         let seconds = 0;
 
-        if (this._proxy.State == UPower.DeviceState.FULLY_CHARGED)
+        if (this._proxy.State == UPower.DeviceState.FULLY_CHARGED ||
+            this._proxy.State == UPower.DeviceState.PENDING_CHARGE)
             return _("Fully Charged");
         else if (this._proxy.State == UPower.DeviceState.CHARGING)
             seconds = this._proxy.TimeToFull;
         else if (this._proxy.State == UPower.DeviceState.DISCHARGING)
             seconds = this._proxy.TimeToEmpty;
-        // state is one of PENDING_CHARGING, PENDING_DISCHARGING
+        // state is PENDING_DISCHARGE
         else
             return _("Estimating…");
 


### PR DESCRIPTION
The pending-charge state means AC power is on but the battery is not
being charged because its charge is above a certain threshold, to avoid
short charing cycles and prolong the battery's life. From the user's
perspective this is equivalent to the situation where the battery is
fully charged.

This commit sets the power indicator label for the pending-charge state
to "Fully Charged".

https://phabricator.endlessm.com/T24044