### PR TITLE
parentalControls: Update filter flags domain to prevent having all apps blacklisted

### DIFF
--- a/js/misc/parentalControlsManager.js
+++ b/js/misc/parentalControlsManager.js
@@ -51,7 +51,7 @@ var ParentalControlsManager = class {
         this._manager = new Malcontent.Manager({connection: connection});
 
         try {
-            this._appFilter = this._manager.get_app_filter(Shell.util_get_uid (), Malcontent.GetAppFilterFlags.NONE, null);
+            this._appFilter = this._manager.get_app_filter(Shell.util_get_uid (), Malcontent.ManagerGetValueFlags.NONE, null);
         } catch (e) {
             if (e.matches(Malcontent.ManagerError, Malcontent.ManagerError.DISABLED)) {
                 log('Parental controls globally disabled');
@@ -65,7 +65,7 @@ var ParentalControlsManager = class {
             let current_uid = Shell.util_get_uid();
             // Emit 'changed' signal only if app-filter is changed for currently logged-in user.
             if (current_uid == uid)
-                this._manager.get_app_filter_async(current_uid, Malcontent.GetAppFilterFlags.NONE,
+                this._manager.get_app_filter_async(current_uid, Malcontent.ManagerGetValueFlags.NONE,
                                                    null, this._onAppFilterChanged.bind(this));
         });
     }


### PR DESCRIPTION
As with commit 53f510b2, in recent libmalcontent, MctGetAppFilterFlags was also
renamed to MctManagerGetValueFlags:
https://github.com/endlessm/malcontent/commit/300b5a624f8afde8d3ba250f5b6ff8912d0baa50

That commit includes compatibility defines, but evidently those aren't
working as intended via GIR, because gnome-shell is considering all apps as blacklisted
in the latest master ostree build due to this:
```
Jan 22 22:58:08 endless-master gnome-shell[5152]: JS WARNING: [resource:///org/gnome/shell/misc/parentalControlsManager.js 68]: reference to undefined property "GetAppFilterFlags"
Jan 22 22:58:08 endless-master gnome-shell[5152]: JS ERROR: TypeError: Malcontent.GetAppFilterFlags is undefined
                                                  ParentalControlsManager</<@resource:///org/gnome/shell/misc/parentalControlsManager.js:68:17
Jan 22 22:58:09 endless-master gnome-shell[5152]: JS ERROR: TypeError: Malcontent.GetAppFilterFlags is undefined
                                                  ParentalControlsManager</<@resource:///org/gnome/shell/misc/parentalControlsManager.js:68:17
```

So update the flags to use the new type so things work again.

https://phabricator.endlessm.com/T28747