### PR TITLE
clubhouse: Change the visibility of the close button in quest banners

### DIFF
--- a/js/ui/components/clubhouse.js
+++ b/js/ui/components/clubhouse.js
@@ -274,6 +274,18 @@ var ClubhouseNotificationBanner = new Lang.Class({
     },
 });
 
+
+var ClubhouseQuestBanner = new Lang.Class({
+    Name: 'ClubhouseQuestBanner',
+    Extends: ClubhouseNotificationBanner,
+
+    _init: function(notification) {
+        this.parent(notification);
+
+        this._closeButton.visible = Main.sessionMode.hasOverview;
+    },
+});
+
 var ClubhouseItemBanner = new Lang.Class({
     Name: 'ClubhouseItemBanner',
     Extends: ClubhouseNotificationBanner,
@@ -312,7 +324,7 @@ var ClubhouseNotification = new Lang.Class({
     },
 
     createBanner: function() {
-        return new ClubhouseNotificationBanner(this);
+        return new ClubhouseQuestBanner(this);
     },
 });
 


### PR DESCRIPTION
The first quest (HackUnlock) shouldn't have a close button (because the
Clubhouse is not supposed to be used while in that moment). Thus, this
patch only allows the close button in quest banners to be visible if the
session has an overview (i.e. if changing windows is a normal thing).

This is not a very flexible way of changing the close button's
visibility, but it is not clear ATM whether we will need something much
more clever to justify the extra time involved in that.

https://phabricator.endlessm.com/T24405