### PR TITLE
clubhouse: Clip close button near the right side

### DIFF
--- a/js/ui/components/clubhouse.js
+++ b/js/ui/components/clubhouse.js
@@ -769,6 +769,18 @@ var ClubhouseButtonManager = new Lang.Class({
         let clubhouseWindowX = getClubhouseWindowTracker().getWindowX();
         if (clubhouseWindowX != -1)
             this._closeButton.x = clubhouseWindowX - this._closeButton.width / 2;
+
+        // To avoid this button appearing in a possible right monitor during
+        // the animation we need to clip it to adjust to the monitor width
+        let monitor = Main.layoutManager.primaryMonitor;
+        if (!monitor)
+            return;
+        let buttonEdge = this._closeButton.x + this._closeButton.width;
+        let monitorEdge = monitor.x + monitor.width;
+        let offset =  buttonEdge - monitorEdge;
+        offset = Math.max(offset, 0);
+        let clip = this._closeButton.width - offset;
+        this._closeButton.set_clip(0, 0, clip, this._closeButton.height);
     },
 
     _reposition: function() {


### PR DESCRIPTION
When there's an external monitor on the right side we need to clip the
clubhouse close button to avoid this button to be visible outside the
main monitor.

This patch clips the button on every movement so it'll be full visible
when it's full inside the monitor and clipped to the monitor with when
it's at the edge.

https://phabricator.endlessm.com/T25241