### PR TITLE
clubhouse: Update CSS to have transparent banner

### DIFF
--- a/data/theme/gnome-shell-sass/_endless.scss
+++ b/data/theme/gnome-shell-sass/_endless.scss
@@ -815,7 +815,7 @@ $clubhouse_button_color_d: #2D9B98;
   background-color: transparent;
   width: $clubhouse-notification-width + 25px;
   border: none;
-  &:hover, &:focus {
+  &:hover, &:focus, &:active {
     background-color: transparent;
   }
   .clubhouse-notification-close-button {


### PR DESCRIPTION
The CSS of the notification-banner class changed in common.scss.

https://phabricator.endlessm.com/T28614