### PR TITLE
Add eos-hack@endlessm.com extension

### DIFF
--- a/debian/endless-session-mods/endless.json
+++ b/debian/endless-session-mods/endless.json
@@ -1,4 +1,8 @@
 {
     "parentMode": "user",
-    "enabledExtensions": ["eos-watermark@endlessm.com", "ubuntu-appindicators@ubuntu.com"]
+    "enabledExtensions": [
+        "eos-hack@endlessm.com",
+        "eos-watermark@endlessm.com",
+        "ubuntu-appindicators@ubuntu.com"
+    ]
 }


### PR DESCRIPTION
Add the hack extension to the list of extensions of
the Endless session.

https://phabricator.endlessm.com/T28568

### NOTES

This PR depends on:
 * https://github.com/endlessm/gnome-shell/pull/630

And requires the eos-hack-extension to be installed to make it work the hack desktop icon: https://github.com/endlessm/eos-hack-extension

The current clubhouse doesn't work with the extension so to make it work we need to use the branch: https://github.com/endlessm/clubhouse/tree/hack-extension