### PR TITLE
T24016

### DIFF
--- a/js/ui/layout.js
+++ b/js/ui/layout.js
@@ -14,6 +14,7 @@ const AppDisplay = imports.ui.appDisplay;
 const Background = imports.ui.background;
 const BackgroundMenu = imports.ui.backgroundMenu;
 const LoginManager = imports.misc.loginManager;
+const ParentalControlsManager = imports.misc.parentalControlsManager;
 
 const DND = imports.ui.dnd;
 const Main = imports.ui.main;
@@ -87,6 +88,7 @@ var LayoutManager = new Lang.Class({
         this._isPopupWindowVisible = false;
         this._startingUp = true;
         this._pendingLoadBackground = false;
+        this._backgroundLoaded = false;
 
         // We don't want to paint the stage background color because either
         // the SystemBackground we create or the MetaBackgroundActor inside
@@ -189,6 +191,7 @@ var LayoutManager = new Lang.Class({
         Main.sessionMode.connect('updated', Lang.bind(this, this._sessionUpdated));
 
         this._loadBackground();
+        this._loadParentalControls();
     },
 
     showOverview: function() {
@@ -537,8 +540,28 @@ var LayoutManager = new Lang.Class({
             this._systemBackground.actor.show();
             global.stage.show();
 
-            this._prepareStartupAnimation();
+            this._backgroundLoaded = true;
+
+            this._maybePrepareStartupAnimation();
         }));
+    },
+
+    _loadParentalControls: function() {
+        let parentalControlsManager = ParentalControlsManager.getDefault();
+
+        if (!parentalControlsManager.initialized)
+            parentalControlsManager.connect('initialized', this._maybePrepareStartupAnimation.bind(this));
+        else
+            this._maybePrepareStartupAnimation();
+    },
+
+    _maybePrepareStartupAnimation: function() {
+        let parentalControlsManager = ParentalControlsManager.getDefault();
+
+        if (!this._backgroundLoaded || !parentalControlsManager.initialized)
+            return;
+
+        this._prepareStartupAnimation();
     },
 
     // Startup Animations

--- a/js/ui/overview.js
+++ b/js/ui/overview.js
@@ -24,6 +24,7 @@ const Monitor = imports.ui.monitor;
 const OverviewControls = imports.ui.overviewControls;
 const Panel = imports.ui.panel;
 const Params = imports.misc.params;
+const ParentalControlsManager = imports.misc.parentalControlsManager;
 const Tweener = imports.ui.tweener;
 const ViewSelector = imports.ui.viewSelector;
 const WorkspaceThumbnail = imports.ui.workspaceThumbnail;
@@ -295,6 +296,18 @@ var Overview = new Lang.Class({
 
         if (this.isDummy)
             return;
+
+        // To avoid creating the IconGrid (through OverviewControls),
+        // delay until ParentalControlsManager is initialized
+        let parentalControlsManager = ParentalControlsManager.getDefault();
+
+        if (!parentalControlsManager.initialized) {
+            let id = parentalControlsManager.connect('initialized', () => {
+                parentalControlsManager.disconnect(id);
+                this.init();
+            });
+            return;
+        }
 
         this._shellInfo = new ShellInfo();
 


### PR DESCRIPTION
Hiding the applications while  ParentalControlsManager is not
initialized may lead to losing all icons. Since the icon grid
is updated after ParentalControlsManager is initialized anyway,
and initialization shouldn't take more than a split second,
showing the icons by default is reasonable to prevent data loss.

https://phabricator.endlessm.com/T24016