### PR TITLE
appDisplay: Temporarily disable "Remove from desktop" action for folders

### DIFF
--- a/js/ui/appDisplay.js
+++ b/js/ui/appDisplay.js
@@ -1988,13 +1988,6 @@ var RenameFolderMenu = class RenameFolderMenu extends PopupMenu.PopupMenu {
         let separator = new PopupMenu.PopupSeparatorMenuItem();
         this.addMenuItem(separator);
 
-        // Add the "Remove from desktop" menu item at the end.
-        let item = new PopupMenu.PopupMenuItem(_("Remove from desktop"));
-        this.addMenuItem(item);
-        item.connect('activate', () => {
-            this._iconGridLayout.removeIcon(source.id, true);
-        });
-
         Main.uiGroup.add_actor(this.actor);
     }
 };


### PR DESCRIPTION
Right now removing a folder from desktop works but there is no way to
undo the action as is done for non-folder icons.
Given that individual icons can still be removed from a folder and
that the folder gets deleted once the last icon is removed (and
recreated if we undo the removal of the last icon) lets remove this
option for folders for now to avoid confusing user trying to undo
the operation.

https://phabricator.endlessm.com/T29052