### PR TITLE
appDisplay: Refresh folder view when app cache is updated

### DIFF
--- a/js/ui/appDisplay.js
+++ b/js/ui/appDisplay.js
@@ -1217,6 +1217,7 @@ class FolderView extends BaseAppView {
         action.connect('pan', this._onPan.bind(this));
         this._scrollView.add_action(action);
 
+        Shell.AppSystem.get_default().connect('installed-changed', this._redisplay.bind(this));
         this._iconGridLayout.connect('layout-changed', this._redisplay.bind(this));
         this._redisplay();
     }


### PR DESCRIPTION
This fixes a race condition between an app getting installed from a "Get $app" icon, gnome-software asking the shell to replace the "Get $app" icon with the "$app" icon and the shell app cache getting
updated with the new installed app.

By the time the shell gets the request from gnome-software to replace the "Get $app" icon it tries to reload the folder view which checks if the new $app is available invoking `Shell.AppSystem.get_default().lookup_app()` which checks the app cache but the cache may not have been updated yet with the new app (the cache is updated on a timer triggered by
a file monitor changed signal).

Fix this by making sure to refresh the folder view when the app cache is updated, as is already done by the main app view (AppDisplay).

https://phabricator.endlessm.com/T30108