### PR TITLE
sessionMode: Enable the panel extension on gdm and lockscreen mode

### DIFF
--- a/js/ui/sessionMode.js
+++ b/js/ui/sessionMode.js
@@ -45,6 +45,8 @@ const _modes = {
         isGreeter: true,
         isPrimary: true,
         unlockDialog: imports.gdm.loginDialog.LoginDialog,
+        allowExtensions: true,
+        enabledExtensions: ['eos-panel@endlessm.com'],
         components: ['polkitAgent'],
         panel: {
             left: [],
@@ -57,6 +59,8 @@ const _modes = {
     'unlock-dialog': {
         isLocked: true,
         unlockDialog: undefined,
+        allowExtensions: true,
+        enabledExtensions: ['eos-panel@endlessm.com'],
         components: ['polkitAgent', 'telepathyClient'],
         panel: {
             left: [],


### PR DESCRIPTION
We want the customized panel to be available on gdm and lockscreen mode as well.

https://phabricator.endlessm.com/T30445