### PR TITLE
eos-payg: Add prefix and sufix characters for code insert

### DIFF
--- a/data/theme/gnome-shell-sass/_endless.scss
+++ b/data/theme/gnome-shell-sass/_endless.scss
@@ -979,6 +979,14 @@ $success_time_payg_color: #02b842;
           padding-top: 1em;
       }
 
+      .unlock-dialog-payg-code-entry {
+          color: darken($osd_fg_color, 20%);
+          font-size: 24px; // Consistent with .login-dialog-prompt-label
+          padding-left: 3px;
+          padding-right: 3px;
+          padding-top: 0.3em;
+      }
+
       .unlock-dialog-payg-entry {
           font-size: 24px;
           padding-left: 12px;

--- a/js/misc/paygManager.js
+++ b/js/misc/paygManager.js
@@ -43,6 +43,8 @@ const EOS_PAYG_IFACE = '<node> \
 <property name="Enabled" type="b" access="read"/> \
 <property name="RateLimitEndTime" type="t" access="read"/> \
 <property name="CodeFormat" type="s" access="read"/> \
+<property name="CodeFormatPrefix" type="s" access="read"/> \
+<property name="CodeFormatSuffix" type="s" access="read"/> \
 </interface> \
 </node>';
 
@@ -206,6 +208,7 @@ var PaygManager = GObject.registerClass({
             this._codeFormatRegex = new GLib.Regex(this._codeFormat,
                                                    GLib.RegexCompileFlags.DOLLAR_ENDONLY,
                                                    GLib.RegexMatchFlags.PARTIAL);
+
         } catch (e) {
             logError(e, 'Error compiling CodeFormat regex: %s'.format(this._codeFormat));
             this._codeFormatRegex = null;
@@ -309,13 +312,28 @@ var PaygManager = GObject.registerClass({
             log("Unable to validate PAYG code: no regex")
             return false;
         }
+        
+        let is_match, match_info;
 
-        let [is_match, match_info] = this._codeFormatRegex.match(code, 0);
+        if (partial)
+            [is_match, match_info] = this._codeFormatRegex.match(this.codeFormatPrefix + code, 0);
+        else
+            [is_match, match_info] = this._codeFormatRegex.match(this.codeFormatPrefix + code +
+                                                                 this.codeFormatSuffix, 0);
+
         return is_match || (partial && match_info.is_partial_match());
     }
 
     get initialized() {
         return this._initialized;
+    }
+
+    get codeFormatPrefix() {
+        return this._proxy.CodeFormatPrefix;
+    }
+
+    get codeFormatSuffix() {
+        return this._proxy.CodeFormatSuffix;
     }
 
     get enabled() {

--- a/js/ui/payg.js
+++ b/js/ui/payg.js
@@ -77,7 +77,7 @@ var PaygUnlockUi = GObject.registerClass({
     }
 
     updateApplyButtonSensitivity() {
-        let sensitive = this.validateCurrentCode() &&
+        let sensitive = this.validateCurrentCode(false) &&
             this.verificationStatus != UnlockStatus.VERIFYING &&
             this.verificationStatus != UnlockStatus.SUCCEEDED &&
             this.verificationStatus != UnlockStatus.TOO_MANY_ATTEMPTS;
@@ -190,12 +190,12 @@ var PaygUnlockUi = GObject.registerClass({
         this.updateSensitivity();
     }
 
-    validateCurrentCode() {
-        return Main.paygManager.validateCode(this.entryCode);
+    validateCurrentCode(partial=true) {
+        return Main.paygManager.validateCode(this.entryCode, partial);
     }
 
     startVerifyingCode() {
-        if (!this.validateCurrentCode())
+        if (!this.validateCurrentCode(false))
             return;
 
         this.verificationStatus = UnlockStatus.VERIFYING;
@@ -203,7 +203,8 @@ var PaygUnlockUi = GObject.registerClass({
         this.updateSensitivity();
         this.cancelled = false;
 
-        Main.paygManager.addCode(this.entryCode, (error) => {
+        Main.paygManager.addCode(Main.paygManager.codeFormatPrefix + this.entryCode
+                                 + Main.paygManager.codeFormatSuffix, (error) => {
             // We don't care about the result if we're closing the dialog.
             if (this.cancelled) {
                 this.verificationStatus = UnlockStatus.NOT_VERIFYING;

--- a/js/ui/paygUnlockDialog.js
+++ b/js/ui/paygUnlockDialog.js
@@ -57,7 +57,9 @@ var PaygUnlockCodeEntry = GObject.registerClass({
         super._init({ style_class: 'unlock-dialog-payg-entry',
                       reactive: true,
                       can_focus: true,
-                      x_align: Clutter.ActorAlign.FILL });
+                      x_align: Clutter.ActorAlign.FILL,
+                      x_expand: true,
+                      y_expand: false });
 
         this._code = '';
         this.clutter_text.ellipsize = Pango.EllipsizeMode.NONE;
@@ -137,7 +139,9 @@ var PaygUnlockCodeEntry = GObject.registerClass({
     }
 
     addCharacter(character) {
-        if (!this._enabled || !GLib.unichar_isprint(character))
+        if (!this._enabled || !GLib.unichar_isprint(character) ||
+            character == Main.paygManager.codeFormatPrefix ||
+            character == Main.paygManager.codeFormatSuffix)
             return;
 
         let pos = this.clutter_text.get_cursor_position();
@@ -241,8 +245,8 @@ var PaygUnlockDialog = GObject.registerClass({
         promptLabel.clutter_text.ellipsize = Pango.EllipsizeMode.NONE;
         promptBox.add_child(promptLabel);
 
-        this._entry = new PaygUnlockCodeEntry();
-        promptBox.add_child(this._entry);
+        let entryBox = this._createEntryArea();
+        promptBox.add_child(entryBox);
 
         this._errorMessage = new St.Label({ opacity: 0,
                                             styleClass: 'unlock-dialog-payg-message' });
@@ -371,6 +375,32 @@ var PaygUnlockDialog = GObject.registerClass({
         buttonsBox.add_child(this._nextButton);
 
         return buttonsBox;
+    }
+
+    _createEntryArea() {
+        let entryBox = new St.BoxLayout({ vertical: false,
+                                          x_expand: true,
+                                          x_align: Clutter.ActorAlign.FILL});
+
+        if (Main.paygManager.codeFormatPrefix != '') {
+            let prefix = new St.Label({ style_class: 'unlock-dialog-payg-code-entry',
+                                      text: Main.paygManager.codeFormatPrefix,
+                                      x_align: Clutter.ActorAlign.CENTER });
+
+            entryBox.add_child(prefix);
+        }
+
+        this._entry = new PaygUnlockCodeEntry();
+        entryBox.add_child(this._entry);
+
+        if (Main.paygManager.codeFormatSuffix != '') {
+            let suffix = new St.Label({ style_class: 'unlock-dialog-payg-code-entry',
+                                      text: Main.paygManager.codeFormatSuffix,
+                                      x_align: Clutter.ActorAlign.CENTER });
+            entryBox.add_child(suffix);
+        }
+
+        return entryBox;
     }
 
     _createMessageBox() {


### PR DESCRIPTION
Add a prefix and sufix characters for codes inserted on the
payg-unlock-screen, making it more user-friendly.

This is blocked on endlessm/eos-payg#44 and endlessm/eos-payg-nonfree#18

https://phabricator.endlessm.com/T25987