### PR TITLE
clubhouse: Clip notification banner slide in/out

### DIFF
--- a/js/ui/components/clubhouse.js
+++ b/js/ui/components/clubhouse.js
@@ -507,6 +507,7 @@ var ClubhouseNotificationBanner = new Lang.Class({
                              { x: endX,
                                time: CLUBHOUSE_BANNER_ANIMATION_TIME,
                                transition: 'easeOutQuad',
+                               onUpdate: this._clipActor.bind(this),
                                onComplete: () => {
                                    // Ensure it only slides in once
                                    this._shouldSlideIn = false;
@@ -564,11 +565,24 @@ var ClubhouseNotificationBanner = new Lang.Class({
                          { x: endX,
                            time: CLUBHOUSE_BANNER_ANIMATION_TIME,
                            transition: 'easeOutQuad',
+                           onUpdate: this._clipActor.bind(this),
                            onComplete: () => {
                                this.actor.destroy();
                                this.actor = null;
                            }
                          });
+    },
+
+    _clipActor: function() {
+        let monitor = Main.layoutManager.primaryMonitor;
+        if (!monitor)
+            return;
+
+        let monitorEdge = monitor.x + monitor.width;
+        let actorEdge = this.actor.x + this.actor.width;
+        let offset = Math.max(0, actorEdge - monitorEdge);
+        let clip = this.actor.width - offset;
+        this.actor.set_clip(0, 0, clip, this.actor.height);
     },
 
     dismiss: function(shouldSlideOut) {


### PR DESCRIPTION
When there's an external monitor on the right side we need to clip the
clubhouse notification banner to avoid this bubble to be visible outside
the main monitor.

This patch clips the notification bubble on every movement so it'll be
full visible when it's full inside the monitor and clipped to the
monitor width when it's at the edge.

https://phabricator.endlessm.com/T25241