### PR TITLE
clubhouse: use source from notification to activate action

### DIFF
--- a/js/ui/components/clubhouse.js
+++ b/js/ui/components/clubhouse.js
@@ -885,7 +885,7 @@ var ClubhouseComponent = new Lang.Class({
             notification.connect('destroy', (notification, reason) => {
                 if (reason != MessageTray.NotificationDestroyedReason.REPLACED &&
                     reason != MessageTray.NotificationDestroyedReason.SOURCE_CLOSED)
-                    this._dismissQuest();
+                    this._dismissQuest(notification.source);
 
                 this._clearQuestBanner();
             });
@@ -917,10 +917,10 @@ var ClubhouseComponent = new Lang.Class({
         this._syncVisibility();
     },
 
-    _dismissQuest: function() {
+    _dismissQuest: function(source) {
         // Stop the quest since the banner has been dismissed
-        if (this.proxy.g_name_owner && this._clubhouseSource)
-            this._clubhouseSource.activateAction('stop-quest', null);
+        if (this.proxy.g_name_owner)
+            source.activateAction('stop-quest', null);
 
         this._isRunningQuest = false;
     },


### PR DESCRIPTION
Instead of relying on this._clubhouseSource.

Both the clubhouse source and the clubhouse component connect to the
destroy signal of the notification; the clubhouse source callback will
destroy the source when there are no notifications, while the
clubhouse component will possibly activate the stop-quest action.

We set the source to NULL in the clubhouse component when it's
destroyed, but that happens before the other callback for the
stop-quest action to be activated is reached. Since the stop-quest
action is currently activated on the clubhouse source reference owned
by the clubhouse component, the result is that we never manage to
activate the action when the notification banner is destroyed.

This commit fixes the issue by using the source reference owned by the
notification in order to activate stop-quest, which will still be
alive during the callback.

This is a regression from commit
b31067f480e946d80f16c3f5536503f6d324c753.

https://phabricator.endlessm.com/T24698