### PR TITLE
fixup! js: Add support for parental controls filtering to the desktop

### DIFF
--- a/js/ui/appDisplay.js
+++ b/js/ui/appDisplay.js
@@ -1109,7 +1109,7 @@ var AppSearchProvider = class AppSearchProvider {
 
                 const app = this._appSys.lookup_app(appID);
 
-                if (!parentalControlsManager.shouldShowApp(app.app_info))
+                if (app && !parentalControlsManager.shouldShowApp(app.app_info))
                     return false;
 
                 if (app && app.app_info.should_show()) {


### PR DESCRIPTION
shell_app_system_lookup_app() can return NULL, even if the app ID was
returned by shell_app_system_query(). In particular, this can happen
when the executable referenced in the Exec= line of the .desktop file
does not exist. This is because GLib validates whether the Exec= line is
in the path when constructing a GDesktopAppInfo (and returns NULL if
not), but g_desktop_app_info_search() does not validate this before
returning results.

The visible symptom of this bug is that, when a desktop search query
matches such a file, desktop search gets stuck on "Searching…" with the
following backtrace:

    JS ERROR: TypeError: app is null
    getInitialResultSet/</group<@resource:///org/gnome/shell/ui/appDisplay.js:1112:21
    getInitialResultSet/<@resource:///org/gnome/shell/ui/appDisplay.js:1102:27
    getInitialResultSet@resource:///org/gnome/shell/ui/appDisplay.js:1101:16
    _doSearch/<@resource:///org/gnome/shell/ui/search.js:640:26
    _doSearch@resource:///org/gnome/shell/ui/search.js:628:25
    _onSearchTimeout@resource:///org/gnome/shell/ui/search.js:655:14

The TypeError comes from accessing 'app.app_info' when 'app' is 'null'.
The other conditional in this function performs a truthiness test, so do
the same here.

https://phabricator.endlessm.com/T29860