### PR TITLE
appDisplay: Use AppIcon as HackAppIcon base class

### DIFF
--- a/js/ui/appDisplay.js
+++ b/js/ui/appDisplay.js
@@ -2787,17 +2787,16 @@ const HackAppIconState = {
 };
 
 var HackAppIcon = GObject.registerClass(
-class HackAppIcon extends ViewIcon {
+class HackAppIcon extends AppIcon {
     _init(parentView) {
         let viewIconParams = { isDraggable: false,
                                showMenu: false,
                                parentView: parentView };
 
-        let buttonParams = { button_mask: St.ButtonMask.ONE | St.ButtonMask.TWO };
         let iconParams = { createIcon: this._createIcon.bind(this) };
+        let app = Clubhouse.getClubhouseApp();
 
-
-        super._init(viewIconParams, buttonParams, iconParams);
+        super._init(app, viewIconParams, iconParams);
 
         let activated = global.settings.get_boolean('hack-mode-enabled');
         this.iconState = activated ? HackAppIconState.ACTIVATED : HackAppIconState.DEACTIVATED;
@@ -2808,12 +2807,6 @@ class HackAppIcon extends ViewIcon {
         });
 
         this.canDrop = false;
-
-        this._iconContainer = new St.Widget({ layout_manager: new Clutter.BinLayout(),
-                                              x_expand: true, y_expand: true });
-        this._iconContainer.add_child(this.icon.actor);
-
-        this.actor.set_child(this._iconContainer);
     }
 
     _createIcon(iconSize) {
@@ -2832,28 +2825,17 @@ class HackAppIcon extends ViewIcon {
         return false;
     }
 
-    activate(button) {
-        // launch clubhouse, the clubhouse is reponsible to set the
-        // hack-mode-enabled key to true on the first launch
-        const component = Main.componentManager._ensureComponent('clubhouse');
-        if (!component) {
-            logError('Clubhouse component not found.');
-            return;
-        }
-        component.callShow();
-        this.icon.animateZoomOut();
-    }
-
     getName() {
         return 'Hack';
     }
 
     getId() {
-        return 'com.endlessm.Hack';
+        return 'com.endlessm.Clubhouse';
     }
 
     _onDestroy() {
         if (this._hackModeId)
             global.settings.disconnect(this._hackModeId);
+        super._onDestroy();
     }
 });

--- a/js/ui/components/clubhouse.js
+++ b/js/ui/components/clubhouse.js
@@ -711,30 +711,6 @@ var Component = GObject.registerClass({
         return this._imageUsesClubhouse() && !!getClubhouseApp();
     }
 
-    _ensureProxy() {
-        if (this.proxy)
-            return this.proxy;
-
-        const clubhouseInstalled = !!getClubhouseApp();
-        if (!clubhouseInstalled) {
-            log('Cannot construct Clubhouse proxy because Clubhouse app was not found.');
-        } else {
-            try {
-                this.proxy = new Gio.DBusProxy({ g_connection: Gio.DBus.session,
-                                            g_interface_name: this._proxyInfo.name,
-                                            g_interface_info: this._proxyInfo,
-                                            g_name: this._proxyName,
-                                            g_object_path: this._proxyPath,
-                                            g_flags: this.proxyConstructFlags });
-                this.proxy.init(null);
-                return this.proxy;
-            } catch (e) {
-                logError(e, 'Error while constructing the DBus proxy for ' + this._proxyName);
-            }
-        }
-        return null;
-    }
-
     enable() {
         if (!this._useClubhouse) {
             log('Cannot enable Clubhouse in this image version');
@@ -772,7 +748,7 @@ var Component = GObject.registerClass({
     }
 
     callShow(timestamp) {
-        if (this._ensureProxy() && this.proxy.g_name_owner) {
+        if (this.proxy.g_name_owner) {
             this.proxy.showRemote(timestamp);
             return;
         }


### PR DESCRIPTION
The HackAppIcon is only for launch the clubhouse, so we can use the
AppIcon base class and only override the icon itself.

This should fix the rare behaviour with the show/hide of the window
because it calls the app activation directly.

Unfortunately, this will bring back the spinning cursor problem with the
launch, but that problem is a minor issue and the show/hide problem is a
bigger problem right now. The solution was a workaround in the meantime the
cursor problem is solved, so we should wait until we solve the real
cursor problem.

https://phabricator.endlessm.com/T27357