### PR TITLE
fix: Remove obsolete notifications

### DIFF
--- a/js/ui/payg.js
+++ b/js/ui/payg.js
@@ -472,7 +472,7 @@ var PaygNotifier = new Lang.Class({
         }
 
         // Clear previous notification
-        clearNotification();
+        this.clearNotification();
 
         let source = new MessageTray.SystemNotificationSource();
         Main.messageTray.add(source);


### PR DESCRIPTION
Local method is not being found without the <this>
identifier, so we use it.

https://phabricator.endlessm.com/T25246