### PR TITLE
Fix bad layout of app icon right click menu

### DIFF
--- a/js/ui/appIconBar.js
+++ b/js/ui/appIconBar.js
@@ -289,7 +289,7 @@ const AppIconButton = GObject.registerClass({
 
         this._rightClickMenuManager = new PopupMenu.PopupMenuManager(this);
 
-        this._rightClickMenu = new PopupMenu.PopupMenu(this, 0.0, St.Side.TOP, 0);
+        this._rightClickMenu = new PopupMenu.PopupMenu(this, 0.0, St.Side.BOTTOM, 0);
         this._rightClickMenu.blockSourceEvents = true;
 
         if (allowsPinning) {


### PR DESCRIPTION
Not sure why the arrow was nonetheless drawn on the bottom despite it being specified on the top, but this is why the allocation of the menu items wasn't being calculated correctly.

https://phabricator.endlessm.com/T28471