### PR TITLE
background: Adjust to gnome-desktop API break

### DIFF
--- a/js/ui/background.js
+++ b/js/ui/background.js
@@ -617,7 +617,7 @@ var Animation = class Animation {
     }
 
     load(callback) {
-        this._show = new GnomeDesktop.BGSlideShow({ filename: this.file.get_path() });
+        this._show = new GnomeDesktop.BGSlideShow({ file: this.file });
 
         this._show.load_async(null, (object, result) => {
             this.loaded = true;


### PR DESCRIPTION
gnome-desktop broke API in commit ca5d61cf24, as it didn't *add* a property
as incorrectly stated in the commit message, but *replaced* an existing one.

https://gitlab.gnome.org/GNOME/gnome-shell/issues/1457

https://phabricator.endlessm.com/T27822