### PR TITLE
T28153

### DIFF
--- a/js/ui/iconGrid.js
+++ b/js/ui/iconGrid.js
@@ -1222,7 +1222,7 @@ var PaginatedIconGrid = GObject.registerClass({
         // As a temporary solution for now, let's assume that the folder
         // will be closed after EXTRA_SPACE_ANIMATION_TIME and reset the
         // status + emit the space-closed signal only once at that point.
-        GLib.timeout_add_seconds(
+        GLib.timeout_add(
             GLib.PRIORITY_DEFAULT,
             EXTRA_SPACE_ANIMATION_TIME * St.Settings.get().slow_down_factor,
             () => {


### PR DESCRIPTION
With the move to Clutter implicit animations, the duration of animations
is now measured in milisseconds rather than Tweener's seconds. That means
EXTRA_SPACE_ANIMATION_TIME is now 250 (ms) instead of 0.25 (s).

We're using EXTRA_SPACE_ANIMATION_TIME to call GLib.timeout_add_seconds(),
which means every time a folder popup is closed, we wait 250 seconds!

Fix that by using GLib.timeout_add() instead, which takes milisseconds as
input.

https://phabricator.endlessm.com/T28153