### PR TITLE
Hack: Set the custom icon on drag to HackAppIcon

### DIFF
--- a/js/ui/appDisplay.js
+++ b/js/ui/appDisplay.js
@@ -2748,6 +2748,10 @@ class HackAppIcon extends AppIcon {
         });
     }
 
+    getDragActor() {
+        return this._createIcon(this._iconSize);
+    }
+
     activate(button) {
         global.settings.set_boolean('hack-icon-pulse', false);
         super.activate(button);


### PR DESCRIPTION
This patch sets the custom icon that shows the hack state as drag actor,
by default it was using the Clubhouse icon that doesn't show the on/off
status.

https://phabricator.endlessm.com/T28375