### PR TITLE
Revert "soundServer: initialize sound server proxy asynchronously"

### DIFF
--- a/js/misc/soundServer.js
+++ b/js/misc/soundServer.js
@@ -84,14 +84,8 @@ var SoundItem = class {
 
 class SoundServer {
     constructor() {
-        this._proxy = new SoundServerProxy(
-            Gio.DBus.session,
-            'com.endlessm.HackSoundServer',
-            '/com/endlessm/HackSoundServer',
-            (proxy, err) => {
-                if (err)
-                    logError(err, 'Could not create sound server proxy');
-            });
+        this._proxy = new SoundServerProxy(Gio.DBus.session,
+            'com.endlessm.HackSoundServer', '/com/endlessm/HackSoundServer');
     }
 
     // Most common use case, fire and forget, no return value


### PR DESCRIPTION
This reverts commit 25dc013adf59be557080570de7bc3c5b057473be.
Asynchronously initializing the proxy can cause a race condition where
methods are called before the proxy finishes initializing.