### PR TITLE
theme: Add style for icon grid

### DIFF
--- a/data/theme/gnome-shell-sass/_endless.scss
+++ b/data/theme/gnome-shell-sass/_endless.scss
@@ -468,6 +468,12 @@ popup-separator-menu-item {
     text-align: center;
 }
 
+.overview-icon-label {
+    text-shadow: black 0px 2px 2px;
+    border: none;
+    background-color: transparent;
+}
+
 .icon-grid {
     spacing: 10px;
     -shell-grid-horizontal-item-size: 118px;

--- a/js/ui/iconGrid.js
+++ b/js/ui/iconGrid.js
@@ -90,7 +90,10 @@ class BaseIcon extends St.Bin {
         this._layeredIcon.add_actor(shadow);
 
         if (params.showLabel) {
-            this.label = new St.Label({ text: label });
+            this.label = new St.Label({
+                text: label,
+                style_class: 'overview-icon-label',
+            });
             this.label.clutter_text.set({
                 x_align: Clutter.ActorAlign.CENTER,
                 y_align: Clutter.ActorAlign.CENTER,


### PR DESCRIPTION
This adds a slight shadow to the icons in the icon grid. This was
previously part of the "Editable Labels" feature which was dropped in
the GNOME 3.34 rebase, but this part needs to be preserved.

In the next rebase, this commit should be moved before commit 0590f9f6
("Implement the desktop search's results panel").

https://phabricator.endlessm.com/T28279