### PR TITLE
T25241 clubhouse button ext monitor

### DIFF
--- a/js/ui/components/clubhouse.js
+++ b/js/ui/components/clubhouse.js
@@ -776,7 +776,7 @@ var ClubhouseButtonManager = new Lang.Class({
         let workarea = Main.layoutManager.getWorkAreaForMonitor(monitor.index);
 
         this._openButton.x = monitor.x + monitor.width - this._openButton.width / 2;
-        this._openButton.y = Math.floor(workarea.height / 2.0 - this._openButton.height / 2.0);
+        this._openButton.y = workarea.y + Math.floor(workarea.height / 2.0 - this._openButton.height / 2.0);
 
         this._updateCloseButtonPosition();
     },

--- a/js/ui/components/clubhouse.js
+++ b/js/ui/components/clubhouse.js
@@ -739,6 +739,7 @@ var ClubhouseButtonManager = new Lang.Class({
     _init: function() {
         this._openButton = new ClubhouseOpenButton();
         this._openButton.connect('clicked', () => { this.emit('open-clubhouse'); })
+        this._openButton.set_clip(0, 0, CLUBHOUSE_BUTTON_SIZE / 2, CLUBHOUSE_BUTTON_SIZE);
 
         Main.layoutManager.addChrome(this._openButton);
 


### PR DESCRIPTION
This PR fixes the button positioning with multiples monitors. I've tried adding an external monitor to the right, top, left and bottom and it works okay in all the cases.

To do this I've changed the button, instead of drawing the complete circle 110x110 and positioned at the edge of the screen, I've changed that to draw it 55x110 so there's no part of it in the secondary monitor.

The second commit fixes the button positioning when we've the external monitor above or below the primary.

https://phabricator.endlessm.com/T25241