### PR TITLE
windowManager: always pass window destroy event to CodeViewManager

### DIFF
--- a/js/ui/windowManager.js
+++ b/js/ui/windowManager.js
@@ -2401,6 +2401,9 @@ var WindowManager = new Lang.Class({
         if (window.is_attached_dialog())
             this._checkDimming(window.get_transient_for(), window);
 
+        if (this._codeViewManager.handleDestroyWindow(actor))
+            return;
+
         let types = [Meta.WindowType.NORMAL,
                      Meta.WindowType.DIALOG,
                      Meta.WindowType.MODAL_DIALOG];
@@ -2433,9 +2436,6 @@ var WindowManager = new Lang.Class({
 
         switch (actor.meta_window.window_type) {
         case Meta.WindowType.NORMAL:
-            if (this._codeViewManager.handleDestroyWindow(actor))
-                return;
-
             actor.set_pivot_point(0.5, 0.5);
             this._destroying.push(actor);
 


### PR DESCRIPTION
At the moment, we only forward the window destroy event to
CodeViewManager when a determination is made that the window needs an
animation, and is a normal window.

However, whether the window needs an animation also depends on
external factors, such as whether the overview is visible. We don't
want to miss the even in those cases, or we can e.g. end up with a
mismatched app/toolbox pair when an app is closed while the overview
is visible.

This commit fixes that by simply passing the event over to
CodeViewManager earlier. If the event referred to a window that is not
tracked by CodeViewManager, no harm is done anyway.

https://phabricator.endlessm.com/T25040