### PR TITLE
payg: Properly update time remaining every minute

### DIFF
--- a/js/ui/status/payg.js
+++ b/js/ui/status/payg.js
@@ -57,7 +57,7 @@ var Indicator = new Lang.Class({
 
         // refresh the displayed icon and "time remaining" label periodically
         this._timeoutRefreshId = Mainloop.timeout_add_seconds (REFRESH_TIME_SECS, () => {
-            this._timeoutRefresh();
+            return this._timeoutRefresh();
         });
         GLib.Source.set_name_by_id(this._timeoutRefreshId, '[gnome-shell] this._timeoutRefresh');
     },


### PR DESCRIPTION
Currently the payg tray applet only decrements the displayed number of
minutes remaining once and then stays stuck at a number (e.g. 58
minutes) until the credit expires completely. This is because we're not
returning GLib.SOURCE_CONTINUE in the callback, so fix this so that the
applet updates the time remaining every 60 seconds.

https://phabricator.endlessm.com/T24300