### PR TITLE
fixup! appDisplay: Add the App Center icon to the grid

### DIFF
--- a/js/ui/appDisplay.js
+++ b/js/ui/appDisplay.js
@@ -2674,6 +2674,7 @@ class AppCenterIcon extends AppIcon {
 
         this._id = EOS_APP_CENTER_ID;
         this._name = this.app.get_generic_name();
+        this.icon.label.text = this.name;
     }
 
     _onDragBegin() {


### PR DESCRIPTION
We want the app center icon to read “More Apps”, not “App Center” (or,
heaven forbid, “Software”). Previously, this was set as the GenericName
in our gnome-software's .desktop file, and this custom icon class
attempted to use that as its name.

However, this regressed in the 3.34 rebase. The problem is that
assigning to this._name after chaining up to AppIcon._init() is too
late: AppIcon._init() sets this._name to the non-generic name, then in
turn chains up to ViewIcon._init() which accesses this.name (defined by
AppIcon to return this._name). After a drag, the label for the icon is
correctly re-set to the app center's GenericName.

Fix this by explicitly re-setting the icon's label at the end of
_init(), similarly to how it is re-set after a drag.

Alternative approach to
https://github.com/endlessm/gnome-shell/pull/603.

https://phabricator.endlessm.com/T28817