### PR TITLE
plugin: remove implementation of MetaPlugin::stop

### DIFF
--- a/src/gnome-shell-plugin.c
+++ b/src/gnome-shell-plugin.c
@@ -132,7 +132,6 @@ gnome_shell_plugin_class_init (GnomeShellPluginClass *klass)
   MetaPluginClass *plugin_class  = META_PLUGIN_CLASS (klass);
 
   plugin_class->start            = gnome_shell_plugin_start;
-  plugin_class->stop             = gnome_shell_plugin_stop;
   plugin_class->map              = gnome_shell_plugin_map;
   plugin_class->minimize         = gnome_shell_plugin_minimize;
   plugin_class->unminimize       = gnome_shell_plugin_unminimize;
@@ -266,12 +265,6 @@ get_shell_wm (void)
   g_object_unref (wm);
 
   return wm;
-}
-
-static void
-gnome_shell_plugin_stop (MetaPlugin *plugin)
-{
-  _shell_wm_stop (get_shell_wm ());
 }
 
 static void


### PR DESCRIPTION
This partially reverts ba62a90c03f6055c6cc0e290e705f8b59dadd30a. Due to
an ongoing distro update, gnome-shell is not currently buildable on
master. The addition of this ->stop vfunc in mutter is an ABI break;
running gnome-shell built against a previous version of mutter with the
new version of mutter will crash on startup.

Once gnome-shell becomes buildable again on master, we'll revert this
(and the corresponding mutter revert) again.

This backs out #405. https://github.com/endlessm/mutter/pull/79 is the corresponding Mutter change.

https://phabricator.endlessm.com/T24406