### PR TITLE
iconGrid: Adjust internal alignment of icon components in icon container

### DIFF
--- a/data/theme/gnome-shell-sass/_endless.scss
+++ b/data/theme/gnome-shell-sass/_endless.scss
@@ -469,6 +469,7 @@ popup-separator-menu-item {
 }
 
 .overview-icon-label {
+    height: 46px;
     text-shadow: black 0px 2px 2px;
     border: none;
     background-color: transparent;


### PR DESCRIPTION
Previously, icons were vertically centered within their bin layout.
However, the icon label may take up one or two lines, so that would mean
that icons were staggered vertically when icons with two-line labels
were next to icons with one-line labels.

This can be squashed with 36d607fc3fc1814a19cfab762a41481e74c9d439 on
the next rebase. It's not relevant to upstream since upstream icons only
have one line of text (which ellipsizes a lot less frequently since the
icons are larger.)

https://phabricator.endlessm.com/T28168