### PR TITLE
config: Remove obsolete notifications

### DIFF
--- a/js/misc/paygManager.js
+++ b/js/misc/paygManager.js
@@ -181,6 +181,7 @@ var PaygManager = new Lang.Class({
         this._expiryTime = value;
         this._updateExpirationReminders();
 
+        this._paygNotifier.clearNotification();
         this.emit('expiry-time-changed', this._expiryTime);
     },
 

--- a/js/ui/payg.js
+++ b/js/ui/payg.js
@@ -471,8 +471,8 @@ var PaygNotifier = new Lang.Class({
             return;
         }
 
-        if (this._notification)
-            this._notification.destroy();
+        // Clear previous notification
+        clearNotification();
 
         let source = new MessageTray.SystemNotificationSource();
         Main.messageTray.add(source);
@@ -510,5 +510,11 @@ var PaygNotifier = new Lang.Class({
         this._notification.connect('destroy', () => {
             this._notification = null;
         });
+
+    },
+
+    clearNotification() {
+        if (this._notification)
+            this._notification.destroy();
     },
 });


### PR DESCRIPTION
Pay-As-You-Go Notifications keep appearing after being
useful when using eos-payg-ctl in the middle of a
time-session or when the session expires normally. So we
clean all notifications on the message tray when a
expiry-time-changed signal is sent.

https://phabricator.endlessm.com/T25246