### PR TITLE
fixup! codeView: Add codeview to provide Flip to Hack

### DIFF
--- a/js/ui/codeView.js
+++ b/js/ui/codeView.js
@@ -559,6 +559,7 @@ var CodingSession = GObject.registerClass({
                     this._detachBackendWindow();
                     this._grabbed = false;
                     this._syncButtonVisibility();
+                    this._synchronizeButton(this._actorForCurrentState().meta_window);
                     return GLib.SOURCE_REMOVE;
                 });
         }


### PR DESCRIPTION
There is a problem with the Flip to hack button position when moving the window. The button position is synced with the window on movement, but during the movement the button is hidden and the `queue_relayout` call do nothing, so we need to call the `_synchronizeButton` method after the window movement to ensure that the button is placed correctly.

https://phabricator.endlessm.com/T28535