### PR TITLE
fixup! viewsSelector: New ViewsClone class for desaturated versions o…

### DIFF
--- a/js/ui/viewSelector.js
+++ b/js/ui/viewSelector.js
@@ -504,6 +504,7 @@ class ViewsClone extends St.Widget {
         this._allViewClone = new AppDisplay.AllView({ allowScrolling: false }, {
             allowDnD: false,
         });
+        this._allViewClone.actor.style_class = 'all-apps all-apps-scroller';
         this._allViewClone._eventBlocker.visible = true;
 
         let discoveryFeedButton = DiscoveryFeedButton.maybeCreateInactiveButton();


### PR DESCRIPTION
…f the desktop

The ViewsClone is not properly really applying the same set of style properties
compared to the App Grid, which ends up removing pixels from the top padding of
the entry, which misaligns everything.

Fix that by applying the appropriate style classes.

https://phabricator.endlessm.com/T28547