### PR TITLE
Do not show background menu when long-pressing app icon

### DIFF
--- a/js/ui/appDisplay.js
+++ b/js/ui/appDisplay.js
@@ -2130,22 +2130,22 @@ var AppIcon = GObject.registerClass({
     }
 
     vfunc_button_press_event(buttonEvent) {
-        super.vfunc_button_press_event(buttonEvent);
+        const ret = super.vfunc_button_press_event(buttonEvent);
         if (buttonEvent.button == 1) {
             this._setPopupTimeout();
         } else if (buttonEvent.button == 3) {
             this.popupMenu();
             return Clutter.EVENT_STOP;
         }
-        return Clutter.EVENT_PROPAGATE;
+        return ret;
     }
 
     vfunc_touch_event(touchEvent) {
-        super.vfunc_touch_event(touchEvent);
+        const ret = super.vfunc_touch_event(touchEvent);
         if (touchEvent.type == Clutter.EventType.TOUCH_BEGIN)
             this._setPopupTimeout();
 
-        return Clutter.EVENT_PROPAGATE;
+        return ret;
     }
 
     vfunc_clicked(button) {

--- a/js/ui/appDisplay.js
+++ b/js/ui/appDisplay.js
@@ -2034,8 +2034,6 @@ var AppIcon = GObject.registerClass({
             button_mask: St.ButtonMask.ONE | St.ButtonMask.TWO,
         }, iconParams);
 
-        let buttonParams = { button_mask: St.ButtonMask.ONE | St.ButtonMask.TWO };
-
         this._iconContainer = new St.Widget({ layout_manager: new Clutter.BinLayout(),
                                               x_expand: true, y_expand: true });
         this._iconContainer.add_child(this.icon);

--- a/js/ui/appDisplay.js
+++ b/js/ui/appDisplay.js
@@ -2017,7 +2017,7 @@ var AppIcon = GObject.registerClass({
         this._id = app.get_id();
         this._name = app.get_name();
 
-        // Get the isDraggable property without passing it on to the BaseIcon:
+        // Get the showMenu property without passing it on to the BaseIcon:
         let appIconParams = Params.parse(iconParams, {
             showMenu: true,
         }, true);

--- a/js/ui/appDisplay.js
+++ b/js/ui/appDisplay.js
@@ -2025,7 +2025,9 @@ var AppIcon = GObject.registerClass({
         this._showMenu = appIconParams['showMenu'];
         delete iconParams['showMenu'];
 
-        iconParams['createIcon'] = this._createIcon.bind(this);
+        iconParams = Params.parse(iconParams, {
+            createIcon: this._createIcon.bind(this),
+        }, true);
         iconParams['setSizeManually'] = false;
 
         super._init({
@@ -2033,9 +2035,6 @@ var AppIcon = GObject.registerClass({
         }, iconParams);
 
         let buttonParams = { button_mask: St.ButtonMask.ONE | St.ButtonMask.TWO };
-        iconParams = Params.parse(iconParams, {
-            createIcon: this._createIcon.bind(this),
-        }, true);
 
         this._iconContainer = new St.Widget({ layout_manager: new Clutter.BinLayout(),
                                               x_expand: true, y_expand: true });


### PR DESCRIPTION
This PR contains 4 patches but only the first one (to fix the vfuncs to return parent results) is actually needed for the fix. I can split the changes in separate PRs if needed, please let me know.

I noticed folder icons never show the background menu and after investigations I noticed the issue was that `vfunc_button_press_event` (and touch-event) were always propagating the events and thus triggering the background action long-press event. Fixed by returning the parent class result for the vfuncs if the event is not handled by AppIcon itself.

This fix may be a good candidate for upstream but I didn't push it yet as I wasn't sure if that is an upstream issue as well given the background action in question here is a downstream only change.

https://phabricator.endlessm.com/T29781