### PR TITLE
Hack2 deploy: rename hack apps

### DIFF
--- a/js/misc/soundServer.js
+++ b/js/misc/soundServer.js
@@ -4,7 +4,7 @@ const {Gio} = imports.gi;
 
 const SoundServerIface = `
 <node>
-  <interface name='com.endlessm.HackSoundServer'>
+  <interface name='com.hack_computer.HackSoundServer'>
     <method name='PlaySound'>
       <arg type='s' name='sound_event' direction='in'/>
       <arg type='s' name='uuid' direction='out'/>
@@ -85,7 +85,7 @@ var SoundItem = class {
 class SoundServer {
     constructor() {
         this._proxy = new SoundServerProxy(Gio.DBus.session,
-            'com.endlessm.HackSoundServer', '/com/endlessm/HackSoundServer');
+            'com.hack_computer.HackSoundServer', '/com/hack_computer/HackSoundServer');
     }
 
     // Most common use case, fire and forget, no return value

--- a/js/ui/appDisplay.js
+++ b/js/ui/appDisplay.js
@@ -2831,7 +2831,7 @@ class HackAppIcon extends AppIcon {
     }
 
     getId() {
-        return 'com.endlessm.Clubhouse';
+        return 'com.hack_computer.Clubhouse';
     }
 
     _onDestroy() {

--- a/js/ui/codeView.js
+++ b/js/ui/codeView.js
@@ -91,7 +91,7 @@ const _ensureHackDataFile = (function () {
         GLib.build_filenamev([GLib.get_home_dir(), '.local/share/flatpak']),
         '/var/lib/flatpak',
     ];
-    const flatpakPath = 'app/com.endlessm.Clubhouse/current/active/files';
+    const flatpakPath = 'app/com.hack_computer.Clubhouse/current/active/files';
     const fileRelPath = 'share/hack-components';
     const searchPaths = flatpakInstallationPaths.map(installation =>
         GLib.build_filenamev([installation, flatpakPath, fileRelPath]));
@@ -458,8 +458,8 @@ var CodingSession = GObject.registerClass({
         // arbitrary toolboxes in the future, depending on the application
         this._toolboxAppActionGroup =
             Gio.DBusActionGroup.get(Gio.DBus.session,
-                                    'com.endlessm.HackToolbox',
-                                    '/com/endlessm/HackToolbox');
+                                    'com.hack_computer.HackToolbox',
+                                    '/com/hack_computer/HackToolbox');
         this._toolboxAppActionGroup.list_actions();
 
         this._hackModeChangedId = global.settings.connect('changed::hack-mode-enabled',
@@ -1480,10 +1480,10 @@ var CodeViewManager = GObject.registerClass({
         if (appInfo.has_key(_HACKABLE_DESKTOP_KEY)) {
             if (!appInfo.get_boolean(_HACKABLE_DESKTOP_KEY))
                 return false;
-        // HackUnlock and HackToolbox are inside the com.endlessm.Clubhouse flatpak
+        // HackUnlock and HackToolbox are inside the com.hack_computer.Clubhouse flatpak
         // and have the Clubhouse appInfo, so we should ignore those cases here
         // to be able to show the HackUnlock and HackToolbox windows
-        } else if (gtkId !== 'com.endlessm.HackUnlock' && gtkId !== 'com.endlessm.HackToolbox') {
+        } else if (gtkId !== 'com.hack_computer.HackUnlock' && gtkId !== 'com.hack_computer.HackToolbox') {
             // Do not manage apps that are NoDisplay=true
             if (!appInfo.should_show())
                 return false;

--- a/js/ui/components/clubhouse.js
+++ b/js/ui/components/clubhouse.js
@@ -39,12 +39,12 @@ const GtkNotificationDaemon = NotificationDaemon.GtkNotificationDaemon;
 const CLUBHOUSE_BANNER_TIMEOUT_MSEC = 3000;
 const CLUBHOUSE_BANNER_ANIMATION_TIME = 0.2;
 
-var CLUBHOUSE_ID = 'com.endlessm.Clubhouse';
-const CLUBHOUSE_DBUS_OBJ_PATH = '/com/endlessm/Clubhouse';
+var CLUBHOUSE_ID = 'com.hack_computer.Clubhouse';
+const CLUBHOUSE_DBUS_OBJ_PATH = '/com/hack_computer/Clubhouse';
 
 const ClubhouseIface =
 '<node> \
-  <interface name="com.endlessm.Clubhouse"> \
+  <interface name="com.hack_computer.Clubhouse"> \
     <method name="show"> \
       <arg type="u" direction="in" name="timestamp"/> \
     </method> \

--- a/src/shell-window-tracker.c
+++ b/src/shell-window-tracker.c
@@ -393,7 +393,7 @@ maybe_find_target_app_for_toolbox (ShellWindowTracker  *tracker,
                                          NULL,
                                          window_app_id,
                                          window_object_path,
-                                         "com.endlessm.HackToolbox.Toolbox",
+                                         "com.hack_computer.HackToolbox.Toolbox",
                                          NULL,
                                          &local_error);
 


### PR DESCRIPTION
Rename hack services and apps to com.hack_computer instead of
com.endlessm, this is the new prefix that we'll use

https://phabricator.endlessm.com/T27400