### PR TITLE
fixup! js: Delay instantiation of IconGridLayout until it’s needed

### DIFF
--- a/js/ui/appDisplay.js
+++ b/js/ui/appDisplay.js
@@ -1909,6 +1909,8 @@ var RenameFolderMenu = class RenameFolderMenu extends PopupMenu.PopupMenu {
         super(source.actor, 0.5, St.Side.BOTTOM);
         this.actor.add_style_class_name('rename-folder-popup');
 
+        this._iconGridLayout = IconGridLayout.getDefault();
+
         // We want to keep the item hovered while the menu is up
         this.blockSourceEvents = true;
 


### PR DESCRIPTION
Fix the following issue:
  JS ERROR: TypeError: this._iconGridLayout is undefined
  RenameFolderMenu/<@resource:///org/gnome/shell/ui/appDisplay.js:1936:13
  activate@resource:///org/gnome/shell/ui/popupMenu.js:182:9
  _onButtonReleaseEvent@resource:///org/gnome/shell/ui/popupMenu.js:135:9

https://phabricator.endlessm.com/T28485