### PR TITLE
clubhouse: hide button for sessions that do not have an overview

### DIFF
--- a/js/ui/components/clubhouse.js
+++ b/js/ui/components/clubhouse.js
@@ -152,6 +152,8 @@ var ClubhouseButtonManager = new Lang.Class({
                                                              this._updateVisibility.bind(this));
         this._overviewHiddenHandler = Main.overview.connect('hidden',
                                                             this._updateVisibility.bind(this));
+        this._sessionModeHandler = Main.sessionMode.connect('updated',
+                                                            this._updateVisibility.bind(this));
     },
 
     _updateCloseButtonPosition: function() {
@@ -172,7 +174,8 @@ var ClubhouseButtonManager = new Lang.Class({
     },
 
     _updateVisibility: function() {
-        this._closeButton.visible = this._visible && !Main.overview.visible && this._clubhouseWindowActor;
+        this._closeButton.visible = this._visible && Main.sessionMode.hasOverview &&
+                                    !Main.overview.visible && this._clubhouseWindowActor;
         this._openButton.visible = this._visible && !this._closeButton.visible;
         this._reposition();
     },
@@ -229,6 +232,9 @@ var ClubhouseButtonManager = new Lang.Class({
 
         Main.overview.disconnect(this._overviewHiddenHandler);
         this._overviewHiddenHandler = 0;
+
+        Main.sessionMode.disconnect(this._sessionModeHandler);
+        this._sessionModeHandler = 0;
 
         global.screen.disconnect(this._restackedHandler);
         this._restackedHandler = 0;


### PR DESCRIPTION
Which is every session but the user one.
In particular, this will hide the button on the initial-setup session.

https://phabricator.endlessm.com/T24404