### PR TITLE
fixup! passwordReset: Implement Endless-specific password reset feature

### DIFF
--- a/js/gdm/authPrompt.js
+++ b/js/gdm/authPrompt.js
@@ -1,6 +1,6 @@
 // -*- mode: js; js-indent-level: 4; indent-tabs-mode: nil -*-
 
-const { AccountsService, Clutter, GLib,
+const { AccountsService, Clutter, GLib, Gio,
         Pango, Polkit, Shell, St } = imports.gi;
 const ByteArray = imports.byteArray;
 const Signals = imports.signals;


### PR DESCRIPTION
Relevant error message inside journal:

Jul 10 20:19:09 endless gnome-shell[662]: JS ERROR: ReferenceError: Gio is not defined
                                          _maybeShowPasswordResetButton@resource:///org/gnome/shell/gdm/authPrompt.js:672:13
                                          _onVerificationFailed@resource:///org/gnome/shell/gdm/authPrompt.js:306:16
                                          _emit@resource:///org/gnome/gjs/modules/signals.js:142:27
                                          _verificationFailed@resource:///org/gnome/shell/gdm/util.js:561:9
                                          _onConversationStopped@resource:///org/gnome/shell/gdm/util.js:579:13

https://phabricator.endlessm.com/T27205