### PR TITLE
st/icon: Only load default fallback icon if an icon was set and failed to load

### DIFF
--- a/src/st/st-icon.c
+++ b/src/st/st-icon.c
@@ -418,6 +418,9 @@ st_icon_update (StIcon *icon)
       priv->opacity_handler_id = 0;
     }
 
+  if (priv->gicon == NULL && priv->fallback_gicon == NULL)
+    return;
+
   if (!st_widget_get_resource_scale (ST_WIDGET (icon), &resource_scale))
     return;
 


### PR DESCRIPTION
Commit c89d6a633 introduced a default fallback icon that would be displayed in case the main gicon or the fallback gicon wasn't set or failed to load.
    
This broke the use case where a StIcon is created but no main icon or fallback icon are set on purpose, for example the appindicator extension which always creates a StIcon to represent icons in menu items but the actual icons are only set if the application provides one, leaving the menu showing the default fallback ("image-missing") icon for all menu entries that don't actually have an icon provided by the application.
    
Fix that by only using the default fallback icon if the provided one failed to load.
    
https://gitlab.gnome.org/GNOME/gnome-shell/-/merge_requests/1173

https://phabricator.endlessm.com/T29665