### PR TITLE
sessionMode: Allow eos-hack-extension to remain enabled when screen is locked

### DIFF
--- a/js/ui/sessionMode.js
+++ b/js/ui/sessionMode.js
@@ -62,6 +62,8 @@ const _modes = {
     'unlock-dialog': {
         isLocked: true,
         unlockDialog: imports.ui.unlockDialog.UnlockDialog,
+        allowExtensions: true,
+        enabledExtensions: ['eos-hack@endlessm.com'],
         components: ['polkitAgent', 'telepathyClient'],
         panel: {
             left: [],


### PR DESCRIPTION
When locking the screen the shell switches to the `unlock-dialog` session mode and then it switches back to the previous session mode (in our case the `endless` mode) when the screen is unlocked.

When entering a mode the shell ensures all extensions configured in the `enabledExtensions` for that mode are enabled (as long as `allowExtensions` is also set to `true` for that mode).
It will also disable all extensions that are not configured for that mode and were previously enabled.

The problem here is that our default mode (`endless`) has the hack extension enabled but the `unlock-dialog` mode (mode used when the screen is locked) does not, so the shell disables the
hack extension when locking the screen and re-enables it when unlocking the screen (when it switches back to the `endless` mode).

This causes an issue because the hack extension will add the Hack icon to the desktop (always in the first position of the icon grid) when it gets enabled and then remove the icon when disabled, thus causing the icon grid to reorder/redraw the icons when locking/unlocking the screen.

Ideally we could extend the `unlock-dialog` by installing a json file similar to how we define our `endless` mode but the problem is that the shell currently doesn't allow the default modes (e.g.
`unlock-dialog`) to be updated via external files, so lets fix this by forcing the `unlock-dialog` mode to also include the hack extension as an allowed/enabled extension.

Note that this could become an issue if/when we start shipping a default user session mode (e.g. GNOME standard mode) that doesn't enable the hack extension by default, but given we only support the `endless` user session mode atm I think the approach here is the least invasive.

Fwiw, our PAYG lock screen mode inherits from the `unlock-dialog` mode so this should work (untested) when entering/leaving the PAYG lock mode as well.

https://phabricator.endlessm.com/T29719