### PR TITLE
ibus: launch daemon via D-Bus service activation

### DIFF
--- a/js/misc/ibusManager.js
+++ b/js/misc/ibusManager.js
@@ -70,12 +70,23 @@ var IBusManager = new Lang.Class({
     },
 
     _spawn: function() {
-        try {
-            Gio.Subprocess.new(['ibus-daemon', '--xim', '--panel', 'disable'],
-                               Gio.SubprocessFlags.NONE);
-        } catch(e) {
-            log('Failed to launch ibus-daemon: ' + e.message);
-        }
+        // Create and initialize a proxy. Because we did not specify
+        // Gio.DBusProxyFlags.DO_NOT_AUTO_START, calling init_async() will
+        // cause StartServiceByName() to be called to launch it if it's not
+        // already running.
+        let proxy = new Gio.DBusProxy({ g_connection: Gio.DBus.session,
+                                        g_name: 'org.freedesktop.IBus',
+                                        g_object_path: '/',
+                                        g_interface_name: 'org.freedesktop.DBus.Peer',
+                                        g_flags: Gio.DBusProxyFlags.DO_NOT_LOAD_PROPERTIES |
+                                                 Gio.DBusProxyFlags.DO_NOT_CONNECT_SIGNALS });
+        proxy.init_async(GLib.PRIORITY_DEFAULT, null, (object, result) => {
+            try {
+                object.init_finish(result);
+            } catch(e) {
+                logError(e, 'Failed to launch ibus-daemon');
+            }
+        });
     },
 
     _clear: function() {


### PR DESCRIPTION
At the end of the first boot experience, the newly-created user is
signed in, and GDM tears down the gnome-initial-setup session by sending
SIGTERM to its gnome-session's process group. gnome-shell is a child of
gnome-session, and currently spawns ibus-daemon directly as a
subprocess.

However, one of the first actions ibus-daemon takes is to move itself to
a new process group, so it escapes the SIGTERM sent to gnome-session's
process group at the end of the session. Ordinarily, this wouldn't
matter, because the X11 session would soon also die, causing the
ibus-x11 process (spawned by ibus-daemon) to die; its last act is to
send a message to ibus-daemon, telling it to terminate. But in this case
we are reusing the X11 session for the new user, since on Endless GDM is
built with --disable-user-display-server, so ibus-x11 and ibus-daemon
are untouched.

A further knock-on problem is that logind waits for all processes in the
session (identified by unknown means) to exit before killing the systemd
--user session, the D-Bus session bus, and all services connected to it.

    systemd-logind[453]: Session c1 logged out. Waiting for processes to exit.

    $ loginctl  session-status c1
    c1 - gnome-initial-setup (110)
               Since: Mon 2018-11-19 15:17:36 GMT; 5min ago
              Leader: 735
                Seat: seat0; vc1
             Display: :0
             Service: gdm-launch-environment; type x11; class greeter
               State: closing
                Unit: session-c1.scope
                      ├─ 875 ibus-daemon --xim --panel disable
                      ├─1092 /usr/lib/ibus/ibus-dconf
                      ├─1094 /usr/lib/ibus/ibus-x11 --kill-daemon
                      └─1202 /usr/lib/ibus/ibus-engine-simple

Most of the other lingering applications have no GUI, but for Hack we
have a D-Bus-activated GUI, which is carried over from the
gnome-initial-setup session into the new user's session. Due to
downstream shell elements which are not locked down in the
gnome-initial-setup shell mode, it's possible to start the App Center
(and many other apps, by extension) from within the FBE session; these,
too, are carried over into the new user's session.

logind doesn't consider D-Bus-activated services to be part of the login
session, so launching ibus-daemon via D-Bus service activation means
that logind considers the gnome-initial-setup session to be closed and
tears down everything else.

One outstanding question here is that `/usr/share/dbus-1/services/org.freedesktop.IBus.service` specifies:

    Exec=/usr/bin/ibus-daemon --replace --xim --panel disable

But when testing, the running ibus-daemon has a different command line:

    /usr/bin/ibus-daemon --daemonize --xim

So *something else* is spawning IBus. It turns out to be `im-config`, inherited from Debian. The net result is the same, though: the `ibus-daemon` process gets reparented out of the `gnome-session` process tree, so logind doesn't wait for it before declaring the session dead.

https://phabricator.endlessm.com/T24418