### PR TITLE
codeView: indicate user move/resize when synchronizing windows

### DIFF
--- a/js/ui/codeView.js
+++ b/js/ui/codeView.js
@@ -137,9 +137,8 @@ function _synchronizeMetaWindowActorGeometries(src, dst) {
     if (srcIsMaximized && !dstIsMaximized)
         dst.meta_window.maximize(Meta.MaximizeFlags.BOTH);
 
-
     if (!srcGeometry.equal(dstGeometry))
-        dst.meta_window.move_resize_frame(false,
+        dst.meta_window.move_resize_frame(true,
                                           srcGeometry.x,
                                           srcGeometry.y,
                                           srcGeometry.width,


### PR DESCRIPTION
User movements make it so the window we're synchronizing follows the
same constraints as the window being dragged by the user.
In particular, it will make it so that the underlying window is not
confined to be fully contained in the workarea, which is the bug we're
interested in fixing.

https://phabricator.endlessm.com/T24547