### PR TITLE
Revert "appDisplay: Fix small app folder icons when using HIDPI"

### DIFF
--- a/js/ui/appDisplay.js
+++ b/js/ui/appDisplay.js
@@ -1574,12 +1574,11 @@ var FolderView = class FolderView extends BaseAppView {
                                    style_class: 'app-folder-icon' });
         layout.hookup_style(icon);
         let subSize = Math.floor(FOLDER_SUBICON_FRACTION * size);
-        let scale = St.ThemeContext.get_for_stage(global.stage).scale_factor;
 
         let numItems = this._allItems.length;
         let rtl = icon.get_text_direction() == Clutter.TextDirection.RTL;
         for (let i = 0; i < 4; i++) {
-            let bin = new St.Bin({ width: subSize * scale, height: subSize * scale });
+            let bin = new St.Bin({ width: subSize, height: subSize });
             if (i < numItems)
                 bin.child = this._allItems[i].app.create_icon_texture(subSize);
             layout.attach(bin, rtl ? (i + 1) % 2 : i % 2, Math.floor(i / 2), 1, 1);


### PR DESCRIPTION
This reverts commit 92f1aec3dd1a373645aa0f70016440993a8ac997. With
resource scale in place, this is not necessary anymore.

https://phabricator.endlessm.com/T26531