### PR TITLE
workspace: Protect against NULL apps

### DIFF
--- a/js/ui/workspace.js
+++ b/js/ui/workspace.js
@@ -594,6 +594,8 @@ var WindowOverlay = class {
 
         let tracker = Shell.WindowTracker.get_default();
         let app = tracker.get_window_app(metaWindow);
+        if (!app)
+            return '';
         return app.get_name();
     }
 


### PR DESCRIPTION
Under some (unknown) circumstances, Shell.WindowTracker's
get_window_app() method may return NULL. The code under
workspace.js is not robust against that. This is reproducible
with Minetest.

Check for a NULL app, and return an empty title when that's
the case, before trying to retrieve the app title.

https://phabricator.endlessm.com/T27263