### PR TITLE
fixup! iconGridLayout: Add the Endless-specific class IconGridLayout

### DIFF
--- a/js/ui/iconGridLayout.js
+++ b/js/ui/iconGridLayout.js
@@ -298,12 +298,8 @@ var IconGridLayout = GObject.registerClass({
         if (interactive)
             Main.overview.setMessage(_("%s has been removed").format(info.get_name()),
                                      { forFeedback: true,
-                                       destroyCallback: (info) => {
-                                           this._onMessageDestroy (info);
-                                       },
-                                       undoCallback: (undoInfo) => {
-                                           this._undoRemoveItem(undoInfo);
-                                       },
+                                       destroyCallback: () => this._onMessageDestroy(info),
+                                       undoCallback: () => this._undoRemoveItem(info),
                                      });
         else
             this._onMessageDestroy(info);


### PR DESCRIPTION
When calling either the destroyCallback or the undoCallback,
Overview doesn't pass any arguments. However, the callbacks
passed by IconGridLayout were expecting an 'info' argument
that never came!

Remove these arguments and simplify the callbacks.

https://phabricator.endlessm.com/T28051