### PR TITLE
T30092

### DIFF
--- a/js/ui/layout.js
+++ b/js/ui/layout.js
@@ -219,6 +219,7 @@ var LayoutManager = GObject.registerClass({
 
         this._inOverview = false;
         this._updateRegionIdle = 0;
+        this._timeoutId = 0;
 
         this._overlayRegion = null;
         this._trackedActors = [];
@@ -619,6 +620,19 @@ var LayoutManager = GObject.registerClass({
     }
 
     _monitorsChanged() {
+        this._updateEverything();
+        this.emit('monitors-changed');
+
+        if (!this._timeoutId) {
+            this._timeoutId = GLib.timeout_add(GLib.PRIORITY_DEFAULT, 1, () => {
+                this._updateEverything();
+                this._timeoutId = 0;
+                return GLib.SOURCE_REMOVE;
+            });
+        }
+    }
+
+    _updateEverything() {
         this._updateMonitors();
         this._updateBoxes();
         this._updateHotCorners();
@@ -626,8 +640,6 @@ var LayoutManager = GObject.registerClass({
         this._updateFullscreen();
         this._updateVisibility();
         this._queueUpdateRegions();
-
-        this.emit('monitors-changed');
     }
 
     _isAboveOrBelowPrimary(monitor) {


### PR DESCRIPTION
For reasons still unknown, there's an apparently racy behavior
between Mutter, GNOME Shell, and X11, where GNOME Shell sends
the wrong input region to X11.

Work around that by queueing an extra full update after receiving
the monitors-changed signal from Mutter.

https://phabricator.endlessm.com/T30092