### PR TITLE
clubhouse: Don't add actions directly in the item banner

### DIFF
--- a/js/ui/components/clubhouse.js
+++ b/js/ui/components/clubhouse.js
@@ -406,8 +406,6 @@ var ClubhouseItemBanner = new Lang.Class({
     _init: function(notification) {
         this.parent(notification);
         this._topBanner = null;
-
-        this._addActions();
     },
 
     setTopBanner: function(topBanner) {


### PR DESCRIPTION
The item banner was calling the _addActions method directly in its
constructor, but due to some changes in the base class, this is no
longer needed and as a result, it'll end up adding the double of
actions/buttons to the banner.

https://phabricator.endlessm.com/T24625