### PR TITLE
shellDBus: Fix showing the app grid

### DIFF
--- a/js/ui/shellDBus.js
+++ b/js/ui/shellDBus.js
@@ -171,7 +171,7 @@ var GnomeShell = new Lang.Class({
     },
 
     ShowApplications: function() {
-        Main.overview.viewSelector.showApps();
+        Main.overview.showApps();
     },
 
     GrabAcceleratorAsync: function(params, invocation) {


### PR DESCRIPTION
Calling the ShowApplications() method was displaying the app windows
view instead of the app grid.

https://phabricator.endlessm.com/T24218