### PR TITLE
Backport some leftovers from 3.34 rebase

### DIFF
--- a/js/misc/parentalControlsManager.js
+++ b/js/misc/parentalControlsManager.js
@@ -51,7 +51,7 @@ var ParentalControlsManager = class {
         this._manager = new Malcontent.Manager({connection: connection});
 
         try {
-            this._appFilter = this._manager.get_app_filter(Shell.util_get_uid (), Malcontent.GetAppFilterFlags.NONE, null, null);
+            this._appFilter = this._manager.get_app_filter(Shell.util_get_uid (), Malcontent.GetAppFilterFlags.NONE, null);
         } catch (e) {
             if (e.matches(Malcontent.AppFilterError, Malcontent.AppFilterError.DISABLED)) {
                 log('Parental controls globally disabled');

--- a/js/misc/parentalControlsManager.js
+++ b/js/misc/parentalControlsManager.js
@@ -60,8 +60,24 @@ var ParentalControlsManager = class {
                 logError(e, 'Failed to get parental controls settings');
             }
         }
+
+        this._manager.connect('app-filter-changed', (manager, uid) => {
+            let current_uid = Shell.util_get_uid();
+            // Emit 'changed' signal only if app-filter is changed for currently logged-in user.
+            if (current_uid == uid)
+                this._manager.get_app_filter_async(current_uid, Malcontent.GetAppFilterFlags.NONE,
+                                                   null, this._onAppFilterChanged.bind(this));
+        });
     }
 
+    _onAppFilterChanged(object, res) {
+        try {
+            this._appFilter = this._manager.get_app_filter_finish(res);
+            this.emit('changed');
+        } catch (e) {
+            logError(e, 'Failed to get new MctAppFilter for uid ' + Shell.util_get_uid() + ' on app-filter-changed');
+        }
+    }
     // Calculate whether the given app (a Gio.DesktopAppInfo) should be shown
     // on the desktop, in search results, etc. The app should be shown if:
     //  - The .desktop file doesn’t say it should be hidden.
@@ -88,3 +104,4 @@ var ParentalControlsManager = class {
         return this._appFilter.is_appinfo_allowed(appInfo);
     }
 };
+Signals.addSignalMethods(ParentalControlsManager.prototype);

--- a/js/ui/components/networkAgent.js
+++ b/js/ui/components/networkAgent.js
@@ -34,7 +34,7 @@ class NetworkSecretDialog extends ModalDialog.ModalDialog {
 
         this._inputSourceManager = Keyboard.getInputSourceManager();
         this._inputSourceIndicator = new Keyboard.InputSourceIndicator(this, false);
-        let manager = new PopupMenu.PopupMenuManager({ actor: this._inputSourceIndicator.container });
+        let manager = new PopupMenu.PopupMenuManager(this._inputSourceIndicator.container);
         manager.addMenu(this._inputSourceIndicator.menu);
         this._inputSourceManager.passwordModeEnabled = true;
 

--- a/js/ui/components/polkitAgent.js
+++ b/js/ui/components/polkitAgent.js
@@ -115,7 +115,7 @@ var AuthenticationDialog = GObject.registerClass({
         this._inputSourceManager = Keyboard.getInputSourceManager();
         this._inputSourceIndicator = new Keyboard.InputSourceIndicator(this, false);
         this._passwordBox.add(this._inputSourceIndicator.container);
-        let manager = new PopupMenu.PopupMenuManager({ actor: this._inputSourceIndicator.container });
+        let manager = new PopupMenu.PopupMenuManager(this._inputSourceIndicator.container);
         manager.addMenu(this._inputSourceIndicator.menu);
 
         this._workSpinner = new Animation.Spinner(WORK_SPINNER_ICON_SIZE, true);

--- a/js/ui/iconGridLayout.js
+++ b/js/ui/iconGridLayout.js
@@ -50,6 +50,11 @@ var IconGridLayout = GObject.registerClass({
         super._init();
 
         this._parentalControlsManager = ParentalControlsManager.getDefault();
+        this._parentalControlsManager.connect('changed', () => {
+            this._updateIconTree();
+            this.emit('changed');
+        });
+
         this._updateIconTree();
 
         this._removeUndone = false;

--- a/js/ui/search.js
+++ b/js/ui/search.js
@@ -454,6 +454,10 @@ var SearchResults = class {
         Util.blockClickEventsOnActor(this.actor);
 
         this._parentalControlsManager = ParentalControlsManager.getDefault();
+        this._parentalControlsManager.connect('changed', () => {
+            this._reloadInternetProviders();
+            this._reloadRemoteProviders();
+        });
 
         let closeIcon = new St.Icon({ icon_name: 'window-close-symbolic' });
         let closeButton = new St.Button({ name: 'searchResultsCloseButton',
@@ -529,6 +533,18 @@ var SearchResults = class {
             this._registerProvider(this._internetProvider);
 
         this._reloadRemoteProviders();
+    }
+
+    _reloadInternetProviders() {
+        if (this._internetProvider)
+            this._unregisterProvider(this._internetProvider);
+
+        // GNOME settings will take care of parentally controlling all web-browsers(T27064).
+        // Therefore, just reload the default InternetProvider at this given moment,
+        // to decide whether the InternetProvider's search results are to be shown or not.
+        this._internetProvider = InternetSearch.getInternetSearchProvider();
+        if (this._internetProvider)
+            this._registerProvider(this._internetProvider);
     }
 
     _reloadRemoteProviders() {

--- a/js/ui/shellMountOperation.js
+++ b/js/ui/shellMountOperation.js
@@ -377,7 +377,7 @@ var ShellMountPasswordDialog = GObject.registerClass({
         this._inputSourceManager = Keyboard.getInputSourceManager();
         this._inputSourceIndicator = new Keyboard.InputSourceIndicator(this, false);
         this._passwordBox.add(this._inputSourceIndicator.container);
-        let manager = new PopupMenu.PopupMenuManager({ actor: this._inputSourceIndicator.container });
+        let manager = new PopupMenu.PopupMenuManager(this._inputSourceIndicator.container);
         manager.addMenu(this._inputSourceIndicator.menu);
         this._inputSourceManager.passwordModeEnabled = true;
 


### PR DESCRIPTION
This PR contains a few patches that were present in 3.6 and got dropped on the 3.34 rebase. I tested and they seem to work fine.

This should fix the following issues:
- Respect parental controls settings for panel icons - https://phabricator.endlessm.com/T27191
- A fixup for parentalControlsManager fixing the call to `MalContent.Manager.get_app_filter()`
- Reload search providers when parental controls change
- Fix an issue with polkit dialogs not showing up (e.g. Clicking `unlock` in the User settings)

https://phabricator.endlessm.com/T27795