### PR TITLE
codeView: Preload toolbox before the flip

### DIFF
--- a/js/ui/codeView.js
+++ b/js/ui/codeView.js
@@ -930,9 +930,17 @@ var CodingSession = new Lang.Class({
             !Main.overview.visible &&
             !inFullscreen &&
             !locked &&
-            this._hackable)
+            this._hackable) {
+
+            if (!this.toolbox) {
+                this._toolboxAppActionGroup.activate_action(
+                    'init',
+                    new GLib.Variant('(ss)', [_getAppId(this.app.meta_window),
+                                              _getWindowId(this.app.meta_window)]));
+            }
+
             this._button.show();
-        else
+        } else
             this._button.hide();
     },
 


### PR DESCRIPTION
The toolbox is being lazy loaded when the user clicks the FtH button. If
the toolbox is a bit complex, this loading can take some time and the
feedback for the user is odd because the interface freezes after the
click.

To try to *improve* the flipping time, we can preload the hack toolbox
for the app before the user clicks the FtH. This patch calls to the init
method of the HackToolbox, when the button is shown only if it's not
init yet.

This depends on this change for the hack toolbox:
https://github.com/endlessm/hack-toolbox-app/pull/130

if the hack toolbox app doesn't have this action yet, the preload won't
work and the FtH will continue working as usual.

https://phabricator.endlessm.com/T25093