### PR TITLE
screenShield: Properly show PaygUnlockDialog on login screen

### DIFF
--- a/js/ui/screenShield.js
+++ b/js/ui/screenShield.js
@@ -145,7 +145,10 @@ var ScreenShield = class {
 
         Main.paygManager.connect('code-expired', () => {
             this._clearCurrentDialog();
-            this.lock(true);
+            if (Main.sessionMode.isGreeter)
+                this.showDialog();
+            else
+                this.lock(true);
         });
         Main.paygManager.connect('expiry-time-changed', () => {
             let userManager = AccountsService.UserManager.get_default();


### PR DESCRIPTION
Currently if PAYG credit expires when you're logged in, you get the
unlock code entry screen. But if credit expires at the gdm login screen,
you don't get it. This is because ScreenShield.lock() has an early
return when you're at the login screen (in which case
Main.sessionMode.isGreeter is true), since in that case the computer is
already locked. Call ScreenShield.showDialog() instead in that case.

https://phabricator.endlessm.com/T29898