### PR TITLE
overview: Show apps again after relayout

### DIFF
--- a/js/ui/overview.js
+++ b/js/ui/overview.js
@@ -429,11 +429,6 @@ var Overview = class {
     }
 
     _relayout() {
-        // To avoid updating the position and size of the workspaces
-        // we just hide the overview. The positions will be updated
-        // when it is next shown.
-        this.hide();
-
         this._relayoutNoHide();
     }
 


### PR DESCRIPTION
When the lid is closed and opened again in a desktop without any app
opened, the overview is hidden and never get shown again. This causes a
desktop with disabled buttons.

To avoid this, this patch calls to showApps just after the hide but only
if the app buttons are visibiles before the hide call.

https://phabricator.endlessm.com/T24778