### PR TITLE
notificationDaemon: create the clubhouse notification source earlier

### DIFF
--- a/js/ui/components/clubhouse.js
+++ b/js/ui/components/clubhouse.js
@@ -36,7 +36,7 @@ const MessageTray = imports.ui.messageTray;
 const NotificationDaemon = imports.ui.notificationDaemon;
 const SideComponent = imports.ui.sideComponent;
 
-const CLUBHOUSE_ID = 'com.endlessm.Clubhouse';
+var CLUBHOUSE_ID = 'com.endlessm.Clubhouse';
 const CLUBHOUSE_DBUS_OBJ_PATH = '/com/endlessm/Clubhouse';
 
 const ClubhouseIface =
@@ -273,12 +273,10 @@ var ClubhouseComponent = new Lang.Class({
             this.hide(global.get_current_time());
         });
 
-        this._clubhouseSource = new ClubhouseNotificationSource(CLUBHOUSE_ID);
+        // Trigger creation of our source, and connect to it
+        this._clubhouseSource =
+            Main.notificationDaemon._gtkNotificationDaemon._ensureAppSource(CLUBHOUSE_ID);
         this._clubhouseSource.connect('notify', Lang.bind(this, this._onNotify));
-
-        // Inject this source in GtkNotificationDaemon's lookup table
-        Main.notificationDaemon._gtkNotificationDaemon._sources[CLUBHOUSE_ID] =
-            this._clubhouseSource;
     },
 
     disable: function() {

--- a/js/ui/notificationDaemon.js
+++ b/js/ui/notificationDaemon.js
@@ -817,12 +817,12 @@ var GtkNotificationDaemon = new Lang.Class({
         if (this._sources[appId])
             return this._sources[appId];
 
-        if (appId == Clubhouse.CLUBHOUSE_ID) {
-            this._sources[appId] = new Clubhouse.ClubhouseNotificationSource(appId);
-            return this._sources[appId];
-        }
+        let source;
 
-        let source = new GtkNotificationDaemonAppSource(appId);
+        if (appId == Clubhouse.CLUBHOUSE_ID)
+            source = new Clubhouse.ClubhouseNotificationSource(appId);
+        else
+            source = new GtkNotificationDaemonAppSource(appId);
 
         source.connect('destroy', Lang.bind(this, function() {
             delete this._sources[appId];

--- a/js/ui/notificationDaemon.js
+++ b/js/ui/notificationDaemon.js
@@ -794,6 +794,11 @@ const GtkNotificationsIface = '<node> \
 </interface> \
 </node>';
 
+// It's important that this is only imported after GtkNotificationDaemonNotification
+// and GtkNotificationDaemonAppSource have been defined, since clubhouse.js will
+// extend them.
+const Clubhouse = imports.ui.components.clubhouse;
+
 var GtkNotificationDaemon = new Lang.Class({
     Name: 'GtkNotificationDaemon',
 
@@ -811,6 +816,11 @@ var GtkNotificationDaemon = new Lang.Class({
     _ensureAppSource: function(appId) {
         if (this._sources[appId])
             return this._sources[appId];
+
+        if (appId == Clubhouse.CLUBHOUSE_ID) {
+            this._sources[appId] = new Clubhouse.ClubhouseNotificationSource(appId);
+            return this._sources[appId];
+        }
 
         let source = new GtkNotificationDaemonAppSource(appId);
 


### PR DESCRIPTION
Instead of injecting it into the sources table when the component
starts up, change _ensureAppSource() to create it when required.

Note that it's important that clubhouse.js is imported after the
GtkNotification classes are defined in notificationDaemon.js,
otherwise subclassing will fail.

https://phabricator.endlessm.com/T24222