### PR TITLE
ShellDBus: Add SHELL_APP_ADDED_EVENT

### DIFF
--- a/js/ui/shellDBus.js
+++ b/js/ui/shellDBus.js
@@ -16,6 +16,9 @@ const { loadInterfaceXML } = imports.misc.fileUtils;
 const GnomeShellIface = loadInterfaceXML('org.gnome.Shell');
 const ScreenSaverIface = loadInterfaceXML('org.gnome.ScreenSaver');
 
+// Occurs when an application is added to the app grid.
+const SHELL_APP_ADDED_EVENT = '51640a4e-79aa-47ac-b7e2-d3106a06e129';
+
 var GnomeShell = class {
     constructor() {
         this._dbusImpl = Gio.DBusExportedObject.wrapJSObject(GnomeShellIface, this);


### PR DESCRIPTION
The AddApplication method uses this varaible as an identifier to record
this event. This variable should have been removed during the 3.32
rebase but the reference is there causing a crash on every call.

This patch recovers this line from previous commits.