### PR TITLE
eos-payg: Add error handling for time removal

### DIFF
--- a/js/misc/paygManager.js
+++ b/js/misc/paygManager.js
@@ -40,6 +40,7 @@ const EOS_PAYG_IFACE = '<node> \
 <interface name="com.endlessm.Payg1"> \
 <method name="AddCode"> \
   <arg type="s" direction="in" name="code"/> \
+  <arg type="x" direction="out" name="time_added"/> \
 </method> \
 <method name="ClearCode" /> \
 <signal name="Expired" /> \
@@ -92,6 +93,7 @@ var PaygManager = new Lang.Class({
 
         this._enabled = false;
         this._expiryTime = 0;
+        this._lastTimeAdded = 0;
         this._rateLimitEndTime = 0;
         this._codeFormat = '';
         this._codeFormatRegex = null;
@@ -283,6 +285,9 @@ var PaygManager = new Lang.Class({
         }
 
         this._proxy.AddCodeRemote(code, (result, error) => {
+            if (!error)
+                this._lastTimeAdded = result;
+
             if (callback)
                 callback(error);
         });
@@ -317,6 +322,10 @@ var PaygManager = new Lang.Class({
 
     get expiryTime() {
         return this._expiryTime;
+    },
+
+    get lastTimeAdded() {
+        return this._lastTimeAdded;
     },
 
     get rateLimitEndTime() {

--- a/js/ui/payg.js
+++ b/js/ui/payg.js
@@ -145,6 +145,13 @@ var UnlockUi = new Lang.Class({
         this.verificationStatus = UnlockStatus.FAILED;
     },
 
+    processReset() {
+        // If time has been removed entirely, we show the user the according message
+        // that the time has been reset to zero.
+        this.setErrorMessage(_("Remaining time cleared."));
+        this.verificationStatus = UnlockStatus.FAILED;
+    },
+
     _onDestroy() {
         if (this._clearTooManyAttemptsId > 0) {
             Mainloop.source_remove(this._clearTooManyAttemptsId);
@@ -210,6 +217,8 @@ var UnlockUi = new Lang.Class({
 
             if (error) {
                 this.processError(error);
+            } else if (Main.paygManager.lastTimeAdded >= 0) {
+                this.processReset();
             } else {
                 this.verificationStatus = UnlockStatus.SUCCEEDED;
                 this.onCodeAdded();


### PR DESCRIPTION
Adding a code that does not add time for the users makes
the paygManager to try and trigger the screenShield, and the
signal is received, but does not make it pop since it's not
unlocked, finishing the unlock process before adding a valid
code. So we add a error handling using the time added from the
daemon so we know how much time has been returned, and if it's
zero, do nothing.

https://phabricator.endlessm.com/T25248