### PR TITLE
fixup! bottomPanel: Add a shutdown button to the login screen

### DIFF
--- a/js/ui/panel.js
+++ b/js/ui/panel.js
@@ -837,7 +837,7 @@ class PopoverMenu extends PanelMenu.SingleIconButton {
         this.add_style_class_name('powermenu');
     }
 
-    _onEvent(actor, event) {
+    vfunc_event(event) {
         if (this.menu &&
             (event.type() == Clutter.EventType.TOUCH_BEGIN ||
              event.type() == Clutter.EventType.BUTTON_PRESS)) {


### PR DESCRIPTION
Commit 55b57421d replaced signal connections with vfunc calls which
means PanelMenu.Button no longer invokes the _onEvent callback when
clicked. Lets fix that by reimplementing the vfunc_event instead.

https://phabricator.endlessm.com/T29673