### PR TITLE
fixup! payg: Add a new screen to allow unlocking PAYG machines

### DIFF
--- a/js/ui/screenShield.js
+++ b/js/ui/screenShield.js
@@ -688,7 +688,8 @@ var ScreenShield = class {
         // end up loging the screen for not regular sessions (e.g. initial-setup).
         let shouldLockForPayg = Main.paygManager.isLocked &&
             (Main.sessionMode.currentMode == 'user' ||
-             Main.sessionMode.currentMode == 'user-coding');
+             Main.sessionMode.currentMode == 'user-coding' ||
+             Main.sessionMode.currentMode == 'endless');
 
         if (!this._settings.get_boolean(LOCK_ENABLED_KEY) && !shouldLockForPayg)
             return;


### PR DESCRIPTION
This change was dropped by mistake during rebase.

Original change from https://github.com/endlessm/gnome-shell/pull/633.

https://phabricator.endlessm.com/T29583