### PR TITLE
Fix force quit dialog

### DIFF
--- a/data/theme/gnome-shell-sass/_endless.scss
+++ b/data/theme/gnome-shell-sass/_endless.scss
@@ -66,7 +66,10 @@
                 spacing: 16px;
                 border-bottom-width: 1px;
                 &:hover { background-color: rgba(255,255,255,0.1); }
-                &:selected { background-color: #333; }
+                &:selected {
+                    background-color: $selected_bg_color;
+                    color: $selected_fg_color;
+                }
             }
         }
     }

--- a/data/theme/gnome-shell-sass/_endless.scss
+++ b/data/theme/gnome-shell-sass/_endless.scss
@@ -41,7 +41,7 @@
     min-width: 470px;
     border: 1px solid rgba(238, 238, 236, 0.2);
 
-    .force-app-exit-dialog-content {
+    .modal-dialog-content-box {
         spacing: 20px;
         padding: 20px 17px;
 

--- a/js/ui/forceAppExitDialog.js
+++ b/js/ui/forceAppExitDialog.js
@@ -38,16 +38,15 @@ const ForceAppExitDialogItem = GObject.registerClass({
     }
 });
 
-var ForceAppExitDialog = class extends ModalDialog.ModalDialog {
-    constructor() {
-        super({ styleClass: 'force-app-exit-dialog' });
+var ForceAppExitDialog = GObject.registerClass(
+class ForceAppExitDialog extends ModalDialog.ModalDialog {
+    _init() {
+        super._init({ styleClass: 'force-app-exit-dialog' });
 
         let title = new St.Label({
             style_class: 'force-app-exit-dialog-header',
             text: _("Quit applications"),
         });
-
-        this.contentLayout.style_class = 'force-app-exit-dialog-content';
         this.contentLayout.add(title);
 
         let subtitle = new St.Label({
@@ -139,4 +138,4 @@ var ForceAppExitDialog = class extends ModalDialog.ModalDialog {
         if (this._selectedAppItem)
             this._selectedAppItem.add_style_pseudo_class('selected');
     }
-};
+});


### PR DESCRIPTION
Without either of these changes, hitting Ctrl+Alt+Del yields no dialog
and the following backtrace:

    JS ERROR: TypeError: this._launchSystemMonitor is undefined
    ForceAppExitDialog<@resource:///org/gnome/shell/ui/forceAppExitDialog.js:85:17
    _showForceAppExitDialog@resource:///org/gnome/shell/ui/windowManager.js:2607:22

I do not understand why none of the class's methods are accessible from
within constructor(), but all other subclasses of ModalDialog use the
pattern:

    var Foo = GObject.registerClass(
    class Foo extends extends ModalDialog.ModalDialog {
        _init() {
            super._init(...);

so follow that pattern here.

With that change alone, hitting Ctrl+Alt+Del shows a small, square,
empty dialog which cannot be dismissed. This appears to be due to this
assignment:

    this.contentLayout.style_class = 'force-app-exit-dialog-content';

In any case, the content layout already has its own style class so we
don't need to add our own – we can just refer to its existing style
class.

Without the second patch, the now-functional dialog looks like this when an app is selected:

![Screenshot from 2019-10-18 14-24-01](https://user-images.githubusercontent.com/86760/67097884-fba6dc00-f1b2-11e9-9282-b0a283f24623.png)

My eyesight is not good enough to spot that Firefox is selected. So I've added an extra patch to reuse the colours used for the network dialog:

![Screenshot from 2019-10-18 14-21-28](https://user-images.githubusercontent.com/86760/67097934-124d3300-f1b3-11e9-83d7-a96afca00e7b.png)

Here, Vim is selected and the mouse is over GIMP.

https://phabricator.endlessm.com/T28184