### PR TITLE
clubhouse: Reload clubhouse paths on fail

### DIFF
--- a/js/ui/components/clubhouse.js
+++ b/js/ui/components/clubhouse.js
@@ -264,7 +264,7 @@ var ClubhouseAnimator = class ClubhouseAnimator {
         return splitDir.join('/');
     }
 
-    _getClubhousePath(path) {
+    _getClubhousePath(path, retry = true) {
         // Discard the /app/ prefix
         let pathSuffix = path.replace(/^\/app\//g, '');
 
@@ -272,6 +272,12 @@ var ClubhouseAnimator = class ClubhouseAnimator {
             let completePath = GLib.build_filenamev([path, 'files', pathSuffix]);
             if (GLib.file_test(completePath, GLib.FileTest.EXISTS))
                 return completePath;
+        }
+
+        // retrying reloading clubhouse paths
+        if (retry) {
+            this._clubhousePaths = this._getClubhousePaths();
+            return this._getClubhousePath(path, false);
         }
 
         return null;


### PR DESCRIPTION
If we install/uninstall a different version of the clubhouse and a new
clubhouse notification comes to the shell, the notification code will
not find the image because the flatpak path has changed.

This patch fixes that problem reloading the clubhouse flaptak
directories if we can't find the animation image. This will be only done
once to avoid an infinite recursion in the case of trying to find a non
existing image.

https://phabricator.endlessm.com/T26543