### PR TITLE
clubhouse: Remove CSS rule for notification image

### DIFF
--- a/data/theme/gnome-shell-sass/_endless.scss
+++ b/data/theme/gnome-shell-sass/_endless.scss
@@ -995,8 +995,8 @@ $clubhouse-image-height: 187px;
   }
   .clubhouse-notification-image {
     icon-size: $clubhouse-image-width;
-    width: $clubhouse-image-width;
-    height: $clubhouse-image-height;
+    min-width: $clubhouse-image-width;
+    min-height: $clubhouse-image-height;
   }
 }
 


### PR DESCRIPTION
The image size in the CSS was hardcoded and can be removed. This
change has no effect for images coming from the clubhouse with a size
equal or less of the hardcoded size. But for larger images, this
change will allow them to expand to the right.

https://phabricator.endlessm.com/T24917