### PR TITLE
codeView: remove CodingSession on actor minimize

### DIFF
--- a/js/ui/windowManager.js
+++ b/js/ui/windowManager.js
@@ -1808,6 +1808,8 @@ var WindowManager = new Lang.Class({
     },
 
     _minimizeWindow : function(shellwm, actor) {
+        this._codeViewManager.handleMinimizeWindow(actor);
+
         let types = [Meta.WindowType.NORMAL,
                      Meta.WindowType.MODAL_DIALOG,
                      Meta.WindowType.DIALOG];
@@ -1866,6 +1868,7 @@ var WindowManager = new Lang.Class({
     },
 
     _unminimizeWindow : function(shellwm, actor) {
+        this._codeViewManager.handleMapWindow(actor);
         let types = [Meta.WindowType.NORMAL,
                      Meta.WindowType.MODAL_DIALOG,
                      Meta.WindowType.DIALOG];


### PR DESCRIPTION
This is an alternative solution to this PR: https://github.com/endlessm/gnome-shell/pull/445

When a hack app is destroyed when it's minimized the corresponding
CodingSession is not removed from the list because the function
handleDestroyWindow is never called and this cause problems in the
future because there's a CodingSession with an app that points to a non
existing window.

This patch links with the minimize/unimimize events and remove/add the
CodingSession to the list.

To avoid to leave some toolbox windows over there, before the minimizing
we need to flip back and then the session can be removed without problems.

https://phabricator.endlessm.com/T25880