### PR TITLE
payg: Properly init accountID menu item

### DIFF
--- a/js/ui/status/payg.js
+++ b/js/ui/status/payg.js
@@ -32,9 +32,6 @@ var Indicator = class extends PanelMenu.SystemIndicator {
         });
         this.menu.addMenuItem(this._item);
 
-        // Account ID
-        this._initializeAccountIDMenu();
-
         // show this status applet if PAYG is enabled and fill in
         // "determining time..." label and icon
         this._sync();
@@ -106,8 +103,6 @@ var Indicator = class extends PanelMenu.SystemIndicator {
         this._item.label.text = this._getTimeRemainingString();
         this._item.icon.gicon = this._getMenuGicon();
         this._indicator.gicon = this._item.icon.gicon;
-
-        this._initializeAccountIDMenu();
     }
 
     _updateTimeRemainingAndSyncWhenReady() {
@@ -117,6 +112,7 @@ var Indicator = class extends PanelMenu.SystemIndicator {
         } else {
             let paygManagerId = this._paygManager.connect('initialized', () => {
                 this._sync();
+                this._initializeAccountIDMenu();
                 this._paygManager.disconnect(paygManagerId);
             });
         }
@@ -127,8 +123,6 @@ var Indicator = class extends PanelMenu.SystemIndicator {
     // when the backend properly supports it.
     _initializeAccountIDMenu () {
         if (this._verifyValidAccountID ()) {
-            if (this._paygItem != null)
-                return;
             this._paygItem = new PopupMenu.PopupSubMenuMenuItem("", true);
             this._paygItem.setSensitive(false);
             this._paygItem.actor.visible = this._indicator.visible = this._paygManager.enabled;


### PR DESCRIPTION
Trying to update the accountID every time we synced the remaining
time made the weird behaviour of not properly populating it the
first time, discarding the rest of the runs. Now, we only add the
item on  the menu just once, after paygManager has been fully
initialized.

https://phabricator.endlessm.com/T28492