### PR TITLE
List eos-desktop@endlessm.com in Endless session

### DIFF
--- a/debian/endless-session-mods/endless.json
+++ b/debian/endless-session-mods/endless.json
@@ -1,6 +1,7 @@
 {
     "parentMode": "user",
     "enabledExtensions": [
+        "eos-desktop@endlessm.com",
         "eos-hack@endlessm.com",
         "eos-watermark@endlessm.com",
         "ubuntu-appindicators@ubuntu.com"


### PR DESCRIPTION
So it's automatically enabled, and undisablable.

https://phabricator.endlessm.com/T30540