### PR TITLE
clubhouse: Don't allow the notification source to be fully destroyed

### DIFF
--- a/js/ui/components/clubhouse.js
+++ b/js/ui/components/clubhouse.js
@@ -110,6 +110,17 @@ var ClubhouseNotificationSource = new Lang.Class({
     _createNotification: function(params) {
         return new ClubhouseNotification(this, params);
     },
+
+    // Override the method so we don't emit the 'destroy' signal, which would end up
+    // actually destroying the source and removing it from the GtkNotificationDaemon,
+    // meaning we could only use the source (and thus the Shell Quest View) once.
+    destroy: function(reason) {
+        let notifications = this.notifications;
+        this.notifications = [];
+
+        for (let i = 0; i < notifications.length; i++)
+            notifications[i].destroy(reason);
+    },
 });
 
 var ClubhouseButtonManager = new Lang.Class({


### PR DESCRIPTION
Turns our that the Shell Quest View could only be used once because the
notification source we create for it gets destroyed and removed from
the GtkNotificationDaemon's list. Since have to keep the source assigned
to the Clubhouse's app ID in the GtkNotificationDaemon, we should
prevent the source from being fully destroyed.

Thus, these changes implement the "destroy" vfunc for the
ClubhouseNotificationSource, doing everything its parent does except for
emitting the "destroy" signal.

https://phabricator.endlessm.com/T24222