### PR TITLE
js: Don't show unlock-dialog during initial-setup

### DIFF
--- a/js/ui/screenShield.js
+++ b/js/ui/screenShield.js
@@ -1363,7 +1363,8 @@ var ScreenShield = new Lang.Class({
                 let userManager = AccountsService.UserManager.get_default();
                 let user = userManager.get_user(GLib.get_user_name());
 
-                if (user.password_mode != AccountsService.UserPasswordMode.NONE)
+                if (user.password_mode != AccountsService.UserPasswordMode.NONE &&
+                    Main.sessionMode.currentMode != 'initial-setup')
                     Main.sessionMode.pushMode('unlock-dialog');
 
                 if (Main.paygManager.isLocked)


### PR DESCRIPTION
Even when the gnome-initial-setup has technically credentials, it's not
correct to show the "unlock-dialog" screen under any circumnstances.

https://phabricator.endlessm.com/T24114