### PR TITLE
clubhouse: Only slide notification banners in once

### DIFF
--- a/js/ui/components/clubhouse.js
+++ b/js/ui/components/clubhouse.js
@@ -223,6 +223,9 @@ var ClubhouseNotificationBanner = new Lang.Class({
         let endX = this.actor.x - this.actor.width - margin;
 
         if (this._shouldSlideIn) {
+            // Ensure it only slides in the first time
+            this._shouldSlideIn = false;
+
             Tweener.addTween(this.actor,
                              { x: endX,
                                time: CLUBHOUSE_BANNER_ANIMATION_TIME,


### PR DESCRIPTION
When the Clubhouse window is opened, any banner who's been created with
the "shouldSlideIn" variable will also be slid in from the right again.
The reason is that we track the Clubhouse window and call for the
banners to be repositioned when the window appears (so they're
positioned to the left of it), which will use the slide in effect again.

To avoid this, this patch sets the mentioned variable to false after the
first time the banner is slid in. This is the desired behavior for all
banners in any case, fixes the mentioned issue.

https://phabricator.endlessm.com/T24599