### PR TITLE
allView: Ensure event blocker is reactive before popup is open

### DIFF
--- a/js/ui/appDisplay.js
+++ b/js/ui/appDisplay.js
@@ -778,6 +778,7 @@ var AllView = class AllView extends BaseAppView {
     openSpaceForPopup(item, side, nRows) {
         this._updateIconOpacities(true);
         this._displayingPopup = true;
+        this._eventBlocker.reactive = true;
         this._grid.openExtraSpace(item, side, nRows);
     }
 


### PR DESCRIPTION
The event blocker in AllView is responsible for stealing click events
from the icon grid and closing the folder popup. The event blocker is
kept unreactive when no folder popup is visible, and it's made reactive
as a response to the 'open-state-changed' signal.

Using this signal, though, is problematic. When opening an app folder,
the icon grid first opens space for the folder to fit in; during this
period, it's possible to click on another folder icon, and break the
icon grid state.

Make sure the event blocker is reactive immediately after clicking on
a folder icon.

Related: https://gitlab.gnome.org/GNOME/gnome-shell/issues/1470

Upstream: https://gitlab.gnome.org/GNOME/gnome-shell/merge_requests/816

https://phabricator.endlessm.com/T28173