### PR TITLE
fixup! clubhouse: Enable hack-mode for hack1 users

### DIFF
--- a/js/ui/components/clubhouse.js
+++ b/js/ui/components/clubhouse.js
@@ -653,7 +653,8 @@ function _migrateHack1() {
 
     // Only enable the first time, to allow the user to disable the hack mode
     try {
-        Gio.File.new_for_path('.hack1-migrated').create(Gio.FileCreateFlags.NONE, null);
+        const filePath = GLib.build_filenamev([GLib.get_user_config_dir(), '.hack1-migrated']);
+        Gio.File.new_for_path(filePath).create(Gio.FileCreateFlags.NONE, null);
         global.settings.set_boolean('hack-mode-enabled', true);
         log('Hack 1 migration: enabled hack mode and created indicator file');
     } catch (e) {


### PR DESCRIPTION
https://phabricator.endlessm.com/T28649

This commit place the flag file inside the user config dir instead of the default path.

This fixup is a follow up of this PR:
https://github.com/endlessm/gnome-shell/pull/594#pullrequestreview-319803683