### PR TITLE
clubhouse: Fix vertical aligment of label notification

### DIFF
--- a/data/theme/gnome-shell-sass/_endless.scss
+++ b/data/theme/gnome-shell-sass/_endless.scss
@@ -820,6 +820,9 @@ $clubhouse_action_buttons_color_active: #44D7B6;
   &:hover, &:focus, &:active {
     background-color: transparent;
   }
+  &.with-buttons .clubhouse-notification-label {
+      margin-bottom: 30px;
+  }
   .clubhouse-notification-close-button {
     color: $clubhouse_action_buttons_color;
     padding: 9px 5px 0 0;
@@ -928,7 +931,7 @@ $clubhouse_action_buttons_color_active: #44D7B6;
   .clubhouse-notification-label {
     color: black;
     margin-left: 30px;
-    margin-bottom: 30px;
+    margin-bottom: 25px;
     width: ($clubhouse-notification-width - $clubhouse-image-width - 30px);
     font: 18px "Metropolis Medium, Sans-Serif";
   }

--- a/js/ui/components/clubhouse.js
+++ b/js/ui/components/clubhouse.js
@@ -396,8 +396,12 @@ class ClubhouseNotificationBanner extends MessageTray.NotificationBanner {
     }
 
     _updateButtonsCss() {
-        if (!this._buttonBox)
+        if (!this._buttonBox || this._buttonBox.get_children().length == 0) {
+            this.actor.remove_style_class_name('with-buttons');
             return;
+        }
+
+        this.actor.add_style_class_name('with-buttons');
 
         // @todo: This is a workaround for the missing CSS selector, :nth-child
         // Upstream issue: https://gitlab.gnome.org/GNOME/gnome-shell/issues/1800


### PR DESCRIPTION
The label bottom margin changed in commit 76bd3e84 from 25px to 30px
to consider the buttons below. But when there are no buttons, the text
looks misaligned.

https://phabricator.endlessm.com/T29046