### PR TITLE
paygManager: Update iface for ImpendingShutdown signal

### DIFF
--- a/data/dbus-interfaces/com.endlessm.Payg1.xml
+++ b/data/dbus-interfaces/com.endlessm.Payg1.xml
@@ -6,6 +6,10 @@
     </method>
     <method name="ClearCode" />
     <signal name="Expired" />
+    <signal name="ImpendingShutdown">
+      <arg type="i" name="seconds_remaining"/>
+      <arg type="s" name="shutdown_reason"/>
+    </signal>
     <property name="ExpiryTime" type="t" access="read"/>
     <property name="Enabled" type="b" access="read"/>
     <property name="RateLimitEndTime" type="t" access="read"/>

--- a/js/misc/paygManager.js
+++ b/js/misc/paygManager.js
@@ -101,6 +101,7 @@ var PaygManager = GObject.registerClass({
         this._proxyInfo = Gio.DBusInterfaceInfo.new_for_xml(EOS_PAYG_IFACE);
 
         this._codeExpiredId = 0;
+        this._impendingShutdownId = 0;
         this._propertiesChangedId = 0;
         this._expirationReminderId = 0;
 
@@ -138,6 +139,7 @@ var PaygManager = GObject.registerClass({
 
             this._propertiesChangedId = this._proxy.connect('g-properties-changed', this._onPropertiesChanged.bind(this));
             this._codeExpiredId = this._proxy.connectSignal('Expired', this._onCodeExpired.bind(this));
+            this._impendingShutdownId = this._proxy.connectSignal('ImpendingShutdown', this._onImpendingShutdown.bind(this));
 
             this._maybeNotifyUser();
             this._updateExpirationReminders();
@@ -209,6 +211,10 @@ var PaygManager = GObject.registerClass({
     }
     _onCodeExpired(proxy) {
         this.emit('code-expired');
+    }
+
+    _onImpendingShutdown(proxy, sender, [secondsRemaining, shutdownReason]) {
+        // TODO notify the user https://phabricator.endlessm.com/T27134
     }
 
     _clockUpdated() {


### PR DESCRIPTION
eos-paygd now emits an ImpendingShutdown signal before initiating a
forced shutdown.[1] Update the D-Bus introspection with the new signal;
this will later be used to give the user warning of the shutdown.[2]

[1] https://github.com/endlessm/eos-payg/pull/65
[2] https://phabricator.endlessm.com/T27134

https://phabricator.endlessm.com/T27133