### PR TITLE
Fix most input issues

### DIFF
--- a/js/ui/appDisplay.js
+++ b/js/ui/appDisplay.js
@@ -624,7 +624,6 @@ class AppDisplay extends BaseAppView {
                         return;
                     }
                     icon = new FolderIcon(item, this);
-                    icon.connect('clicked', () => this._bgAction.release());
                 } else {
                     icon.update();
                 }
@@ -637,7 +636,6 @@ class AppDisplay extends BaseAppView {
                 icon = new AppIcon(app, {
                     isDraggable: favoritesWritable,
                 });
-                icon.connect('clicked', () => this._bgAction.release());
             }
 
             appIcons.push(icon);

--- a/js/ui/appDisplay.js
+++ b/js/ui/appDisplay.js
@@ -493,7 +493,7 @@ class AppDisplay extends BaseAppView {
                 this._currentDialog.popdown();
         });
         Main.overview.addAction(this._clickAction, false);
-        this._eventBlocker.bind_property('visible', this._clickAction,
+        this._eventBlocker.bind_property('reactive', this._clickAction,
             'enabled', GObject.BindingFlags.SYNC_CREATE);
 
         this._bgAction = new Clutter.ClickAction();


### PR DESCRIPTION
This basically restores the old behaviour we had on 3.7 and most functionality works from my tests.

Some input issues still present with these changes:
- dragging an icon to an existing folder doesn't work
- sometimes (rarely) dragging icons on top of others won't work (i.e. won't create a folder)
- clicking and holding an icon show 2 menus (background and app context menu)
- dragging an icon outside a folder does nothing (it can be re-positioned inside a folder though)

https://phabricator.endlessm.com/T29682