### PR TITLE
Hide splash/taskbar button when app is starting/blacklisted

### DIFF
--- a/js/ui/appActivation.js
+++ b/js/ui/appActivation.js
@@ -9,6 +9,7 @@ const Main = imports.ui.main;
 const Mainloop = imports.mainloop
 const Overview = imports.ui.overview;
 const Panel = imports.ui.panel;
+const ParentalControlsManager = imports.misc.parentalControlsManager;
 const Tweener = imports.ui.tweener;
 const Util = imports.misc.util;
 const WindowManager = imports.ui.windowManager;
@@ -47,7 +48,8 @@ function _shouldShowSplash(app) {
         Util.getBrowserApp().state != Shell.AppState.STOPPED)
         return false;
 
-    return true;
+    let parentalControlsManager = ParentalControlsManager.getDefault();
+    return parentalControlsManager.shouldShowApp(app.get_app_info());
 }
 
 var AppActivationContext = class {

--- a/js/ui/appIconBar.js
+++ b/js/ui/appIconBar.js
@@ -899,6 +899,12 @@ const ScrolledIconList = GObject.registerClass({
         let state = app.state;
         switch(state) {
         case Shell.AppState.STARTING:
+            if (!this._parentalControlsManager.shouldShowApp(app.get_app_info()))
+                break;
+            this._addButton(app);
+            this._ensureIsVisible(app);
+            break;
+
         case Shell.AppState.RUNNING:
             this._addButton(app);
             this._ensureIsVisible(app);


### PR DESCRIPTION
Changes include:
- Do not show splash/speedwagon if app is blacklisted
- Do not show taskbar button if app is starting and blacklisted

Signed-off-by: Andre Moreira Magalhaes <andre@endlessm.com>
    
https://phabricator.endlessm.com/T26990
