### PR TITLE
appDisplay: remove reference to this._views

### DIFF
--- a/js/ui/appDisplay.js
+++ b/js/ui/appDisplay.js
@@ -1355,7 +1355,7 @@ var AppDisplay = class AppDisplay {
 
     selectApp(id) {
         this._showView(Views.ALL);
-        this._views[Views.ALL].view.selectApp(id);
+        this._allView.selectApp(id);
     }
 
     adaptToSize(width, height) {


### PR DESCRIPTION
this._views doesn't exists in the current version so we should remove
this reference because it's undefined.