### PR TITLE
codeView: Don't show FtH button when clubhouse isn't installed

### DIFF
--- a/js/ui/codeView.js
+++ b/js/ui/codeView.js
@@ -5,6 +5,7 @@ const Mainloop = imports.mainloop;
 
 const Animation = imports.ui.animation.Animation;
 const AppActivation = imports.ui.appActivation;
+const Clubhouse = imports.ui.components.clubhouse;
 const Main = imports.ui.main;
 const Params = imports.misc.params;
 const Soundable = imports.ui.soundable;
@@ -1462,7 +1463,7 @@ var CodeViewManager = GObject.registerClass({
         if (this._stopped)
             return false;
 
-        if (!global.settings.get_boolean('hack-mode-enabled'))
+        if (!global.settings.get_boolean('hack-mode-enabled') || !Clubhouse.getClubhouseApp())
             return false;
 
         // Do not manage apps that don't have an associated .desktop file


### PR DESCRIPTION
If you've the hack mode enabled and you uninstall the clubhouse, the
hack-mode-enabled continue being true and in this case we should not
show the Flip to Hack button in any case.

https://phabricator.endlessm.com/T27420

GNOME rebase note:

This can be squashed with the following commit in the next shell rebase:
codeView: Add codeview to provide Flip to Hack (b5ad90504)