### PR TITLE
Enable eos-desktop extension on lock screen as well

### DIFF
--- a/js/ui/sessionMode.js
+++ b/js/ui/sessionMode.js
@@ -60,7 +60,7 @@ const _modes = {
         isLocked: true,
         unlockDialog: undefined,
         allowExtensions: true,
-        enabledExtensions: ['eos-panel@endlessm.com'],
+        enabledExtensions: ['eos-desktop@endlessm.com', 'eos-panel@endlessm.com'],
         components: ['polkitAgent', 'telepathyClient'],
         panel: {
             left: [],


### PR DESCRIPTION
Keep the eos-desktop extension enabled on the lock screen.
Nowadays the desktop extension can handle tearing down
fine, but the act of destroying and recreating the app
grid is a heavy one and incurs stuttering when unlocking
the screen.

https://phabricator.endlessm.com/T30623