### PR TITLE
payg/automaticUpdates: Fix banner notification

### DIFF
--- a/js/ui/payg.js
+++ b/js/ui/payg.js
@@ -660,7 +660,8 @@ class PaygNotifier extends GObject.Object {
 
     notify(secondsLeft) {
         // Only notify when in an regular session, not in GDM or initial-setup.
-        if (Main.sessionMode.currentMode != 'user') {
+        if (Main.sessionMode.currentMode != 'user' &&
+            Main.sessionMode.currentMode != 'endless') {
             return;
         }
 

--- a/js/ui/screenShield.js
+++ b/js/ui/screenShield.js
@@ -1429,7 +1429,8 @@ var ScreenShield = class {
         // end up loging the screen for not regular sessions (e.g. initial-setup).
         let shouldLockForPayg = Main.paygManager.isLocked &&
             (Main.sessionMode.currentMode == 'user' ||
-             Main.sessionMode.currentMode == 'user-coding');
+             Main.sessionMode.currentMode == 'user-coding' ||
+             Main.sessionMode.currentMode == 'endless');
 
         if (!this._settings.get_boolean(LOCK_ENABLED_KEY) && !shouldLockForPayg)
             return;

--- a/js/ui/status/automaticUpdates.js
+++ b/js/ui/status/automaticUpdates.js
@@ -217,7 +217,8 @@ var Indicator = class extends PanelMenu.SystemIndicator {
     _updateNotification() {
         // Only notify when in an regular session, not in GDM or initial-setup.
         if (Main.sessionMode.currentMode != 'user' &&
-            Main.sessionMode.currentMode != 'user-coding') {
+            Main.sessionMode.currentMode != 'user-coding' &&
+            Main.sessionMode.currentMode != 'endless') {
             return;
         }
 


### PR DESCRIPTION
After https://phabricator.endlessm.com/T29401, the notification
banners emitted by the automaticUpdates and the payg classes didn't
work because they depended on an unexpected sessionMode. This fixes
that to the old behaviour.

https://phabricator.endlessm.com/T29582