### PR TITLE
payg: Don’t calculate times if PAYG is disabled

### DIFF
--- a/js/ui/status/payg.js
+++ b/js/ui/status/payg.js
@@ -85,6 +85,10 @@ class PaygIndicator extends PanelMenu.SystemIndicator {
         if (!this._paygManager.initialized)
             return _('Getting time…');
 
+        // if PAYG is disabled, nothing should be showing this label
+        if (!this._paygManager.enabled)
+            return '';
+
         let seconds = this._paygManager.timeRemainingSecs();
         if (seconds == 0)
             return _('Subscription expired');


### PR DESCRIPTION
This prevents a JS error on a 32-bit system when trying to build a
string for the remaining time. If PAYG is disabled, that remaining time
is the highest possible 64-bit value, which overflows the standard
32-bit integer passed to `ngettext()`. It’s meaningless to build the
string if PAYG is disabled.

Signed-off-by: Philip Withnall <withnall@endlessm.com>

https://phabricator.endlessm.com/T28788

---

**Untested** since I don’t have a shell, PAYG or 32-bit test setup. It should be fairly low risk.