### PR TITLE
fixup! taskbar: Add the application icons taskbar and related style c…

### DIFF
--- a/js/ui/appIconBar.js
+++ b/js/ui/appIconBar.js
@@ -59,7 +59,10 @@ class WindowMenuItem extends PopupMenu.PopupBaseMenuItem {
         let maxH = (ratio > 1) ?
             PANEL_WINDOW_MENU_THUMBNAIL_SIZE / ratio : PANEL_WINDOW_MENU_THUMBNAIL_SIZE;
 
-        let clone = new Clutter.Clone({ source: windowActor.get_texture() });
+        let clone = new Clutter.Actor({
+            content: windowActor.get_texture(),
+            request_mode: Clutter.RequestMode.CONTENT_SIZE,
+        });
         let cloneW = clone.width;
         let cloneH = clone.height;
 


### PR DESCRIPTION
…hanges

MetaShapedTexture became a GObject subclass that implements
ClutterContent in GNOME 3.34. The preview code assumed that
MetaShapedTexture is a ClutterActor, breaking window previews.

We can actually remove the ClutterClone usage from WindowMenuItem
and make the window preview a plain ClutterActor with a
ClutterContent attached to it -- win / win! This theoretically
does not account for client subsurfaces, but that's fine since
X11 doesn't support subsurfaces anyway.

For GNOME 3.36, we'll have MetaWindowContent which will account
not only for subsurfaces, but also effects applied to the window
actors.

https://phabricator.endlessm.com/T28331