### PR TITLE
parentalControls: Update error domain to prevent crash

### DIFF
--- a/js/misc/parentalControlsManager.js
+++ b/js/misc/parentalControlsManager.js
@@ -53,7 +53,7 @@ var ParentalControlsManager = class {
         try {
             this._appFilter = this._manager.get_app_filter(Shell.util_get_uid (), Malcontent.GetAppFilterFlags.NONE, null);
         } catch (e) {
-            if (e.matches(Malcontent.AppFilterError, Malcontent.AppFilterError.DISABLED)) {
+            if (e.matches(Malcontent.ManagerError, Malcontent.ManagerError.DISABLED)) {
                 log('Parental controls globally disabled');
                 this._disabled = true;
             } else {


### PR DESCRIPTION
In libmalcontent, MctAppFilterError was renamed to MctManagerError:
https://github.com/endlessm/malcontent/commit/300b5a624f8afde8d3ba250f5b6ff8912d0baa50

That commit includes compatibility defines, but evidently those aren't
working as intended, because gnome-shell is crashing in the latest
master ostree build with this:

Jan 22 15:01:55 endless gnome-shell[4252]: Getting parental controls for user 110
Jan 22 15:01:55 endless gnome-shell[4252]: JS WARNING: [resource:///org/gnome/shell/misc/parentalControlsManager.js 54]: reference to undefined property "GetAppFilterFlags"
Jan 22 15:01:55 endless gnome-shell[4252]: JS ERROR: TypeError: Malcontent.AppFilterError is undefined
                                           ParentalControlsManager<@resource:///org/gnome/shell/misc/parentalControlsManager.js:56:1
                                           getDefault@resource:///org/gnome/shell/misc/parentalControlsManager.js:33:22
                                           start@resource:///org/gnome/shell/ui/main.js:154:5
                                           @<main>:1:31
Jan 22 15:01:55 endless gnome-shell[4252]: Execution of main.js threw exception: Script <main> threw an exception
Jan 22 15:01:55 endless systemd[4028]: gnome-shell-x11.service: Failed with result 'protocol'.
Jan 22 15:01:55 endless systemd[4028]: Failed to start GNOME Shell on X11.

So update the error domain so things work again.