### PR TITLE
appDisplay: Fix selectApp method

### DIFF
--- a/js/ui/appDisplay.js
+++ b/js/ui/appDisplay.js
@@ -1066,7 +1066,7 @@ var AppDisplay = class AppDisplay {
 
     selectApp(id) {
         this._showView();
-        this._allView.view.selectApp(id);
+        this._allView.selectApp(id);
     }
 
     adaptToSize(width, height) {


### PR DESCRIPTION
The AllView class has a direct method called selectApp and doesn't have
the view attribute, so this call should be done directly.

https://phabricator.endlessm.com/T28310