### PR TITLE
T28152

### DIFF
--- a/js/ui/appDisplay.js
+++ b/js/ui/appDisplay.js
@@ -483,10 +483,10 @@ class AllViewContainer extends St.Widget {
 });
 
 var AllView = class AllView extends BaseAppView {
-    constructor() {
+    constructor(params = {}) {
         super({ usePagination: true },
               { minRows: EOS_DESKTOP_MIN_ROWS });
-        this.actor = new AllViewContainer(this._grid);
+        this.actor = new AllViewContainer(this._grid, params);
         this._scrollView = this.actor.scrollView;
         this._stack = this.actor.stack;
         this._stackBox = this.actor.stackBox;

--- a/js/ui/layout.js
+++ b/js/ui/layout.js
@@ -357,6 +357,8 @@ var LayoutManager = GObject.registerClass({
         if (!this._viewsClone)
             return;
 
+        this._viewsClone.show();
+
         // Don't unnecessarily tween the clone's saturation & opacity.
         if (this._viewsClone.opacity == targetOpacity && this._viewsClone.saturation == targetSaturation)
             return;

--- a/js/ui/viewSelector.js
+++ b/js/ui/viewSelector.js
@@ -594,25 +594,6 @@ class ViewsClone extends St.Widget {
                 );
             }
         });
-
-        let settings = Clutter.Settings.get_default();
-        settings.connect('notify::font-dpi', () => {
-            let overviewVisible = Main.layoutManager.overviewGroup.visible;
-            let saturationEnabled = this._saturation.enabled;
-
-            // Maybe because of the already known issue with FBO and ClutterClones,
-            // simply redrawing the overview group without assuring it is visible
-            // won't work. Clutter was supposed to do that, but it doesn't. The
-            // FBO, in this case, is introduced through the saturation effect.
-            this._saturation.enabled = false;
-            Main.layoutManager.overviewGroup.visible = true;
-
-            Main.layoutManager.overviewGroup.queue_redraw();
-
-            // Restore the previous states
-            Main.layoutManager.overviewGroup.visible = overviewVisible;
-            this._saturation.enabled = saturationEnabled;
-        });
     }
 
     _onGridAvailableSizeChanged(actor, width, height) {

--- a/js/ui/viewSelector.js
+++ b/js/ui/viewSelector.js
@@ -528,6 +528,8 @@ class ViewsClone extends St.Widget {
             null
         );
 
+        this._firstRelayout = false;
+
         layoutManager.connect('grid-available-size-changed',
             this._onGridAvailableSizeChanged.bind(this));
 
@@ -536,7 +538,8 @@ class ViewsClone extends St.Widget {
             x_expand: true,
             y_expand: true,
             reactive: false,
-            opacity: AppDisplay.EOS_ACTIVE_GRID_OPACITY,
+            visible: false,
+            opacity: 0,
         });
 
         Shell.util_set_hidden_from_pick(this, true);
@@ -577,6 +580,7 @@ class ViewsClone extends St.Widget {
             // clone saturation and opacity in the background as an override
             if (!this._forOverview &&
                 this._viewSelector.getActivePage() == ViewPage.APPS) {
+                this.show();
                 this.opacity = AppDisplay.EOS_ACTIVE_GRID_OPACITY;
                 this.saturation = AppDisplay.EOS_ACTIVE_GRID_SATURATION;
                 this.ease({
@@ -606,6 +610,18 @@ class ViewsClone extends St.Widget {
         let availHeight = box.y2 - box.y1;
 
         this._allViewClone.adaptToSize(availWidth, availHeight);
+
+        if (!this._firstRelayout &&
+            this.visible &&
+            this.opacity != 0 &&
+            this._viewSelector.getActivePage() == ViewPage.APPS) {
+
+            GLib.idle_add(GLib.PRIORITY_LOW, () => {
+                this._allViewClone.gridActor.queue_relayout();
+                return GLib.SOURCE_REMOVE;
+            });
+            this._firstRelayout = true;
+        }
     }
 
     set saturation(factor) {


### PR DESCRIPTION
From the first commit:

```
The problem is complicated, so please bear with us: during the 3.34 cycle,
Clutter received an optimization where hidden actors are not allocated
anymore. This caused a few problems in the app grid, which uses
ClutterClones for running the spring animation, so a fix was committed
to ClutterClone that makes it allocate the preferred size of the
source actor when necessary.

Fast-foward to Endless OS 3.7; we introduce the ViewsClone class which
contains a bunch of real actors, and a ClutterClone for the IconGrid.
The ViewsClone is shown when the real icon grid is hidden, thus hitting
that code path that allocates the preferred size of the icon grid. Turns
out, most of the time the preferred size won't match the allocation made
by ViewsDisplayLayout; in fact, it will be much bigger.

Enter ClutterOffscreenEffect. The dessaturation effect applied by the
ViewsClone class has one unfortunate side-effect: the actor pixels are
cached in the GPU as a texture. ClutterOffscreenEffect itself has an
optimization where, if the actor didn't itself redraw, it would use the
cached framebuffer to draw instead (this is the optimization path taken
when using offscreen-redirect).

Now connecting the dots: we're drawing the GPU-cached, offscreen-redirected
icon grid using ClutterClone's preferred size -- which is much larger than
what it *should* be.

In essence, this commit restructures ViewsClone so that it doesn't use an
actual ClutterClone internally. Instead, use a real icon grid, and hide it
from picking entirely.
```

https://phabricator.endlessm.com/T28152