### PR TITLE
StTextureCache: use right event to detect file changes

### DIFF
--- a/src/st/st-texture-cache.c
+++ b/src/st/st-texture-cache.c
@@ -983,7 +983,7 @@ file_changed_cb (GFileMonitor      *monitor,
   char *key;
   guint file_hash;
 
-  if (event_type != G_FILE_MONITOR_EVENT_CHANGED)
+  if (event_type != G_FILE_MONITOR_EVENT_CHANGES_DONE_HINT)
     return;
 
   file_hash = g_file_hash (file);


### PR DESCRIPTION
StTextureCache installs file monitors that invalidate caches when
contents of the underlying file change.
At the moment, the cache uses the Gio.FileMonitorEvent.CHANGED event
type to make that determination.

However, that is suboptimal for at least two reasons:
- while a file is being written to disk, many CHANGED events will be
  emitted in sequence. That will cause needless cache invalidations,
  and we will risk loading the file before it's fully loaded.
- if an existing file is replaced, e.g. with g_file_replace(), we may
  not get a CHANGED event but a CREATED one instead, so the cache ends
  up never getting invalidated.

The good news is that in both of those cases GFileMonitor will send a
CHANGES_DONE_HINT event after changes have settled, or after the file
is replaced.

This commit fixes both cases by switching from the CHANGED event to
CHANGES_DONE_HINT to determine that a file has in fact changed.

https://phabricator.endlessm.com/T24438