### PR TITLE
Use g_desktop_app_info_get_string_list(); fix two broken .desktop files

### DIFF
--- a/data/eos-launch.desktop.in.in
+++ b/data/eos-launch.desktop.in.in
@@ -1,6 +1,6 @@
 [Desktop Entry]
-_Name=EOS Launch
-_Comment=Utility to launch EndlessOS applications
+Name=EOS Launch
+Comment=Utility to launch EndlessOS applications
 Exec=gjs @pkgdatadir@/eos-launch.js %U
 Categories=EndlessOS;Utility;Core;
 MimeType=x-scheme-handler/endlessm-app;

--- a/data/eos-link-feedback.desktop.in.in
+++ b/data/eos-link-feedback.desktop.in.in
@@ -1,10 +1,8 @@
 [Desktop Entry]
 Version=1.0
-_Name=Feedback
-_Comment=
+Name=Feedback
 Type=Application
 Exec=chromium-browser chrome-extension://fpmnjlkappdkncfmjefheaidpmbmfdfk/index.html#feedback
-Icon=
 Categories=Utility;
 NoDisplay=true
 X-Endless-LaunchMaximized=false


### PR DESCRIPTION
I noticed while telling @erikos about `X-Flatpak-RenamedFrom` (for https://github.com/endlessm/hack-toy-apps/pull/328) that the code that implements it predates [this merge request](https://gitlab.gnome.org/GNOME/glib/merge_requests/339) making it into a GLib release, and can now be simplified.

While working on simplifying it, I noticed that two of our downstream `.desktop` files use the old intltool syntax of prefixing translatable fields with `_`. gnome-shell now uses `xgettext` which doesn't work with this syntax; as a result, the installed versions of these `.desktop` files are missing these fields.

```
wjt@camille:~$ cat /usr/share/applications/eos-link-feedback.desktop 
[Desktop Entry]
Version=1.0
Type=Application
Exec=chromium-browser chrome-extension://fpmnjlkappdkncfmjefheaidpmbmfdfk/index.html#feedback
Icon=Categories=Utility;
NoDisplay=true
X-Endless-LaunchMaximized=false
wjt@camille:~$ cat /usr/share/applications/eos-launch.desktop
[Desktop Entry]
Exec=gjs /usr/share/gnome-shell/eos-launch.js %U
Categories=EndlessOS;Utility;Core;
MimeType=x-scheme-handler/endlessm-app;
Type=Application
NoDisplay=true
```

TODO:

- [x] Test the resulting package (I've compiled it but not run it)

https://phabricator.endlessm.com/T28603