### PR TITLE
icon-grid: improve wording when removing desktop icons

### DIFF
--- a/js/ui/appDisplay.js
+++ b/js/ui/appDisplay.js
@@ -2723,7 +2723,7 @@ class AppCenterIcon extends AppIcon {
 
     handleViewDragBegin() {
         this.iconState = AppCenterIconState.EMPTY_TRASH;
-        this.replaceText(_("Delete"));
+        this.replaceText(_("Remove"));
     }
 
     setDragHoverState(state) {

--- a/js/ui/iconGridLayout.js
+++ b/js/ui/iconGridLayout.js
@@ -285,7 +285,7 @@ var IconGridLayout = GObject.registerClass({
             return;
 
         if (interactive)
-            Main.overview.setMessage(_("%s has been deleted").format(info.get_name()),
+            Main.overview.setMessage(_("%s has been removed").format(info.get_name()),
                                      { forFeedback: true,
                                        destroyCallback: (info) => {
                                            this._onMessageDestroy (info);


### PR DESCRIPTION
Currently, if you right-click an app icon and click “Remove from
desktop”, you see a notification reading “$APP has been deleted”, which
is not true. If you drag an icon, the app center icon changes to a trash
can, and the label changes to “Delete”, which is inaccurate in the same
way.

Change these strings to say “remove[d]”, not “delete[d]”, per design
direction in March 2017(!).

https://phabricator.endlessm.com/T16267