### PR TITLE
clubhouse: Don't stop the quest if the notification source is destroyed

### DIFF
--- a/js/ui/components/clubhouse.js
+++ b/js/ui/components/clubhouse.js
@@ -800,7 +800,6 @@ var ClubhouseComponent = new Lang.Class({
         this._clubhouseSource = new ClubhouseNotificationSource(CLUBHOUSE_ID);
         this._clubhouseSource.connect('notify', Lang.bind(this, this._onNotify));
         this._clubhouseSource.connect('destroy', () => {
-            this._clubhouseSource.activateAction('stop-quest', null);
             this._clubhouseSource = null;
         })
 


### PR DESCRIPTION
The Clubhouse notification source is getting destroyed when it runs out
of notifications, and it was calling the action to stop the ongoing
quest in the Clubhouse. This was a problem when stopping a quest from
the Clubhouse and immediately start another, because the Clubhouse
itself stops the ongoing quest (and removes the notification) which
would end up destroying the notification source and thus getting the
"stop quest" action called again, while at this point the new quest may
be running already.
i.e. the new quest would be quickly stopped because of the "stop quest"
action called by the Clubhouse notification source destruction.

This patch stops this behavior by not calling the mentioned action when
the Clubhouse notification source is destroyed. This was unnecessary
in any case, because the notifications are the ones that should
eventually dismiss the quest, and not the notification source itself.

https://phabricator.endlessm.com/T24658