### PR TITLE
eos-payg: Add prefix and suffix characters for the payg-tray

### DIFF
--- a/data/theme/gnome-shell-sass/_endless.scss
+++ b/data/theme/gnome-shell-sass/_endless.scss
@@ -1040,3 +1040,12 @@ $success_time_payg_color: #02b842;
   letter-spacing: 6px;
   margin: 5px;
 }
+
+.notification-payg-code-entry {
+  text-align: center;
+  font-size: 20px;
+  color: darken($osd_fg_color, 20%);
+  padding-left: 12px;
+  padding-right: 12px;
+  margin-top: 6px;
+}

--- a/js/ui/payg.js
+++ b/js/ui/payg.js
@@ -238,8 +238,25 @@ var PaygUnlockWidget = GObject.registerClass({
         this._spinner = this._createSpinner();
         let entrySpinnerBox = new St.BoxLayout({ style_class: 'notification-actions',
                                                  x_expand: false, });
+
+        if (Main.paygManager.codeFormatPrefix != '') {
+            let prefix = new St.Label({ style_class: 'notification-payg-code-entry',
+                                        text: Main.paygManager.codeFormatPrefix,
+                                        x_align: Clutter.ActorAlign.CENTER });
+
+            entrySpinnerBox.add_child(prefix);
+        }
+
         entrySpinnerBox.add_child(this._codeEntry);
         entrySpinnerBox.add_child(this._spinner.actor);
+
+        if (Main.paygManager.codeFormatSuffix != '') {
+            let suffix = new St.Label({ style_class: 'notification-payg-code-entry',
+                                        text: Main.paygManager.codeFormatSuffix,
+                                        x_align: Clutter.ActorAlign.CENTER });
+
+            entrySpinnerBox.add_child(suffix);
+        }
 
         this._buttonBox = new St.BoxLayout({ style_class: 'notification-actions',
                                                      x_expand: true,


### PR DESCRIPTION
https://phabricator.endlessm.com/T25988

This is blocked on the merge of https://github.com/endlessm/gnome-shell/pull/477