### PR TITLE
fixup! window-tracker: associate toolbox windows with target application

### DIFF
--- a/src/shell-window-tracker.c
+++ b/src/shell-window-tracker.c
@@ -375,13 +375,6 @@ maybe_find_target_app_for_toolbox (ShellWindowTracker  *tracker,
   g_autofree gchar *app_id_prefix = NULL;
   const gchar *hack_toolbox_id = HACK_TOOLBOX_ID;
 
-  /* If code view is disabled globally, do nothing here */
-  settings = shell_global_get_settings (shell_global_get ());
-  g_object_get (settings, "settings-schema", &schema, NULL);
-  if (!g_settings_schema_has_key (schema, "hack-mode-enabled") ||
-      !g_settings_get_boolean (settings, "hack-mode-enabled"))
-    return NULL;
-
   /* Check if there is a set application id and object path
    * on this window. If not, then it can't be a toolbox. */
   window_app_id = meta_window_get_gtk_application_id (window);


### PR DESCRIPTION
This patch removes the check to ensure that the hack mode is enabled
because that setting is not in the shell anymore. It was moved to the
extension.

We could try to use the shell extension dbus service to check if the hack
mode is enabled, but I think that it's not needed because it'll make the
code a bit complex and the performance improvement will not be great.
To do that we'll need to create a new dbus proxy and keep it alive, so it's
simpler and easier to just continue and try to create the toolbox proxy
for all windows even if the hack mode is disabled.

https://phabricator.endlessm.com/T28568