### PR TITLE
sideComponent: Clip side components during slide

### DIFF
--- a/js/ui/windowManager.js
+++ b/js/ui/windowManager.js
@@ -1776,14 +1776,20 @@ var WindowManager = new Lang.Class({
                                onCompleteParams: [shellwm, actor],
                                onOverwrite: onOverwrite,
                                onOverwriteScope: this,
-                               onOverwriteParams: [shellwm, actor]
+                               onOverwriteParams: [shellwm, actor],
+                               onUpdate: this._clipActor,
+                               onUpdateParams: [Clutter.ContentGravity.TOP, endY, actor],
                              });
         } else {
             let endX;
-            if (actor.x <= monitor.x)
+            let origin;
+            if (actor.x <= monitor.x) {
                 endX = monitor.x - actor.width;
-            else
+                origin = Clutter.ContentGravity.LEFT;
+            } else {
                 endX = monitor.x + monitor.width;
+                origin = Clutter.ContentGravity.RIGHT;
+            }
 
             Tweener.addTween(actor,
                              { x: endX,
@@ -1794,7 +1800,9 @@ var WindowManager = new Lang.Class({
                                onCompleteParams: [shellwm, actor],
                                onOverwrite: onOverwrite,
                                onOverwriteScope: this,
-                               onOverwriteParams: [shellwm, actor]
+                               onOverwriteParams: [shellwm, actor],
+                               onUpdate: this._clipActor,
+                               onUpdateParams: [origin, endX, actor],
                              });
         }
     },
@@ -2172,18 +2180,26 @@ var WindowManager = new Lang.Class({
                                onCompleteParams: [shellwm, actor],
                                onOverwrite: this._mapWindowOverwrite,
                                onOverwriteScope: this,
-                               onOverwriteParams: [shellwm, actor]
+                               onOverwriteParams: [shellwm, actor],
+                               onUpdate: this._clipActor,
+                               onUpdateParams: [Clutter.ContentGravity.TOP, monitor.y - actor.height, actor],
                              });
         }
         else {
             let origX = actor.x;
+            let position;
+            let origin;
             if (origX == monitor.x) {
                 // the side bar will appear from the left side
-                actor.set_position(monitor.x - actor.width, actor.y);
+                position = monitor.x - actor.width;
+                origin = Clutter.ContentGravity.LEFT;
             } else {
                 // ... from the right side
-                actor.set_position(monitor.x + monitor.width, actor.y);
+                position = monitor.x + monitor.width;
+                origin = Clutter.ContentGravity.RIGHT;
             }
+
+            actor.set_position(position, actor.y);
 
             Tweener.addTween(actor,
                              { x: origX,
@@ -2194,7 +2210,9 @@ var WindowManager = new Lang.Class({
                                onCompleteParams: [shellwm, actor],
                                onOverwrite: this._mapWindowOverwrite,
                                onOverwriteScope: this,
-                               onOverwriteParams: [shellwm, actor]
+                               onOverwriteParams: [shellwm, actor],
+                               onUpdate: this._clipActor,
+                               onUpdateParams: [origin, position, actor],
                              });
         }
 
@@ -2203,6 +2221,32 @@ var WindowManager = new Lang.Class({
 
         if (SideComponent.shouldHideOtherWindows(actor.meta_window))
             this._hideOtherWindows(actor, animateFade);
+    },
+
+    _clipActor : function(origin, position, actor) {
+        let clipX = 0;
+        let clipY = 0;
+        let clipWidth = actor.width;
+        let clipHeight = actor.height;
+
+        switch (origin) {
+            case Clutter.ContentGravity.RIGHT:
+                clipWidth = position - actor.x;
+                break;
+            case Clutter.ContentGravity.LEFT:
+                clipX = actor.width - (actor.x - position);
+                break;
+            case Clutter.ContentGravity.TOP:
+                clipY = actor.height - (actor.y - position);
+                break;
+            case Clutter.ContentGravity.BOTTOM:
+                clipHeight = position - actor.y;
+                break;
+            default:
+                break;
+        }
+
+        actor.set_clip(clipX, clipY, clipWidth, clipHeight);
     },
 
     _mapWindow : function(shellwm, actor) {


### PR DESCRIPTION
When we've multiple monitors and the workarea is expanded, we can view
the animation for the side components in the external monitor during the
slide.

To avoid this, this patch adds a callback for each Tweener animation to
clip the actor during the update. Doing this, the actor isn't visible in
the other monitors.

This problem was detected as part of the https://github.com/endlessm/gnome-shell/pull/430, so it's related with this task: https://phabricator.endlessm.com/T25241