### PR TITLE
codeView: improve placement of FlipToHack button

### DIFF
--- a/data/theme/gnome-shell-sass/_endless.scss
+++ b/data/theme/gnome-shell-sass/_endless.scss
@@ -782,9 +782,7 @@ popup-separator-menu-item {
         color: $insensitive-color;
     }
 
-    // FIXME this should animate. Leave it constant for now so that the whole
-    // icon is visible.
-    padding-left: 80px;
+    padding-left: 8px;
 }
 
 // Discovery Feed

--- a/js/ui/codeView.js
+++ b/js/ui/codeView.js
@@ -141,7 +141,7 @@ function _synchronizeMetaWindowActorGeometries(src, dst) {
 }
 
 function _synchronizeViewSourceButtonToRectCorner(button, rect) {
-    button.set_position(rect.x - button.width / 2,
+    button.set_position(rect.x,
                         rect.y + (rect.height - button.height) / 2);
 }
 


### PR DESCRIPTION
This does not actually change the position of the button, but at the
moment we set a large left padding, which makes it so  the button is
clickable for a large portion immediately left of the window.

Instead, position it flush on the window edge, and add a small left
padding.

https://phabricator.endlessm.com/T24407