### PR TITLE
clubhouse: Don't stop quests when closing their banner

### DIFF
--- a/js/ui/components/clubhouse.js
+++ b/js/ui/components/clubhouse.js
@@ -797,7 +797,7 @@ var ClubhouseComponent = new Lang.Class({
         this.parent(ClubhouseIface, CLUBHOUSE_ID, CLUBHOUSE_DBUS_OBJ_PATH);
 
         this._enabled = false;
-        this._isRunningQuest = false;
+        this._hasForegroundQuest = false;
 
         this._questBanner = null;
         this._itemBanner = null;
@@ -897,7 +897,7 @@ var ClubhouseComponent = new Lang.Class({
         if (!this._questBanner)
             return;
 
-        this._questBanner.dismiss(!this._isRunningQuest);
+        this._questBanner.dismiss(!this._hasForegroundQuest);
 
         this._questBanner = null;
 
@@ -967,15 +967,15 @@ var ClubhouseComponent = new Lang.Class({
             notification.connect('destroy', (notification, reason) => {
                 if (reason != MessageTray.NotificationDestroyedReason.REPLACED &&
                     reason != MessageTray.NotificationDestroyedReason.SOURCE_CLOSED)
-                    this._dismissQuest(notification.source);
+                    this._dismissQuestBanner(notification.source);
 
                 this._clearQuestBanner();
             });
 
             if (!this._questBanner) {
-                this._questBanner = notification.createBanner(!this._isRunningQuest,
+                this._questBanner = notification.createBanner(!this._hasForegroundQuest,
                                                               this._clubhouseAnimator);
-                this._isRunningQuest = true;
+                this._hasForegroundQuest = true;
 
                 Main.layoutManager.addChrome(this._questBanner.actor);
                 this._questBanner.reposition();
@@ -999,12 +999,12 @@ var ClubhouseComponent = new Lang.Class({
         this._syncVisibility();
     },
 
-    _dismissQuest: function(source) {
-        // Stop the quest since the banner has been dismissed
+    _dismissQuestBanner: function(source) {
+        // Inform the Clubhouse that the quest banner has been dismissed
         if (this.proxy.g_name_owner)
-            source.activateAction('stop-quest', null);
+            source.activateAction('quest-view-close', null);
 
-        this._isRunningQuest = false;
+        this._hasForegroundQuest = false;
     },
 
     _syncVisibility: function() {


### PR DESCRIPTION
The new approach for closing the quest banner is that we don't stop the
quest, instead we simply inform the Clubhouse that the banner has been
closed.

https://phabricator.endlessm.com/T24641