### PR TITLE
userMenu: Fix open user preferences on avatar click

### DIFF
--- a/js/ui/userMenu.js
+++ b/js/ui/userMenu.js
@@ -43,7 +43,7 @@ const UserAccountSection = class extends PopupMenu.PopupMenuSection {
 
         iconButton.connect('clicked', () => {
             if (Main.sessionMode.allowSettings)
-                this.userIconItem.activate();
+                this.userIconItem.activate(null);
         });
 
         this.userIconItem.connect('notify::sensitive', () => {


### PR DESCRIPTION
The activate signal requires a ClutterEvent object and the call is done
with no params, so it's undefined and this breaks the avatar button in
the user menu, giving this error in the log:

JS ERROR: Error: Wrong type undefined; boxed type ClutterEvent expected
activate@resource:///org/gnome/shell/ui/popupMenu.js:182:9
UserAccountSection</<@resource:///org/gnome/shell/ui/userMenu.js:46:17

This patch fixes this problem passing null as parameter.

https://phabricator.endlessm.com/T28203