### PR TITLE
clubhouse: Fix banners' position when initially showing them

### DIFF
--- a/js/ui/components/clubhouse.js
+++ b/js/ui/components/clubhouse.js
@@ -492,13 +492,19 @@ var ClubhouseNotificationBanner = new Lang.Class({
         let endX = this.actor.x - this.actor.width - margin;
 
         if (this._shouldSlideIn) {
-            // Ensure it only slides in the first time
-            this._shouldSlideIn = false;
+            // If the banner is still sliding in, stop it (because we have a new position for it).
+            // This should prevent the banner from not being set in the right position when the
+            // Clubhouse is hidden while the banner is still sliding in.
+            Tweener.removeTweens(this.actor);
 
             Tweener.addTween(this.actor,
                              { x: endX,
                                time: CLUBHOUSE_BANNER_ANIMATION_TIME,
-                               transition: 'easeOutQuad'
+                               transition: 'easeOutQuad',
+                               onComplete: () => {
+                                   // Ensure it only slides in once
+                                   this._shouldSlideIn = false;
+                               }
                              });
         } else {
             this.actor.x = endX;


### PR DESCRIPTION
When a banner is sliding in and the Clubhouse is hidden, the banner may
end up in the wrong position in the screen. This happens because, even
though we reassign the banner's X coordinate, the tweener may still be
actively changing it too.

To avoid that, this patch removes any tweens in the banner's actor if a
new position is to be assigned to it, and only changes the
"shouldSlideIn" variable at the end of the tween. This means that until
a first slide in is achieved, the banner cancels and starts a new slide
in animation if its target X coordinate changes.
This gets us the right effect of having the banner sliding in, even when
a new X coordinate is set in the middle of a slide.

https://phabricator.endlessm.com/T24691