### PR TITLE
fixup! appDisplay: Continue loading icon grid even if an icon folder cant be loaded

### DIFF
--- a/js/ui/appDisplay.js
+++ b/js/ui/appDisplay.js
@@ -651,6 +651,7 @@ var AllView = class AllView extends BaseAppView {
                     let item = Shell.DesktopDirInfo.new(itemId);
                     if (!item) {
                         log(`Error loading folder for ${itemId}`);
+                        this._iconGridLayout.removeIcon(itemId, false);
                         return;
                     }
                     icon = new FolderIcon(item, this);


### PR DESCRIPTION
Also remove folder from icon grid, otherwise it assumes the folder is visible and breaks state (e.g. when creating new folders by drag & drop).

The downside is that the user cannot (easily unless updating gsettings directly) restore the folder - for example by fixing wrong permissions - after restarting the shell, given the new layout will be saved without the folder.

https://phabricator.endlessm.com/T29205