### PR TITLE
appActivation: Return value on launch invocation

### DIFF
--- a/js/ui/shellDBus.js
+++ b/js/ui/shellDBus.js
@@ -634,6 +634,7 @@ var AppLauncher = class {
         }
 
         activationContext.activate(null, timestamp);
+        invocation.return_value(null);
     }
 
     LaunchViaDBusCallAsync(params, invocation) {


### PR DESCRIPTION
All DBUS calls to this method raises a Timeout exception because the
launch method never returns anything to the invocation.

This patch fixes that problem returning null when the application is
activated.

https://phabricator.endlessm.com/T27234