### PR TITLE
codeView: move hack-data.ini search paths to the function

### DIFF
--- a/js/ui/codeView.js
+++ b/js/ui/codeView.js
@@ -103,15 +103,15 @@ const _ensureHackDataFile = (function () {
         '/var/lib/flatpak',
     ];
 
-    const componentsId = Clubhouse.getClubhouseApp() ? 'com.hack_computer.Clubhouse' : 'com.endlessm.HackComponents';
-    const flatpakPath = `app/${componentsId}/current/active/files`;
-    const fileRelPath = 'share/hack-components';
-    const searchPaths = flatpakInstallationPaths.map(installation =>
-        GLib.build_filenamev([installation, flatpakPath, fileRelPath]));
-
     return function() {
         if (initialized)
             return keyfile;
+
+        const componentsId = Clubhouse.getClubhouseApp() ? 'com.hack_computer.Clubhouse' : 'com.endlessm.HackComponents';
+        const flatpakPath = `app/${componentsId}/current/active/files`;
+        const fileRelPath = 'share/hack-components';
+        const searchPaths = flatpakInstallationPaths.map(installation =>
+            GLib.build_filenamev([installation, flatpakPath, fileRelPath]));
 
         // Only create file monitors the first time
         if (monitors.length === 0) {


### PR DESCRIPTION
The hack-data.ini search paths was calculated in the function creation
so if the clubhouse is not installed, the path will be incorrect and the
keyfile can't be found.

If the user installs the clubhouse, every following call will use that
null keyfile that will cause the problem of the FtH in every window.

This patch moves the search paths calculation to the function returned
to solve this problem and be resilent to clubhouse
installation/uninstallation.

https://phabricator.endlessm.com/T28218