### PR TITLE
Reintroduce Shell API to launch applications (eos3.6)

### DIFF
--- a/data/dbus-interfaces/meson.build
+++ b/data/dbus-interfaces/meson.build
@@ -1,4 +1,5 @@
 dbus_interfaces = [
+  'org.gnome.Shell.AppLauncher.xml',
   'org.gnome.Shell.AppStore.xml',
   'org.gnome.Shell.Extensions.xml',
   'org.gnome.Shell.Introspect.xml',

--- a/data/dbus-interfaces/org.gnome.Shell.AppLauncher.xml
+++ b/data/dbus-interfaces/org.gnome.Shell.AppLauncher.xml
@@ -4,5 +4,13 @@
       <arg type="s" direction="in" name="name" />
       <arg type="u" direction="in" name="timestamp" />
     </method>
+    <method name="LaunchViaDBusCall">
+      <arg type="s" direction="in" name="name" />
+      <arg type="s" direction="in" name="busName" />
+      <arg type="s" direction="in" name="objectPath" />
+      <arg type="s" direction="in" name="interfaceName" />
+      <arg type="s" direction="in" name="methodName" />
+      <arg type="v" direction="in" name="args" />
+    </method>
   </interface>
 </node>

--- a/data/dbus-interfaces/org.gnome.Shell.AppLauncher.xml
+++ b/data/dbus-interfaces/org.gnome.Shell.AppLauncher.xml
@@ -1,0 +1,8 @@
+<node>
+  <interface name="org.gnome.Shell.AppLauncher">
+    <method name="Launch">
+      <arg type="s" direction="in" name="name" />
+      <arg type="u" direction="in" name="timestamp" />
+    </method>
+  </interface>
+</node>

--- a/data/eos-launch.desktop.in.in
+++ b/data/eos-launch.desktop.in.in
@@ -1,0 +1,8 @@
+[Desktop Entry]
+_Name=EOS Launch
+_Comment=Utility to launch EndlessOS applications
+Exec=gjs @pkgdatadir@/eos-launch.js %U
+Categories=EndlessOS;Utility;Core;
+MimeType=x-scheme-handler/endlessm-app;
+Type=Application
+NoDisplay=true

--- a/data/gnome-shell-dbus-interfaces.gresource.xml
+++ b/data/gnome-shell-dbus-interfaces.gresource.xml
@@ -38,6 +38,7 @@
     <file preprocess="xml-stripblanks">org.gnome.SettingsDaemon.Power.Screen.xml</file>
     <file preprocess="xml-stripblanks">org.gnome.SettingsDaemon.Rfkill.xml</file>
     <file preprocess="xml-stripblanks">org.gnome.SettingsDaemon.Wacom.xml</file>
+    <file preprocess="xml-stripblanks">org.gnome.Shell.AppLauncher.xml</file>
     <file preprocess="xml-stripblanks">org.gnome.Shell.AppStore.xml</file>
     <file preprocess="xml-stripblanks">org.gnome.Shell.AudioDeviceSelection.xml</file>
     <file preprocess="xml-stripblanks">org.gnome.Shell.CalendarServer.xml</file>

--- a/data/meson.build
+++ b/data/meson.build
@@ -1,6 +1,7 @@
 desktop_files = [
   'org.gnome.Shell.desktop',
   'gnome-shell-extension-prefs.desktop',
+  'eos-launch.desktop',
   'eos-link-feedback.desktop'
 ]
 service_files = []
@@ -14,6 +15,7 @@ desktopconf = configuration_data()
 # We substitute in bindir so it works as an autostart
 # file when built in a non-system prefix
 desktopconf.set('bindir', bindir)
+desktopconf.set('pkgdatadir', pkgdatadir)
 desktopconf.set('VERSION', meson.project_version())
 foreach desktop_file : desktop_files
   i18n.merge_file('desktop',

--- a/js/misc/eos-launch.js
+++ b/js/misc/eos-launch.js
@@ -1,0 +1,55 @@
+const { Gio, GLib } = imports.gi;
+
+const AppLauncherIface = '<node> \
+<interface name="org.gnome.Shell.AppLauncher"> \
+<method name="Launch"> \
+    <arg type="s" direction="in" name="name" /> \
+    <arg type="u" direction="in" name="timestamp" /> \
+</method> \
+</interface> \
+</node>';
+
+const AppLauncherProxy = Gio.DBusProxy.makeProxyWrapper(AppLauncherIface);
+
+function getLocalizedAppNames(appName) {
+    // trim .desktop part, if present
+    let idx = appName.indexOf('.desktop');
+    if (idx != -1)
+        appName = appName.substring(0, idx);
+
+    let appNames = [appName];
+
+    let languageNames = GLib.get_language_names();
+    let variants = GLib.get_locale_variants(languageNames[0]);
+    variants.filter((variant) => {
+        // discard variants with an encoding
+        return (variant.indexOf('.') == -1)
+    }).forEach((variant) => {
+        appNames.push(appName + '.' + variant);
+    });
+
+    appNames.push(appName + '.en');
+    return appNames;
+}
+
+function createProxyAndLaunch(appName) {
+    try {
+        let proxy = new AppLauncherProxy(Gio.DBus.session,
+                                         'org.gnome.Shell',
+                                         '/org/gnome/Shell');
+        proxy.LaunchSync(appName, 0);
+    } catch (error) {
+        logError(error, 'Failed to launch application \'' + appName + '\'');
+    }
+}
+
+var uri = ARGV[0];
+if (! uri) {
+    print('Usage: eos-launch endlessm-app://<application-name>\n');
+} else {
+    let tokens = uri.match(/(endlessm-app:\/\/|)([0-9,a-z,A-Z,-_.]+)/);
+    if (tokens) {
+        let appNames = getLocalizedAppNames(tokens[2]);
+        appNames.some(createProxyAndLaunch);
+    }
+}

--- a/js/misc/meson.build
+++ b/js/misc/meson.build
@@ -16,3 +16,5 @@ config_js = configure_file(
   output: 'config.js',
   configuration: jsconf
 )
+
+install_data('eos-launch.js', install_dir: pkgdatadir)

--- a/js/ui/appActivation.js
+++ b/js/ui/appActivation.js
@@ -85,6 +85,41 @@ var AppActivationContext = class {
             this.showSplash();
     }
 
+    // Activate an app via a D-Bus call and keep track of its splash screen
+    // if we had to open a new window for it. Otherwise, if there were
+    // windows already open, just do the D-Bus call
+    activateViaDBusCall(busName, path, interfaceName, method, args, done) {
+        Gio.bus_get(Gio.BusType.SESSION, null, (source, result) => {
+            let bus = null;
+            try {
+                bus = Gio.bus_get_finish(result);
+            } catch (error) {
+                done(error, null);
+                return;
+            }
+
+            let proxy = new Gio.DBusProxy({
+                g_bus_type: Gio.BusType.SESSION,
+                g_connection: bus,
+                g_default_timeout: GLib.MAXINT32,
+                g_flags: Gio.DBusProxyFlags.NONE,
+                g_interface_name: interfaceName,
+                g_name: busName,
+                g_object_path: path,
+            });
+
+            this.showSplash();
+
+            proxy.call(method, args, Gio.DBusCallFlags.NONE, -1, null, (source, result) => {
+                try {
+                    done(null, proxy.call_finish(result));
+                } catch (error) {
+                    done(error, null);
+                }
+            });
+        });
+    }
+
     activate(event, timestamp) {
         let button = event ? event.get_button() : 0;
         let modifiers = event ? event.get_state() : 0;

--- a/js/ui/shellDBus.js
+++ b/js/ui/shellDBus.js
@@ -3,6 +3,7 @@
 const { EosMetrics, Gio, GLib, Meta, Shell } = imports.gi;
 const Lang = imports.lang;
 
+const AppActivation = imports.ui.appActivation;
 const Config = imports.misc.config;
 const ExtensionSystem = imports.ui.extensionSystem;
 const ExtensionDownloader = imports.ui.extensionDownloader;
@@ -28,6 +29,7 @@ var GnomeShell = class {
         this._screenshotService = new Screenshot.ScreenshotService();
 
         this._appstoreService = null;
+        this._appLauncherService = new AppLauncher();
 
         Main.sessionMode.connect('updated', this._sessionModeChanged.bind(this));
         this._sessionModeChanged();
@@ -514,5 +516,41 @@ var AppStoreService = class {
     _emitApplicationsChanged() {
         let allApps = this._iconGridLayout.listApplications();
         this._dbusImpl.emit_signal('ApplicationsChanged', GLib.Variant.new('(as)', [allApps]));
+    }
+};
+
+const AppLauncherIface = loadInterfaceXML('org.gnome.Shell.AppLauncher');
+
+var AppLauncher = class {
+    constructor() {
+        this._dbusImpl = Gio.DBusExportedObject.wrapJSObject(AppLauncherIface, this);
+        this._dbusImpl.export(Gio.DBus.session, '/org/gnome/Shell');
+
+        this._appSys = Shell.AppSystem.get_default();
+    }
+
+    LaunchAsync(params, invocation) {
+        let [appName, timestamp] = params;
+
+        let activationContext = this._activationContextForAppName(appName);
+        if (!activationContext) {
+            invocation.return_error_literal(Gio.IOErrorEnum,
+                                            Gio.IOErrorEnum.NOT_FOUND,
+                                            'Unable to launch app ' + appName + ': Not installed');
+            return;
+        }
+
+        activationContext.activate(null, timestamp);
+    }
+
+    _activationContextForAppName(appName) {
+        if (!appName.endsWith('.desktop'))
+            appName += '.desktop';
+
+        let app = this._appSys.lookup_app(appName);
+        if (!app)
+            return null;
+
+        return new AppActivation.AppActivationContext(app);
     }
 };

--- a/js/ui/shellDBus.js
+++ b/js/ui/shellDBus.js
@@ -543,6 +543,32 @@ var AppLauncher = class {
         activationContext.activate(null, timestamp);
     }
 
+    LaunchViaDBusCallAsync(params, invocation) {
+        let [appName, busName, path, interfaceName, method, args] = params;
+
+        let activationContext = this._activationContextForAppName(appName);
+        if (!activationContext) {
+            invocation.return_error_literal(Gio.IOErrorEnum,
+                                            Gio.IOErrorEnum.NOT_FOUND,
+                                            'Unable to launch app ' + appName + ': Not installed');
+            return;
+        }
+
+        activationContext.activateViaDBusCall(busName, path, interfaceName, method, args, (error, result) => {
+            if (error) {
+                logError(error);
+                invocation.return_error_literal(Gio.IOErrorEnum,
+                                                Gio.IOErrorEnum.FAILED,
+                                                'Unable to launch app ' + appName +
+                                                ' through DBus call on ' + busName +
+                                                ' ' + path + ' ' + interfaceName + ' ' +
+                                                method + ': ' + String(error));
+            } else {
+                invocation.return_value(result);
+            }
+        });
+    }
+
     _activationContextForAppName(appName) {
         if (!appName.endsWith('.desktop'))
             appName += '.desktop';

--- a/js/ui/shellDBus.js
+++ b/js/ui/shellDBus.js
@@ -29,7 +29,7 @@ var GnomeShell = class {
         this._screenshotService = new Screenshot.ScreenshotService();
 
         this._appstoreService = null;
-        this._appLauncherService = new AppLauncher();
+        this._appLauncherService = null;
 
         Main.sessionMode.connect('updated', this._sessionModeChanged.bind(this));
         this._sessionModeChanged();
@@ -57,8 +57,11 @@ var GnomeShell = class {
         if (Main.sessionMode.isGreeter !== true) {
             if (!this._appstoreService)
                 this._appstoreService = new AppStoreService();
+            if (!this._appLauncherService)
+                this._appLauncherService = new AppLauncher();
         } else {
             this._appstoreService = null;
+            this._appLauncherService = null;
         }
     }
 


### PR DESCRIPTION
Backport of #469 to eos3.6. The first patch did not apply cleanly due to 1e206133a not being on eos3.6, but the conflict seems easy enough to resolve.

https://phabricator.endlessm.com/T26726