### PR TITLE
js: Make Shell responsive against app-fitler changes for current user

### DIFF
--- a/js/misc/parentalControlsManager.js
+++ b/js/misc/parentalControlsManager.js
@@ -60,8 +60,24 @@ var ParentalControlsManager = class {
                 logError(e, 'Failed to get parental controls settings');
             }
         }
+
+        this._manager.connect('app-filter-changed', (manager, uid) => {
+            let current_uid = Shell.util_get_uid();
+            // Emit 'changed' signal only if app-filter is changed for currently logged-in user.
+            if (current_uid == uid)
+                this._manager.get_app_filter_async(current_uid, Malcontent.GetAppFilterFlags.NONE,
+                                                   null, this._onAppFilterChanged.bind(this));
+        });
     }
 
+    _onAppFilterChanged(object, res) {
+        try {
+            this._appFilter = this._manager.get_app_filter_finish(res);
+            this.emit('changed');
+        } catch (e) {
+            logError(e, 'Failed to get new MctAppFilter for uid ' + Shell.util_get_uid() + ' on app-filter-changed');
+        }
+    }
     // Calculate whether the given app (a Gio.DesktopAppInfo) should be shown
     // on the desktop, in search results, etc. The app should be shown if:
     //  - The .desktop file doesn’t say it should be hidden.
@@ -88,3 +104,4 @@ var ParentalControlsManager = class {
         return this._appFilter.is_appinfo_allowed(appInfo);
     }
 };
+Signals.addSignalMethods(ParentalControlsManager.prototype);

--- a/js/ui/appDisplay.js
+++ b/js/ui/appDisplay.js
@@ -1268,6 +1268,9 @@ var FrequentView = class FrequentView extends BaseAppView {
         });
 
         this._parentalControlsManager = ParentalControlsManager.getDefault();
+        this._parentalControlsManager.connect('changed', () => {
+            this._redisplay();
+        });
     }
 
     hasUsefulData() {

--- a/js/ui/iconGridLayout.js
+++ b/js/ui/iconGridLayout.js
@@ -51,6 +51,11 @@ var IconGridLayout = GObject.registerClass({
         super._init();
 
         this._parentalControlsManager = ParentalControlsManager.getDefault();
+        this._parentalControlsManager.connect('changed', () => {
+            this._updateIconTree();
+            this.emit('changed');
+        });
+
         this._updateIconTree();
 
         this._removeUndone = false;

--- a/js/ui/search.js
+++ b/js/ui/search.js
@@ -414,6 +414,10 @@ var SearchResults = class {
         Util.blockClickEventsOnActor(this.actor);
 
         this._parentalControlsManager = ParentalControlsManager.getDefault();
+        this._parentalControlsManager.connect('changed', () => {
+            this._reloadInternetProviders();
+            this._reloadRemoteProviders();
+        });
 
         let closeIcon = new St.Icon({ icon_name: 'window-close-symbolic' });
         let closeButton = new St.Button({ name: 'searchResultsCloseButton',
@@ -495,6 +499,18 @@ var SearchResults = class {
             this._registerProvider(this._internetProvider);
 
         this._reloadRemoteProviders();
+    }
+
+    _reloadInternetProviders() {
+        if (this._internetProvider)
+            this._unregisterProvider(this._internetProvider);
+
+        // GNOME settings will take care of parentally controlling all web-browsers(T27064).
+        // Therefore, just reload the default InternetProvider at this given moment,
+        // to decide whether the InternetProvider's search results are to be shown or not.
+        this._internetProvider = InternetSearch.getInternetSearchProvider();
+        if (this._internetProvider)
+            this._registerProvider(this._internetProvider);
     }
 
     _reloadRemoteProviders() {


### PR DESCRIPTION
Hook up to "app-filter-changed" signal from malcontent and if the app
filter is changed for the currently logged in user, enforce the new
app filter in the shell. This is one of the main pieces for our feature work
in T26893.

https://phabricator.endlessm.com/T26969