### PR TITLE
Don't crash on startup if saved notification data is corrupt

### DIFF
--- a/js/ui/notificationDaemon.js
+++ b/js/ui/notificationDaemon.js
@@ -730,7 +730,11 @@ var GtkNotificationDaemon = class GtkNotificationDaemon {
     constructor() {
         this._sources = {};
 
-        this._loadNotifications();
+        try {
+            this._loadNotifications();
+        } catch (e) {
+            logError(e, "Failed to load saved notifications");
+        }
 
         this._dbusImpl = Gio.DBusExportedObject.wrapJSObject(GtkNotificationsIface, this);
         this._dbusImpl.export(Gio.DBus.session, '/org/gtk/Notifications');

--- a/js/ui/notificationDaemon.js
+++ b/js/ui/notificationDaemon.js
@@ -761,29 +761,31 @@ var GtkNotificationDaemon = class GtkNotificationDaemon {
     _loadNotifications() {
         this._isLoading = true;
 
-        let value = global.get_persistent_state('a(sa(sv))', 'notifications');
-        if (value) {
-            let sources = value.deep_unpack();
-            sources.forEach(([appId, notifications]) => {
-                if (notifications.length == 0)
-                    return;
-
-                let source;
-                try {
-                    source = this._ensureAppSource(appId);
-                } catch(e) {
-                    if (e instanceof InvalidAppError)
+        try {
+            let value = global.get_persistent_state('a(sa(sv))', 'notifications');
+            if (value) {
+                let sources = value.deep_unpack();
+                sources.forEach(([appId, notifications]) => {
+                    if (notifications.length == 0)
                         return;
-                    throw e;
-                }
 
-                notifications.forEach(([notificationId, notification]) => {
-                    source.addNotification(notificationId, notification.deep_unpack(), false);
+                    let source;
+                    try {
+                        source = this._ensureAppSource(appId);
+                    } catch(e) {
+                        if (e instanceof InvalidAppError)
+                            return;
+                        throw e;
+                    }
+
+                    notifications.forEach(([notificationId, notification]) => {
+                        source.addNotification(notificationId, notification.deep_unpack(), false);
+                    });
                 });
-            });
+            }
+        } finally {
+            this._isLoading = false;
         }
-
-        this._isLoading = false;
     }
 
     _saveNotifications() {

--- a/src/shell-global.c
+++ b/src/shell-global.c
@@ -1651,7 +1651,7 @@ load_variant (GFile      *dir,
   else
     {
       GBytes *bytes = g_mapped_file_get_bytes (mfile);
-      res = g_variant_new_from_bytes (G_VARIANT_TYPE (property_type), bytes, TRUE);
+      res = g_variant_new_from_bytes (G_VARIANT_TYPE (property_type), bytes, FALSE);
       g_bytes_unref (bytes);
       g_mapped_file_unref (mfile);
     }


### PR DESCRIPTION
An Endless OS system was found in the wild with a malformed `.local/share/gnome-shell/notifications`. When deserialized in Python, after passing `trusted=True` to `g_variant_new_from_bytes()`, the first element of the first struct in the array looks like this:

    In [41]: _38.get_child_value(0).get_child_value(0)
    Out[41]: GLib.Variant('s',
    '\Uffffffff\Uffffffff\Uffffffff\Uffffffff\Uffffffff')

When deserialised in GJS, we get:

    gjs> v.get_child_value(0).get_child_value(0)
    [object variant of type "s"]
    gjs> v.get_child_value(0).get_child_value(0).get_string()
    typein:43:1 malformed UTF-8 character sequence at offset 0
     @typein:43:1
     @<stdin>:1:34

This branch addresses this problem on two fronts:

* Pass `trusted=FALSE` to `g_variant_new_from_bytes()`, as recommended by `g_variant_new_from_data()`'s documentation
* Handle exceptions from `_loadNotifications()`

I have tested this branch by copying `.local/share/gnome-shell/notifications` from the affected customer machine to my development VM. With just the changes to _loadNotifications(), I see the backtrace in the journal, but the shell comes up OK. With the additional change to pass `trusted=FALSE` to `g_variant_new_from_bytes()`, the journal is blissfully silent.

I don't have an explanation for how this file ended up being malformed. I also don't have an explanation for when this started crashing: my guess is that recent GJS became stricter about validating UTF-8 but I could be wrong!

https://phabricator.endlessm.com/T27153