### PR TITLE
windowManager: don't use ES6 `template strings`

### DIFF
--- a/js/ui/windowManager.js
+++ b/js/ui/windowManager.js
@@ -1136,13 +1136,13 @@ var ShellWindowManagerAnimatableSurface = GObject.registerClass({
         if (effects.length === 0) {
             throw new GLib.Error(AnimationsDbus.error_quark(),
                                  AnimationsDbus.Error.UNSUPPORTED_EVENT_FOR_ANIMATION_SURFACE,
-                                 `Surface does not support event ${event}`);
+                                 "Surface does not support event " + event);
         }
 
         if (effects.indexOf(effect.name) == -1) {
             throw new GLib.Error(AnimationsDbus.error_quark(),
                                  AnimationsDbus.Error.UNSUPPORTED_EVENT_FOR_ANIMATION_EFFECT,
-                                 `Effect ${effect.name} can't be used on event ${event}`);
+                                 "Effect " + effect.name + " can't be used on event " + event);
         }
 
         return effect.bridge.createActorPrivate(this.actor);
@@ -1194,7 +1194,7 @@ const ShellWindowManagerAnimationsFactory = GObject.registerClass({
             default:
                 throw new GLib.Error(AnimationsDbus.error_quark(),
                                      AnimationsDbus.Error.NO_SUCH_EFFECT,
-                                     `No such effect ${name}`);
+                                     "No such effect " + name);
         }
     }
 });


### PR DESCRIPTION
I spotted this while working on https://github.com/endlessm/gnome-shell/pull/475. It makes xgettext sad:

    $ ninja -C obj-x86_64-linux-gnu/ meson-gnome-shell-update-po
    ninja: Entering directory `obj-x86_64-linux-gnu/'
    [0/1] Running external command gnome-shell-update-po.
    xgettext: warning: file 'data/50-gnome-shell-system.xml' extension 'xml' is unknown; will try C
    js/ui/windowManager.js:1146: warning: unterminated string

(The first warning is an upstream bug.)

As it happens, this problem has no effect on the generated .pot file, but I think it would prevent xgettext from seeing translatable strings later in the file.

https://phabricator.endlessm.com/T25388