### PR TITLE
rfkill: Always sync state on construction

### DIFF
--- a/js/ui/status/rfkill.js
+++ b/js/ui/status/rfkill.js
@@ -86,6 +86,8 @@ class Indicator extends PanelMenu.SystemIndicator {
 
         Main.sessionMode.connect('updated', this._sessionUpdated.bind(this));
         this._sessionUpdated();
+
+        this._sync();
     }
 
     _sessionUpdated() {


### PR DESCRIPTION
Cherry-pick of https://gitlab.gnome.org/GNOME/gnome-shell/merge_requests/1386, just so I can remove a workaround from the panel extension.

https://phabricator.endlessm.com/T30172