### PR TITLE
General fixes

### DIFF
--- a/js/misc/config.js.in
+++ b/js/misc/config.js.in
@@ -22,3 +22,5 @@ var LIBMUTTER_API_VERSION = '@LIBMUTTER_API_VERSION@'
 var DATADIR = '@datadir@';
 /* used by the password reset feature */
 var PKGDATADIR = '@pkgdatadir@';
+/* used for the customer support feature and icon grid */
+var LOCALSTATEDIR = '@localstatedir@';

--- a/js/misc/ibusManager.js
+++ b/js/misc/ibusManager.js
@@ -66,7 +66,7 @@ var IBusManager = class {
             let display = GLib.getenv('GNOME_SETUP_DISPLAY');
             if (display)
                 launcher.setenv('DISPLAY', display, true);
-            launcher.launch(cmdLine);
+            launcher.spawnv(cmdLine);
         } catch (e) {
             log(`Failed to launch ibus-daemon: ${e.message}`);
         }

--- a/js/misc/ibusManager.js
+++ b/js/misc/ibusManager.js
@@ -61,7 +61,12 @@ var IBusManager = class {
     _spawn(extraArgs = []) {
         try {
             let cmdLine = ['ibus-daemon', '--panel', 'disable', ...extraArgs];
-            Gio.Subprocess.new(cmdLine, Gio.SubprocessFlags.NONE);
+            let launcher = Gio.SubprocessLauncher.new(Gio.SubprocessFlags.NONE);
+            // Forward the right X11 Display for ibus-x11
+            let display = GLib.getenv('GNOME_SETUP_DISPLAY');
+            if (display)
+                launcher.setenv('DISPLAY', display, true);
+            launcher.launch(cmdLine);
         } catch (e) {
             log(`Failed to launch ibus-daemon: ${e.message}`);
         }

--- a/js/misc/ibusManager.js
+++ b/js/misc/ibusManager.js
@@ -1,7 +1,7 @@
 // -*- mode: js; js-indent-level: 4; indent-tabs-mode: nil -*-
 /* exported getIBusManager */
 
-const { Gio, GLib, IBus } = imports.gi;
+const { Gio, GLib, IBus, Meta } = imports.gi;
 const Signals = imports.signals;
 
 const IBusCandidatePopup = imports.ui.ibusCandidatePopup;
@@ -55,7 +55,7 @@ var IBusManager = class {
         this._ibus.set_watch_ibus_signal(true);
         this._ibus.connect('global-engine-changed', this._engineChanged.bind(this));
 
-        this._spawn();
+        this._spawn(Meta.is_wayland_compositor() ? [] : ['--xim']);
     }
 
     _spawn(extraArgs = []) {


### PR DESCRIPTION
This cherry-picks some commits from latest upstream/master and fixes an issue with code trying to access Config.LOCALSTATEDIR that was dropped when removing the watermark extension.

https://phabricator.endlessm.com/T29580