### PR TITLE
clubhouse: Pulse the "open" button to indicate the user to click it

### DIFF
--- a/data/theme/gnome-shell-sass/_endless.scss
+++ b/data/theme/gnome-shell-sass/_endless.scss
@@ -972,6 +972,11 @@ popup-separator-menu-item {
   width: 80px;
   height: 80px;
   background-image: url('resource:///org/gnome/shell/theme/clubhouse-icon-normal.png');
+  border: none;
+  &:highlighted {
+    border: 5px solid rgba(150, 220, 255, 0.7);
+    border-radius: 40px;
+  }
 }
 
 .clubhouse-close-button-icon {


### PR DESCRIPTION
Add a new signal PulsingIcon in the D-Bus interface. When triggered,
the icon of the Open button is styled with a "highlighted" class.

When the Open button is clicked, the "highlighted" class is removed.

The pulsing animation is done in the CSS by transforming two images in
loop.

The clubhouse-icon-highlighted.png image is a placeholder made by
coloring the icon for the normal state.

https://phabricator.endlessm.com/T24164