### PR TITLE
iconGridLayout: Temporarily disable "Undo" notification action when removing folders

### DIFF
--- a/js/ui/iconGridLayout.js
+++ b/js/ui/iconGridLayout.js
@@ -298,12 +298,19 @@ var IconGridLayout = GObject.registerClass({
             return;
 
         if (interactive) {
+            const options = {
+                forFeedback: true,
+                destroyCallback: () => this._onMessageDestroy(info),
+                undoCallback: null,
+            };
+
+            // FIXME: re-enable Undo action for folders when support is implemented
+            if (!this.iconIsFolder(id))
+                options.undoCallback = () => this._undoRemoveItem(undoInfo);
+
             Main.overview.setMessage(
-                _('%s has been removed').format(info.get_name()), {
-                    forFeedback: true,
-                    destroyCallback: () => this._onMessageDestroy(info),
-                    undoCallback: () => this._undoRemoveItem(undoInfo),
-                });
+                _('%s has been removed').format(info.get_name()),
+                options);
         } else {
             this._onMessageDestroy(info);
         }


### PR DESCRIPTION
Support for undo a folder removal is currently not implemented, lets remove
the notification action for now as to not confuse users.

Patch originally from https://phabricator.endlessm.com/T28532 - not strictly needed as currently (not sure if a bug though) we don't show context menus for icon folders, but still possible to be invoked from other places and given IconGridLayout._undoRemoveItem() doesn't support undo'ing folder removal, lets make sure we don't even try.

https://phabricator.endlessm.com/T29782