### PR TITLE
fixup! project: Add eos-link-feedback back

### DIFF
--- a/data/eos-link-feedback.desktop.in.in
+++ b/data/eos-link-feedback.desktop.in.in
@@ -2,7 +2,7 @@
 Version=1.0
 Name=Feedback
 Type=Application
-Exec=chromium-browser https://community.endlessos.com/
+Exec=gio open https://community.endlessos.com/
 Categories=Utility;
 NoDisplay=true
 X-Endless-LaunchMaximized=false


### PR DESCRIPTION
Use the default browser instead of chromium - we don't need to use chromium anymore given we don't rely on the exploration center existing anymore and instead just redirect users to the forum (which should work on all browsers).

https://phabricator.endlessm.com/T30295