### PR TITLE
T29763

### DIFF
--- a/js/ui/screenShield.js
+++ b/js/ui/screenShield.js
@@ -143,7 +143,10 @@ var ScreenShield = class {
 
         this._syncInhibitor();
 
-        Main.paygManager.connect('code-expired', () => { this.lock(true) });
+        Main.paygManager.connect('code-expired', () => {
+            this._clearCurrentDialog();
+            this.lock(true);
+        });
         Main.paygManager.connect('expiry-time-changed', () => {
             let userManager = AccountsService.UserManager.get_default();
             let user = userManager.get_user(GLib.get_user_name());
@@ -151,6 +154,7 @@ var ScreenShield = class {
             // A new valid code has been introduced but the machine is
             // not unlocked yet -> Make sure we stay in the locked state.
             if (Main.paygManager.isLocked) {
+                this._clearCurrentDialog();
                 this.lock(false);
                 return;
             }
@@ -177,14 +181,18 @@ var ScreenShield = class {
 
                 // The machine is unlocked but we still need to unlock the
                 // user's session with the password, so don't deactivate yet.
-                if (this._dialog) {
-                    this._dialog.destroy();
-                    this._dialog = null;
-                }
+                this._clearCurrentDialog();
 
                 this.showDialog();
             });
         });
+    }
+
+    _clearCurrentDialog() {
+        if (this._dialog) {
+            this._dialog.destroy();
+            this._dialog = null;
+        }
     }
 
     _setActive(active) {
@@ -613,19 +621,19 @@ var ScreenShield = class {
         if (this._activationTime == 0)
             this._activationTime = GLib.get_monotonic_time();
 
-        if (Main.sessionMode.currentMode !== 'unlock-dialog' &&
-            Main.sessionMode.currentMode !== 'unlock-dialog-payg') {
-            this._isGreeter = Main.sessionMode.isGreeter;
-            if (!this._isGreeter) {
-                let userManager = AccountsService.UserManager.get_default();
-                let user = userManager.get_user(GLib.get_user_name());
+        this._isGreeter = Main.sessionMode.isGreeter;
+        if (!this._isGreeter) {
+            let userManager = AccountsService.UserManager.get_default();
+            let user = userManager.get_user(GLib.get_user_name());
 
-                if (user.password_mode !== AccountsService.UserPasswordMode.NONE)
-                    Main.sessionMode.pushMode('unlock-dialog');
+            if (Main.sessionMode.currentMode !== 'unlock-dialog' &&
+                Main.sessionMode.currentMode !== 'unlock-dialog-payg' &&
+                user.password_mode !== AccountsService.UserPasswordMode.NONE)
+                Main.sessionMode.pushMode('unlock-dialog');
 
-                if (Main.paygManager.isLocked)
-                    Main.sessionMode.pushMode('unlock-dialog-payg');
-            }
+            if (Main.sessionMode.currentMode !== 'unlock-dialog-payg' &&
+                Main.paygManager.isLocked)
+                Main.sessionMode.pushMode('unlock-dialog-payg');
         }
 
         this._ensureUnlockDialog(true);


### PR DESCRIPTION
We can already be in the unlock-dialog session mode when PAYG detects
the code expired, in which case we never push the unlock-dialog-payg
mode. Even if we did, because there was a dialog already, we'd never
actually create the PAYG unlock dialog.

Fix both with this commit. The first problem is fixed by properly
checking the session mode, and the second is fixed by destroying
the current dialog if PAYG needs to show its own.

https://phabricator.endlessm.com/T29763