### PR TITLE
 power: Label the PENDING_CHARGE state as "Not Charging"

### DIFF
--- a/js/ui/status/power.js
+++ b/js/ui/status/power.js
@@ -73,14 +73,13 @@ var Indicator = new Lang.Class({
     _getStatus: function() {
         let seconds = 0;
 
-        if (this._proxy.State == UPower.DeviceState.FULLY_CHARGED ||
-            this._proxy.State == UPower.DeviceState.PENDING_CHARGE)
+        if (this._proxy.State == UPower.DeviceState.FULLY_CHARGED)
             return _("Fully Charged");
         else if (this._proxy.State == UPower.DeviceState.CHARGING)
             seconds = this._proxy.TimeToFull;
         else if (this._proxy.State == UPower.DeviceState.DISCHARGING)
             seconds = this._proxy.TimeToEmpty;
-        // state is PENDING_DISCHARGE
+        // state is one of PENDING_CHARGING, PENDING_DISCHARGING
         else
             return _("Estimating…");
 

--- a/js/ui/status/power.js
+++ b/js/ui/status/power.js
@@ -79,7 +79,9 @@ var Indicator = new Lang.Class({
             seconds = this._proxy.TimeToFull;
         else if (this._proxy.State == UPower.DeviceState.DISCHARGING)
             seconds = this._proxy.TimeToEmpty;
-        // state is one of PENDING_CHARGING, PENDING_DISCHARGING
+        else if (this._proxy.State == UPower.DeviceState.PENDING_CHARGE)
+            return _("Not Charging");
+        // state is PENDING_DISCHARGE
         else
             return _("Estimating…");
 


### PR DESCRIPTION
The pending-charge state means AC power is on but the battery is not
being charged. This can happen because its charge is above a certain
threshold, to avoid short charging cycles and prolong the battery's
life, or because the PSU is not powerful enough to charge the batteries.

Instead of lying to the user about something being estimated, we should
simply tell the truth and set the label to "Not Charging".

https://phabricator.endlessm.com/T24044