### PR TITLE
T24855 Fix polkit dialogue signal handling

### DIFF
--- a/js/ui/components/polkitAgent.js
+++ b/js/ui/components/polkitAgent.js
@@ -198,10 +198,10 @@ var AuthenticationDialog = new Lang.Class({
         this.destroySession();
         this._session = new PolkitAgent.Session({ identity: this._identityToAuth,
                                                   cookie: this._cookie });
-        this._session.connect('completed', Lang.bind(this, this._onSessionCompleted));
-        this._session.connect('request', Lang.bind(this, this._onSessionRequest));
-        this._session.connect('show-error', Lang.bind(this, this._onSessionShowError));
-        this._session.connect('show-info', Lang.bind(this, this._onSessionShowInfo));
+        this._sessionCompletedId = this._session.connect('completed', Lang.bind(this, this._onSessionCompleted));
+        this._sessionRequestId = this._session.connect('request', Lang.bind(this, this._onSessionRequest));
+        this._sessionShowErrorId = this._session.connect('show-error', Lang.bind(this, this._onSessionShowError));
+        this._sessionShowInfoId = this._session.connect('show-info', Lang.bind(this, this._onSessionShowInfo));
         this._session.initiate();
     },
 
@@ -343,6 +343,11 @@ var AuthenticationDialog = new Lang.Class({
             if (!this._completed)
                 this._session.cancel();
             this._completed = false;
+
+            this._session.disconnect(this._sessionCompletedId);
+            this._session.disconnect(this._sessionRequestId);
+            this._session.disconnect(this._sessionShowErrorId);
+            this._session.disconnect(this._sessionShowInfoId);
             this._session = null;
         }
     },

--- a/js/ui/components/polkitAgent.js
+++ b/js/ui/components/polkitAgent.js
@@ -46,6 +46,8 @@ var AuthenticationDialog = new Lang.Class({
         this.userNames = userNames;
         this._wasDismissed = false;
 
+        this.connect('closed', Lang.bind(this, this._onDialogClosed));
+
         let icon = new Gio.ThemedIcon({ name: 'dialog-password-symbolic' });
         let title = _("Authentication Required");
 
@@ -195,7 +197,7 @@ var AuthenticationDialog = new Lang.Class({
     },
 
     _initiateSession: function() {
-        this.destroySession();
+        this._destroySession();
         this._session = new PolkitAgent.Session({ identity: this._identityToAuth,
                                                   cookie: this._cookie });
         this._sessionCompletedId = this._session.connect('completed', Lang.bind(this, this._onSessionCompleted));
@@ -337,7 +339,7 @@ var AuthenticationDialog = new Lang.Class({
         this._ensureOpen();
     },
 
-    destroySession: function() {
+    _destroySession: function() {
         if (this._session) {
             this._inputSourceManager.passwordModeEnabled = false;
             if (!this._completed)
@@ -370,6 +372,10 @@ var AuthenticationDialog = new Lang.Class({
         this._wasDismissed = true;
         this.close(global.get_current_time());
         this._emitDone(true);
+    },
+
+    _onDialogClosed: function() {
+        this._destroySession();
     },
 });
 Signals.addSignalMethods(AuthenticationDialog.prototype);
@@ -428,7 +434,6 @@ var AuthenticationAgent = new Lang.Class({
 
     _completeRequest: function(dismissed) {
         this._currentDialog.close();
-        this._currentDialog.destroySession();
         this._currentDialog = null;
 
         this._native.complete(dismissed);

--- a/js/ui/components/polkitAgent.js
+++ b/js/ui/components/polkitAgent.js
@@ -375,6 +375,12 @@ var AuthenticationDialog = new Lang.Class({
     },
 
     _onDialogClosed: function() {
+        if (this._user) {
+            this._user.disconnect(this._userLoadedId);
+            this._user.disconnect(this._userChangedId);
+            this._user = null;
+        }
+
         this._destroySession();
     },
 });

--- a/js/ui/search.js
+++ b/js/ui/search.js
@@ -535,6 +535,7 @@ var SearchResults = new Lang.Class({
     },
 
     _registerProvider: function (provider) {
+        provider.searchInProgress = false;
         this._providers.push(provider);
         this._ensureProviderDisplay(provider);
     },

--- a/js/ui/status/keyboard.js
+++ b/js/ui/status/keyboard.js
@@ -874,6 +874,8 @@ var InputSourceIndicator = new Lang.Class({
     _init: function(parent, showLayout = true) {
         this.parent(0.0, _("Keyboard"));
 
+        this.connect('destroy', Lang.bind(this, this._onDestroy));
+
         this._menuItems = {};
         this._indicatorLabels = {};
         this._showLayoutItem = null;
@@ -901,9 +903,19 @@ var InputSourceIndicator = new Lang.Class({
         this._sessionUpdated();
 
         this._inputSourceManager = getInputSourceManager();
-        this._inputSourceManager.connect('sources-changed', Lang.bind(this, this._sourcesChanged));
-        this._inputSourceManager.connect('current-source-changed', Lang.bind(this, this._currentSourceChanged));
+        this._inputSourceManagerSourcesChangedId =
+            this._inputSourceManager.connect('sources-changed', Lang.bind(this, this._sourcesChanged));
+        this._inputSourceManagerCurrentSourceChangedId =
+            this._inputSourceManager.connect('current-source-changed', Lang.bind(this, this._currentSourceChanged));
         this._inputSourceManager.reload();
+    },
+
+    _onDestroy: function() {
+        if (this._inputSourceManager) {
+            this._inputSourceManager.disconnect(this._inputSourceManagerSourcesChangedId);
+            this._inputSourceManager.disconnect(this._inputSourceManagerCurrentSourceChangedId);
+            this._inputSourceManager = null;
+        }
     },
 
     _sessionUpdated: function() {


### PR DESCRIPTION
This is a tentative fix for the residual polkit dialogue seen on some OpenQA test runs, such as https://openqa.endlessm.com/tests/12952#step/desktop_travel/23. That polkit dialogue should have been cancelled by polkitd, as can be seen from the journal for that test run:
```
Jan 18 11:20:30 endless polkitd[367]: Operator of unix-session:2 FAILED to authenticate to gain authorization for action org.freedesktop.Flatpak.runtime-install for system-bus-name::1.249 [/usr/bin/gnome-software --gapplication-service] (owned by unix-user:test)
Jan 18 11:20:30 endless gnome-software[1612]: failed to call gs_plugin_app_install on flatpak: failed to get permissions: Unable to load metadata from remote eos-apps: GDBus.Error:org.freedesktop.DBus.Error.AccessDenied: Flatpak system operation Deploy not allowed for user
```

Helps https://phabricator.endlessm.com/T24855