### PR TITLE
paygManager: Understand ExpiryTime in terms of CLOCK_BOOTTIME

### DIFF
--- a/js/misc/paygManager.js
+++ b/js/misc/paygManager.js
@@ -271,7 +271,7 @@ var PaygManager = new Lang.Class({
         if (!this._enabled)
             return Number.MAX_SAFE_INTEGER;
 
-        return Math.max(0, this._expiryTime - (GLib.get_real_time() / GLib.USEC_PER_SEC));
+        return Math.max(0, this._expiryTime - (Shell.util_get_boottime() / GLib.USEC_PER_SEC));
     },
 
     addCode: function(code, callback) {

--- a/js/ui/payg.js
+++ b/js/ui/payg.js
@@ -104,7 +104,7 @@ var UnlockUi = new Lang.Class({
 
         // The 'too many errors' case is a bit special, and sets a different state.
         if (error.matches(PaygManager.PaygErrorDomain, PaygManager.PaygError.TOO_MANY_ATTEMPTS)) {
-            let currentTime = GLib.get_real_time() / GLib.USEC_PER_SEC;
+            let currentTime = Shell.util_get_boottime() / GLib.USEC_PER_SEC;
             let secondsLeft = Main.paygManager.rateLimitEndTime - currentTime;
             if (secondsLeft > 30) {
                 let minutesLeft = Math.max(0, Math.ceil(secondsLeft / 60));

--- a/src/shell-util.c
+++ b/src/shell-util.c
@@ -814,4 +814,3 @@ shell_util_get_boottime (void)
 
   return (((gint64) ts.tv_sec) * 1000000) + (ts.tv_nsec / 1000);
 }
-

--- a/src/shell-util.c
+++ b/src/shell-util.c
@@ -790,3 +790,28 @@ shell_util_get_eos_image_version (void)
 
   return image_version;
 }
+
+/**
+ * shell_util_get_boottime:
+ *
+ * Like g_get_monotonic_time(), but also includes any time the system is
+ * suspended. Uses `CLOCK_BOOTTIME`, hence the name, but is not guaranteed to be
+ * the time since boot.
+ *
+ * Returns: the time since some unspecified starting point, in microseconds
+ */
+gint64
+shell_util_get_boottime (void)
+{
+  struct timespec ts;
+  gint result;
+
+  result = clock_gettime (CLOCK_BOOTTIME, &ts);
+
+  if (G_UNLIKELY (result != 0))
+    g_error ("clock_gettime (CLOCK_BOOTTIME) failed: %s",
+             g_strerror (errno));
+
+  return (((gint64) ts.tv_sec) * 1000000) + (ts.tv_nsec / 1000);
+}
+

--- a/src/shell-util.h
+++ b/src/shell-util.h
@@ -70,6 +70,8 @@ gint shell_util_get_uid (void);
 
 gchar * shell_util_get_eos_image_version (void);
 
+gint64 shell_util_get_boottime (void);
+
 G_END_DECLS
 
 #endif /* __SHELL_UTIL_H__ */


### PR DESCRIPTION
The "ExpiryTime" property of the EpgProvider interface is changing to be
in terms of CLOCK_BOOTTIME rather than wall clock time, this commit
changes the paygManager class to account for this.

https://phabricator.endlessm.com/T24300