### PR TITLE
app-cache: Fix cache for folder translations

### DIFF
--- a/src/shell-app-cache.c
+++ b/src/shell-app-cache.c
@@ -109,11 +109,17 @@ load_folder (GHashTable *folders,
 
   while ((name = g_dir_read_name (dir)))
     {
+      g_autofree gchar *stripped_name = NULL;
       g_autofree gchar *filename = NULL;
       g_autoptr(GKeyFile) keyfile = NULL;
 
+      if (!g_str_has_suffix (name, ".directory"))
+        continue;
+
+      stripped_name = g_strndup (name, strlen (name) - strlen (".directory"));
+
       /* First added wins */
-      if (g_hash_table_contains (folders, name))
+      if (g_hash_table_contains (folders, stripped_name))
         continue;
 
       filename = g_build_filename (path, name, NULL);
@@ -128,7 +134,8 @@ load_folder (GHashTable *folders,
                                                      NULL, NULL);
 
           if (translated != NULL)
-            g_hash_table_insert (folders, g_strdup (name), translated);
+            g_hash_table_insert (folders, g_steal_pointer (&stripped_name),
+                                 translated);
         }
     }
 }


### PR DESCRIPTION
The app-cache code currently stores the folder translations in a hash
that can be accessed via shell_util_get_translated_folder_name().
This hash uses the filename (inc. extension) for the "desktop-directory"
as key which causes an issue when trying to find the translation
on AppDisplay._findBestFolderName() which gets categories (folder names)
from the app info which doesn't contain the ".directory" extension.

Fix that by storing the filename without extension as the hash key for
the cached folder translations.

https://gitlab.gnome.org/GNOME/gnome-shell/-/merge_requests/1168

https://phabricator.endlessm.com/T29690