### PR TITLE
codeview: Place the button below the panel box

### DIFF
--- a/js/ui/codeView.js
+++ b/js/ui/codeView.js
@@ -450,6 +450,9 @@ var CodingSession = new Lang.Class({
 
         _ensureAfterFirstFrame(actor, () => {
             Main.layoutManager.addChrome(this._button);
+            // Position the button below the panel
+            Main.layoutManager.uiGroup.set_child_below_sibling(
+                this._button, Main.layoutManager.panelBox);
             this._synchronizeButton(actor.meta_window);
         });
     },


### PR DESCRIPTION
To avoid the codeview button to be placed above the bottom panel and
other floating dialogs like the shutdown dialog, I moved the actor below
the panelBox.

https://phabricator.endlessm.com/T24683
https://phabricator.endlessm.com/T25061