### PR TITLE
clubhouse: Ensure the Clubhouse window is focused when shown

### DIFF
--- a/js/ui/components/clubhouse.js
+++ b/js/ui/components/clubhouse.js
@@ -111,6 +111,10 @@ var ClubhouseWindowTracker = new Lang.Class({
 
         this._windowActor = actor;
 
+        // We need to activate the window directly as otherwise it won't be focused because
+        // of having a DOCK hint type
+        actor.meta_window.activate(global.get_current_time());
+
         this.emit('window-changed');
 
         // Track Clubhouse's window actor to make the closeButton always show on top of


### PR DESCRIPTION
The Clubhouse window has a DOCK hint type and that apparently prevents
it from geting focused most of the time due to how Mutter works [1].

To work around that, we directly activate the window from the Clubhouse
Shell component, hence making it focused.

This is not a great solution, because if the window gets unfocused, then
it won't be focused back until the window is hidden and shown again.
However, this is not a problem for now because the Clubhouse window is
supposed to hidden automatically when unfocused anyway.

An alternative solution from the Clubhouse's side, i.e. making it a
normal window and making it behave like a DOCK one (always on top, no
decoration, etc.) has its caveats because it's easy to still drag it
around (and apparently there's no way to avoid that from the application
side).

[1] https://github.com/endlessm/mutter/blob/master/src/core/window.c#L2232

https://phabricator.endlessm.com/T24075