### PR TITLE
appDisplay: Continue loading icon grid even if an icon folder cant be loaded

### DIFF
--- a/js/ui/appDisplay.js
+++ b/js/ui/appDisplay.js
@@ -649,6 +649,10 @@ var AllView = class AllView extends BaseAppView {
             if (this._iconGridLayout.iconIsFolder(itemId)) {
                 if (!icon) {
                     let item = Shell.DesktopDirInfo.new(itemId);
+                    if (!item) {
+                        log(`Error loading folder for ${itemId}`);
+                        return;
+                    }
                     icon = new FolderIcon(item, this);
                 } else {
                     icon.update();


### PR DESCRIPTION
Loading an icon folder may fail if the user doesn't have access to the
corresponding `.directory` file or if the file doesn't exist.

https://phabricator.endlessm.com/T29205