### PR TITLE
Hack: Fix clubhouse import

### DIFF
--- a/js/ui/appDisplay.js
+++ b/js/ui/appDisplay.js
@@ -2878,7 +2878,7 @@ class HackAppIcon extends AppIcon {
     }
 
     getId() {
-        return Clubhouse.CLUBHOUSE_ID;
+        return 'com.hack_computer.Clubhouse';
     }
 
     _onDestroy() {

--- a/js/ui/codeView.js
+++ b/js/ui/codeView.js
@@ -100,7 +100,7 @@ const _ensureHackDataFile = (function () {
         '/var/lib/flatpak',
     ];
 
-    const componentsId = Clubhouse.getClubhouseApp() ? Clubhouse.CLUBHOUSE_ID : 'com.endlessm.HackComponents';
+    const componentsId = Clubhouse.getClubhouseApp() ? 'com.hack_computer.Clubhouse' : 'com.endlessm.HackComponents';
     const flatpakPath = `app/${componentsId}/current/active/files`;
     const fileRelPath = 'share/hack-components';
     const searchPaths = flatpakInstallationPaths.map(installation =>

--- a/js/ui/components/clubhouse.js
+++ b/js/ui/components/clubhouse.js
@@ -38,7 +38,7 @@ const GtkNotificationDaemon = NotificationDaemon.GtkNotificationDaemon;
 
 const CLUBHOUSE_BANNER_ANIMATION_TIME = 0.2;
 
-var CLUBHOUSE_ID = 'com.hack_computer.Clubhouse';
+const CLUBHOUSE_ID = 'com.hack_computer.Clubhouse';
 const CLUBHOUSE_DBUS_OBJ_PATH = '/com/hack_computer/Clubhouse';
 const ClubhouseIface = loadInterfaceXML('com.hack_computer.Clubhouse');
 
@@ -57,7 +57,7 @@ function clipToMonitor(actor) {
     actor.set_clip(0, 0, clip, actor.height);
 }
 
-function getClubhouseApp(clubhouseId = CLUBHOUSE_ID) {
+function getClubhouseApp(clubhouseId = 'com.hack_computer.Clubhouse') {
     return Shell.AppSystem.get_default().lookup_app(clubhouseId + '.desktop');
 }
 

--- a/js/ui/components/clubhouse.js
+++ b/js/ui/components/clubhouse.js
@@ -38,7 +38,6 @@ const GtkNotificationDaemon = NotificationDaemon.GtkNotificationDaemon;
 
 const CLUBHOUSE_BANNER_ANIMATION_TIME = 0.2;
 
-const CLUBHOUSE_ID = 'com.hack_computer.Clubhouse';
 const CLUBHOUSE_DBUS_OBJ_PATH = '/com/hack_computer/Clubhouse';
 const ClubhouseIface = loadInterfaceXML('com.hack_computer.Clubhouse');
 
@@ -577,7 +576,7 @@ class ClubhouseNotificationSource extends NotificationDaemon.GtkNotificationDaem
 var Component = GObject.registerClass({
 }, class ClubhouseComponent extends SideComponent.SideComponent {
     _init(clubhouseIface, clubhouseId, clubhousePath) {
-        this._clubhouseId = clubhouseId || CLUBHOUSE_ID;
+        this._clubhouseId = clubhouseId || 'com.hack_computer.Clubhouse';
         this._clubhouseIface = clubhouseIface || ClubhouseIface;
         this._clubhousePath = clubhousePath || CLUBHOUSE_DBUS_OBJ_PATH;
 


### PR DESCRIPTION
The use of CLUBHOUSE_ID outside the clubhouse.js file was causing some
problems due to the javascript import and importing cycles, when the
getClubhouseApp function is called in the codeView.js file, the first
time, the CLUBHOUSE_ID is not set yet, so it's undefined and because of
that it's unable to check if the clubhouse is installed.

To fix this problem, this patch changes the use of CLUBHOUSE_ID with a
literal string. Another solution could be to move this id to a new file
to remove the importing cycles, but as we're using it two times, it's
easier to use the literal here.

https://phabricator.endlessm.com/T27778