### PR TITLE
clubhouse: Clear animations metadata cache when the Clubhouse is quit

### DIFF
--- a/js/ui/components/clubhouse.js
+++ b/js/ui/components/clubhouse.js
@@ -306,6 +306,10 @@ var ClubhouseAnimator = new Lang.Class({
         });
     },
 
+    clearCache: function() {
+        this._animations = {};
+    },
+
     getAnimation: function(path, callback) {
         this._loadAnimationByPath(path, (metadata) => {
             if (!metadata) {
@@ -814,6 +818,8 @@ var ClubhouseComponent = new Lang.Class({
         this._clubhouseSource = null;
         this._clubhouseProxyHandler = 0;
 
+        this._clubhouseAnimator = null;
+
         this._clubhouseButtonManager = new ClubhouseButtonManager();
         this._clubhouseButtonManager.connect('open-clubhouse', () => {
             this.show(global.get_current_time());
@@ -847,6 +853,12 @@ var ClubhouseComponent = new Lang.Class({
                 if (!this.proxy.g_name_owner) {
                     log('Nothing owning D-Bus name %s, so dismiss the Clubhouse banner'.format(CLUBHOUSE_ID));
                     this._clearQuestBanner();
+
+                    // Clear the animator cache, so we reload the metadata files the next time
+                    // an animation is used, thus accounting for an eventual Clubhouse update
+                    // in the meantime which may bring metadata changes for the animations.
+                    if (this._clubhouseAnimator != null)
+                        this._clubhouseAnimator.clearCache();
                 }
             });
 


### PR DESCRIPTION
Since the Clubhouse Shell component caches the metadata for the
animations coming from the Clubhouse, there can be the case where, if
the Clubhouse is updated and it brings a different metadata for an
existing animation that's cached in the Shell, any attempt
to create the animation will use the right sprite file but the outdated
metadata, thus likely resulting in a crash (due to trying to
clip the sprite with the wrong values).

This patch fixes this issue by clearing the metadata cache every time
the Clubhouse is quit. This means that if there is an update to the
Clubhouse and it is relaunched, there will be no cached metadata for
animations at that point, thus preventing the issue mentioned above.

https://phabricator.endlessm.com/T25118