### PR TITLE
payg: Missing shell import

### DIFF
--- a/js/ui/payg.js
+++ b/js/ui/payg.js
@@ -23,6 +23,7 @@ const Gettext = imports.gettext;
 const Gio = imports.gi.Gio;
 const GLib = imports.gi.GLib;
 const GObject = imports.gi.GObject;
+const Shell = imports.gi.Shell;
 const St = imports.gi.St;
 const Lang = imports.lang;
 const Mainloop = imports.mainloop;


### PR DESCRIPTION
When adding more that 10 codes, the notification tray
should show a "Too many attempts. Try again in 30 minutes".
Instead, it only showed a spinner animation indefinetly, due
to a broken import.

https://phabricator.endlessm.com/T25132