### PR TITLE
Re-add PAYG support

### DIFF
--- a/data/dbus-interfaces/com.endlessm.Payg1.xml
+++ b/data/dbus-interfaces/com.endlessm.Payg1.xml
@@ -1,0 +1,21 @@
+<node>
+  <interface name="com.endlessm.Payg1">
+    <method name="AddCode">
+      <arg type="s" direction="in" name="code"/>
+      <arg type="x" direction="out" name="time_added"/>
+    </method>
+    <method name="ClearCode" />
+    <signal name="Expired" />
+    <signal name="ImpendingShutdown">
+      <arg type="i" name="seconds_remaining"/>
+      <arg type="s" name="shutdown_reason"/>
+    </signal>
+    <property name="ExpiryTime" type="t" access="read"/>
+    <property name="Enabled" type="b" access="read"/>
+    <property name="RateLimitEndTime" type="t" access="read"/>
+    <property name="AccountID" type="s" access="read"/>
+    <property name="CodeFormat" type="s" access="read"/>
+    <property name="CodeFormatPrefix" type="s" access="read"/>
+    <property name="CodeFormatSuffix" type="s" access="read"/>
+  </interface>
+</node>

--- a/data/gnome-shell-dbus-interfaces.gresource.xml
+++ b/data/gnome-shell-dbus-interfaces.gresource.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <gresources>
   <gresource prefix="/org/gnome/shell/dbus-interfaces">
+    <file preprocess="xml-stripblanks">com.endlessm.Payg1.xml</file>
     <file preprocess="xml-stripblanks">net.hadess.SensorProxy.xml</file>
     <file preprocess="xml-stripblanks">org.freedesktop.Application.xml</file>
     <file preprocess="xml-stripblanks">org.freedesktop.bolt1.Device.xml</file>

--- a/data/gnome-shell-theme.gresource.xml
+++ b/data/gnome-shell-theme.gresource.xml
@@ -32,5 +32,10 @@
     <file>toggle-on.svg</file>
     <file>toggle-on-dark.svg</file>
     <file>toggle-on-hc.svg</file>
+
+    <!-- Endless-specific resources beyond this point -->
+
+    <file>payg-near-expiration-symbolic.svg</file>
+    <file>payg-normal-symbolic.svg</file>
   </gresource>
 </gresources>

--- a/data/theme/gnome-shell-sass/_endless.scss
+++ b/data/theme/gnome-shell-sass/_endless.scss
@@ -30,6 +30,109 @@
   }
 }
 
+// Pay As You Go unlock screen (based on .login-dialog)
+
+$success_time_payg_color: #02b842;
+
+.unlock-dialog-payg {
+  border: none;
+  background-color: transparent;
+
+  .modal-dialog-button-box { spacing: 3px; }
+  .modal-dialog-button {
+    padding: 3px 18px;
+    &:default {
+      @include button(normal,$c:$selected_bg_color);
+      &:hover,&:focus { @include button(hover,$c:$selected_bg_color); }
+      &:active { @include button(active,$c:$selected_bg_color); }
+      &:insensitive { @include button(insensitive); }
+    }
+  }
+
+  .unlock-dialog-payg-layout {
+      padding-top: 24px;
+      padding-bottom: 12px;
+      spacing: 8px;
+
+      .unlock-dialog-payg-title {
+          color: $osd_fg_color;
+          font-size: 24px;
+          font-weight: bold;
+          text-align: left;
+          margin: 24px;
+      }
+
+      .unlock-dialog-payg-promptbox {
+          spacing: 6px;
+          min-width: 400px;
+          max-width: 400px;
+      }
+
+      .unlock-dialog-payg-label {
+          color: darken($osd_fg_color, 20%);
+          font-size: 110%; // Consistent with .login-dialog-prompt-label
+          padding-top: 1em;
+      }
+
+      .unlock-dialog-payg-code-entry {
+          color: darken($osd_fg_color, 20%);
+          font-size: 24px; // Consistent with .login-dialog-prompt-label
+          padding-left: 3px;
+          padding-right: 3px;
+          padding-top: 0.3em;
+      }
+
+      .unlock-dialog-payg-entry {
+          font-size: 24px;
+          padding-left: 12px;
+          padding-right: 12px;
+          letter-spacing: 6px;
+      }
+
+      .unlock-dialog-payg-session-list-button {
+          color: darken($osd_fg_color,30%);
+          &:hover,&:focus { color: $osd_fg_color; }
+          &:active { color: darken($osd_fg_color, 50%); }
+      }
+
+      .unlock-dialog-payg-message {
+          color: $warning_color;
+      }
+
+      .unlock-dialog-payg-button-box {
+          spacing: 5px;
+      }
+
+      .unlock-dialog-payg-help-main {
+          color: $osd_fg_color;
+          font-weight: bold;
+          text-align: left;
+          margin-top: 36px;
+      }
+
+      .unlock-dialog-payg-help-sub {
+          color: $osd_fg_color;
+          font-size: 100%;
+          text-align: left;
+      }
+
+      .unlock-dialog-payg-account-id {
+          color: $osd_fg_color;
+          font-size: 100%;
+          text-align: left;
+          margin: 12px;
+      }
+
+      .unlock-dialog-payg-success {
+          color: $success_time_payg_color;
+          font-size: 24px;
+          font-weight: bold;
+          text-align: left;
+          margin: 24px;
+      }
+  }
+}
+
 // Pay As You Go notifications
 
 .notification-payg-entry {

--- a/data/theme/gnome-shell-sass/_endless.scss
+++ b/data/theme/gnome-shell-sass/_endless.scss
@@ -29,3 +29,22 @@
     color: $osd_fg_color;
   }
 }
+
+// Pay As You Go notifications
+
+.notification-payg-entry {
+  text-align: center;
+  padding-left: 12px;
+  padding-right: 12px;
+  letter-spacing: 6px;
+  margin: 5px;
+}
+
+.notification-payg-code-entry {
+  text-align: center;
+  font-size: 20px;
+  color: darken($osd_fg_color, 20%);
+  padding-left: 12px;
+  padding-right: 12px;
+  margin-top: 6px;
+}

--- a/data/theme/payg-near-expiration-symbolic.svg
+++ b/data/theme/payg-near-expiration-symbolic.svg
@@ -1,0 +1,145 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   sodipodi:docname="payg-near-expiration-symbolic.svg"
+   height="16"
+   inkscape:version="0.92.2 2405546, 2018-03-11"
+   version="1.1"
+   width="16"
+   id="svg7384">
+  <metadata
+     id="metadata90">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>Gnome Symbolic Icon Theme</dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     inkscape:object-paths="true"
+     showgrid="false"
+     inkscape:pageopacity="1"
+     inkscape:snap-global="true"
+     inkscape:object-nodes="true"
+     inkscape:zoom="16"
+     inkscape:window-width="1920"
+     inkscape:snap-others="false"
+     inkscape:snap-bbox-midpoints="false"
+     inkscape:current-layer="layer9"
+     inkscape:snap-bbox="true"
+     showguides="true"
+     inkscape:snap-nodes="true"
+     inkscape:window-height="1004"
+     inkscape:window-maximized="1"
+     bordercolor="#666666"
+     objecttolerance="10"
+     guidetolerance="10"
+     inkscape:window-x="1920"
+     inkscape:window-y="0"
+     showborder="false"
+     inkscape:snap-to-guides="true"
+     gridtolerance="10"
+     id="namedview88"
+     inkscape:cx="6.7083613"
+     inkscape:cy="3.9380467"
+     inkscape:guide-bbox="true"
+     inkscape:snap-grids="true"
+     pagecolor="#555753"
+     borderopacity="1"
+     inkscape:pageshadow="2"
+     inkscape:bbox-paths="false">
+    <inkscape:grid
+       visible="true"
+       snapvisiblegridlinesonly="true"
+       enabled="true"
+       type="xygrid"
+       spacingx="1"
+       spacingy="1"
+       id="grid4866"
+       empspacing="2"
+       originx="0"
+       originy="0" />
+  </sodipodi:namedview>
+  <title
+     id="title9167">Gnome Symbolic Icon Theme</title>
+  <defs
+     id="defs7386" />
+  <g
+     inkscape:groupmode="layer"
+     transform="translate(-161.0002,-397)"
+     id="layer9"
+     style="display:inline"
+     inkscape:label="status">
+    <path
+       style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#bebebe;fill-opacity:1;stroke:none;stroke-width:2.54545712;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+       d="M 6.5 0 C 2.922 0 0 2.92199 0 6.5 C 0 9.3710174 1.8845474 11.814367 4.4765625 12.669922 C 4.4764186 13.043033 4.4708503 13.415835 4.4804688 13.789062 C 4.4804688 13.879363 4.5888569 13.925261 4.6542969 13.863281 L 7 11.607422 L 4.6582031 9.3515625 C 4.5932031 9.2891625 4.484375 9.3335281 4.484375 9.4238281 C 4.4883568 9.7838159 4.4830413 10.144084 4.4804688 10.503906 C 3.011884 9.7656041 2 8.264992 2 6.5 C 2 4.00288 4.00288 2 6.5 2 C 8.99712 2 11 4.00288 11 6.5 C 11 6.6726 10.9561 6.83268 10.9375 7 L 12.96875 7 C 12.98175 6.83269 13 6.6705 13 6.5 C 13 2.92199 10.078 0 6.5 0 z "
+       transform="translate(161.0002,397)"
+       id="path3869-25" />
+    <path
+       d="M 167.40625,400 A 0.50005,0.50005 0 0 0 167,400.5 l 0,2.5 -1.5,0 a 0.50005,0.50005 0 1 0 0,1 l 2,0 a 0.50005,0.50005 0 0 0 0.5,-0.5 l 0,-3 a 0.50005,0.50005 0 0 0 -0.59375,-0.5 z"
+       inkscape:connector-curvature="0"
+       id="path4639-4"
+       style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#bebebe;fill-opacity:1;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans" />
+    <path
+       style="color:#bebebe;display:inline;overflow:visible;visibility:visible;fill:#f57900;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none"
+       d="M 8.875 8.0683594 C 8.38255 8.0683594 8 8.44934 8 8.9375 L 8 15.132812 C 8 15.620972 8.38255 16 8.875 16 L 15.125 16 C 15.61745 16 16 15.620972 16 15.132812 L 16 8.9375 C 16 8.44934 15.61745 8.0683594 15.125 8.0683594 L 8.875 8.0683594 z M 11.677734 8.7089844 L 12.257812 8.7089844 L 12.257812 9.5234375 C 12.496528 9.5425347 12.735894 9.5707465 12.974609 9.6113281 C 13.213325 9.6519097 13.452257 9.7050781 13.693359 9.7695312 L 13.693359 10.679688 C 13.454644 10.579427 13.215278 10.50217 12.976562 10.447266 C 12.737847 10.389974 12.498915 10.353733 12.257812 10.341797 L 12.257812 11.371094 L 12.373047 11.392578 C 12.979384 11.488064 13.402995 11.646701 13.646484 11.871094 C 13.892361 12.093099 14.015625 12.422526 14.015625 12.859375 C 14.015625 13.298611 13.869358 13.636719 13.578125 13.873047 C 13.286892 14.106988 12.847439 14.240017 12.257812 14.273438 L 12.257812 15.359375 L 11.677734 15.359375 L 11.673828 14.28125 C 11.375434 14.269314 11.085938 14.236545 10.806641 14.181641 C 10.527344 14.126736 10.255208 14.049045 9.9902344 13.951172 L 9.9902344 13.013672 C 10.264757 13.154514 10.542969 13.263455 10.822266 13.339844 C 11.10395 13.413845 11.388889 13.455295 11.677734 13.464844 L 11.677734 12.351562 L 11.558594 12.330078 C 10.988064 12.229818 10.582899 12.072266 10.341797 11.857422 C 10.103082 11.642578 9.984375 11.333116 9.984375 10.929688 C 9.984375 10.502387 10.128689 10.170356 10.419922 9.9316406 C 10.713542 9.6905382 11.131944 9.5585938 11.673828 9.5371094 L 11.677734 8.7089844 z M 11.677734 10.353516 C 11.508247 10.363064 11.372179 10.408637 11.269531 10.492188 C 11.169271 10.573351 11.119141 10.678168 11.119141 10.804688 C 11.119141 10.94553 11.164714 11.055556 11.257812 11.136719 C 11.350911 11.215495 11.491536 11.265625 11.677734 11.287109 L 11.677734 10.353516 z M 12.257812 12.455078 L 12.257812 13.451172 C 12.465495 13.448785 12.620009 13.406901 12.722656 13.328125 C 12.827691 13.249349 12.880859 13.132161 12.880859 12.974609 C 12.880859 12.812283 12.833767 12.692057 12.738281 12.613281 C 12.642795 12.532118 12.482205 12.47895 12.257812 12.455078 z "
+       transform="translate(161.0002,397)"
+       id="path10898-2-9-4" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     transform="translate(-161.0002,-397)"
+     id="layer10"
+     inkscape:label="devices" />
+  <g
+     inkscape:groupmode="layer"
+     transform="translate(-161.0002,-397)"
+     id="layer11"
+     inkscape:label="apps" />
+  <g
+     inkscape:groupmode="layer"
+     transform="translate(-161.0002,-397)"
+     id="layer13"
+     inkscape:label="places" />
+  <g
+     inkscape:groupmode="layer"
+     transform="translate(-161.0002,-397)"
+     id="layer14"
+     inkscape:label="mimetypes" />
+  <g
+     inkscape:groupmode="layer"
+     transform="translate(-161.0002,-397)"
+     id="layer15"
+     style="display:inline"
+     inkscape:label="emblems" />
+  <g
+     inkscape:groupmode="layer"
+     transform="translate(-161.0002,-397)"
+     id="g71291"
+     style="display:inline"
+     inkscape:label="emotes" />
+  <g
+     inkscape:groupmode="layer"
+     transform="translate(-161.0002,-397)"
+     id="g4953"
+     style="display:inline"
+     inkscape:label="categories" />
+  <g
+     inkscape:groupmode="layer"
+     transform="translate(-161.0002,-397)"
+     id="layer12"
+     style="display:inline"
+     inkscape:label="actions" />
+</svg>

--- a/data/theme/payg-normal-symbolic.svg
+++ b/data/theme/payg-normal-symbolic.svg
@@ -1,0 +1,151 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   sodipodi:docname="payg-normal-symbolic.svg"
+   height="16"
+   inkscape:version="0.92.2 2405546, 2018-03-11"
+   version="1.1"
+   width="16"
+   id="svg7384">
+  <metadata
+     id="metadata90">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>Gnome Symbolic Icon Theme</dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     inkscape:object-paths="true"
+     showgrid="false"
+     inkscape:pageopacity="1"
+     inkscape:snap-global="true"
+     inkscape:object-nodes="true"
+     inkscape:zoom="16"
+     inkscape:window-width="1920"
+     inkscape:snap-others="false"
+     inkscape:snap-bbox-midpoints="false"
+     inkscape:current-layer="layer9"
+     inkscape:snap-bbox="true"
+     showguides="true"
+     inkscape:snap-nodes="true"
+     inkscape:window-height="1004"
+     inkscape:window-maximized="1"
+     bordercolor="#666666"
+     objecttolerance="10"
+     guidetolerance="10"
+     inkscape:window-x="1920"
+     inkscape:window-y="0"
+     showborder="false"
+     inkscape:snap-to-guides="true"
+     gridtolerance="10"
+     id="namedview88"
+     inkscape:cx="6.7083613"
+     inkscape:cy="3.9380467"
+     inkscape:guide-bbox="true"
+     inkscape:snap-grids="true"
+     pagecolor="#555753"
+     borderopacity="1"
+     inkscape:pageshadow="2"
+     inkscape:bbox-paths="false">
+    <inkscape:grid
+       visible="true"
+       snapvisiblegridlinesonly="true"
+       enabled="true"
+       type="xygrid"
+       spacingx="1"
+       spacingy="1"
+       id="grid4866"
+       empspacing="2"
+       originx="0"
+       originy="0" />
+  </sodipodi:namedview>
+  <title
+     id="title9167">Gnome Symbolic Icon Theme</title>
+  <defs
+     id="defs7386" />
+  <g
+     inkscape:groupmode="layer"
+     transform="translate(-161.0002,-397)"
+     id="layer9"
+     style="display:inline"
+     inkscape:label="status">
+    <path
+       style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#bebebe;fill-opacity:1;stroke:none;stroke-width:2.54545712;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+       d="M 6.5 0 C 2.922 0 0 2.92199 0 6.5 C 0 9.3710174 1.8845474 11.814367 4.4765625 12.669922 C 4.4764186 13.043033 4.4708503 13.415835 4.4804688 13.789062 C 4.4804688 13.879363 4.5888569 13.925261 4.6542969 13.863281 L 7 11.607422 L 4.6582031 9.3515625 C 4.5932031 9.2891625 4.484375 9.3335281 4.484375 9.4238281 C 4.4883568 9.7838159 4.4830413 10.144084 4.4804688 10.503906 C 3.011884 9.7656041 2 8.264992 2 6.5 C 2 4.00288 4.00288 2 6.5 2 C 8.99712 2 11 4.00288 11 6.5 C 11 6.6726 10.9561 6.83268 10.9375 7 L 12.96875 7 C 12.98175 6.83269 13 6.6705 13 6.5 C 13 2.92199 10.078 0 6.5 0 z "
+       transform="translate(161.0002,397)"
+       id="path3869-25" />
+    <path
+       d="M 167.40625,400 A 0.50005,0.50005 0 0 0 167,400.5 l 0,2.5 -1.5,0 a 0.50005,0.50005 0 1 0 0,1 l 2,0 a 0.50005,0.50005 0 0 0 0.5,-0.5 l 0,-3 a 0.50005,0.50005 0 0 0 -0.59375,-0.5 z"
+       inkscape:connector-curvature="0"
+       id="path4639-4"
+       style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#bebebe;fill-opacity:1;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:125%;font-family:'Droid Sans Fallback';-inkscape-font-specification:'Droid Sans Fallback';letter-spacing:0px;word-spacing:0px;display:inline;fill:#bebebe;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       x="169.09883"
+       y="411.2811"
+       id="text5158-4"><tspan
+         sodipodi:role="line"
+         id="tspan5156-2"
+         x="169.09883"
+         y="411.2811"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:7.33333349px;font-family:'Droid Sans Fallback';-inkscape-font-specification:'Droid Sans Fallback Bold';fill:#bebebe;fill-opacity:1">$</tspan></text>
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     transform="translate(-161.0002,-397)"
+     id="layer10"
+     inkscape:label="devices" />
+  <g
+     inkscape:groupmode="layer"
+     transform="translate(-161.0002,-397)"
+     id="layer11"
+     inkscape:label="apps" />
+  <g
+     inkscape:groupmode="layer"
+     transform="translate(-161.0002,-397)"
+     id="layer13"
+     inkscape:label="places" />
+  <g
+     inkscape:groupmode="layer"
+     transform="translate(-161.0002,-397)"
+     id="layer14"
+     inkscape:label="mimetypes" />
+  <g
+     inkscape:groupmode="layer"
+     transform="translate(-161.0002,-397)"
+     id="layer15"
+     style="display:inline"
+     inkscape:label="emblems" />
+  <g
+     inkscape:groupmode="layer"
+     transform="translate(-161.0002,-397)"
+     id="g71291"
+     style="display:inline"
+     inkscape:label="emotes" />
+  <g
+     inkscape:groupmode="layer"
+     transform="translate(-161.0002,-397)"
+     id="g4953"
+     style="display:inline"
+     inkscape:label="categories" />
+  <g
+     inkscape:groupmode="layer"
+     transform="translate(-161.0002,-397)"
+     id="layer12"
+     style="display:inline"
+     inkscape:label="actions" />
+</svg>

--- a/js/gdm/loginDialog.js
+++ b/js/gdm/loginDialog.js
@@ -524,6 +524,10 @@ var LoginDialog = GObject.registerClass({
         // focus later
         this._startupCompleteId = Main.layoutManager.connect('startup-complete',
                                                              this._updateDisableUserList.bind(this));
+
+        // With PAYG machines this class can be created AFTER the startup process.
+        if (!Main.layoutManager.startingUp)
+            this._updateDisableUserList();
     }
 
     _getBannerAllocation(dialogBox) {

--- a/js/js-resources.gresource.xml
+++ b/js/js-resources.gresource.xml
@@ -145,5 +145,7 @@
     <!-- Endless-specific files beyond this point -->
 
     <file>misc/customerSupport.js</file>
+    <file>misc/paygManager.js</file>
+    <file>ui/payg.js</file>
   </gresource>
 </gresources>

--- a/js/js-resources.gresource.xml
+++ b/js/js-resources.gresource.xml
@@ -147,5 +147,6 @@
     <file>misc/customerSupport.js</file>
     <file>misc/paygManager.js</file>
     <file>ui/payg.js</file>
+    <file>ui/paygUnlockDialog.js</file>
   </gresource>
 </gresources>

--- a/js/js-resources.gresource.xml
+++ b/js/js-resources.gresource.xml
@@ -141,6 +141,7 @@
     <file>ui/status/screencast.js</file>
     <file>ui/status/system.js</file>
     <file>ui/status/thunderbolt.js</file>
+    <file>ui/status/payg.js</file>
 
     <!-- Endless-specific files beyond this point -->
 

--- a/js/misc/customerSupport.js
+++ b/js/misc/customerSupport.js
@@ -34,6 +34,12 @@ const CUSTOMER_SUPPORT_KEY_EMAIL = 'Email';
 const PASSWORD_RESET_GROUP_NAME = 'Password Reset';
 const PASSWORD_RESET_KEY_SALT = 'Salt';
 
+const PAYG_GROUP_NAME = 'Pay As You Go';
+const PAYG_KEY_CONTACT_NAME = 'ContactName';
+const PAYG_KEY_CONTACT_NUMBER = 'ContactPhoneNumber';
+const PAYG_KEY_INSTRUCTIONS_LINE1 = 'InstructionsLine1';
+const PAYG_KEY_INSTRUCTIONS_LINE2 = 'InstructionsLine2';
+
 var CustomerSupport = GObject.registerClass(
 class CustomerSupport extends GObject.Object {
 
@@ -89,5 +95,41 @@ class CustomerSupport extends GObject.Object {
         }
 
         return this._passwordResetSalt;
+    }
+
+    get paygContactName() {
+        if (this._paygContactName === undefined) {
+            this._paygContactName = this._getLocaleString(PAYG_GROUP_NAME,
+                                                          PAYG_KEY_CONTACT_NAME);
+        }
+
+        return this._paygContactName;
+    }
+
+    get paygContactNumber() {
+        if (this._paygContactNumber === undefined) {
+            this._paygContactNumber = this._getLocaleString(PAYG_GROUP_NAME,
+                                                            PAYG_KEY_CONTACT_NUMBER);
+        }
+
+        return this._paygContactNumber;
+    }
+
+    get paygInstructionsLine1() {
+        if (this._paygInstructionsLine1 === undefined) {
+            this._paygInstructionsLine1 = this._getLocaleString(PAYG_GROUP_NAME,
+                                                                PAYG_KEY_INSTRUCTIONS_LINE1);
+        }
+
+        return this._paygInstructionsLine1;
+    }
+
+    get paygInstructionsLine2() {
+        if (this._paygInstructionsLine2 === undefined) {
+            this._paygInstructionsLine2 = this._getLocaleString(PAYG_GROUP_NAME,
+                                                                PAYG_KEY_INSTRUCTIONS_LINE2);
+        }
+
+        return this._paygInstructionsLine2;
     }
 });

--- a/js/misc/paygManager.js
+++ b/js/misc/paygManager.js
@@ -1,0 +1,418 @@
+// -*- mode: js; js-indent-level: 4; indent-tabs-mode: nil -*-
+//
+// Copyright (C) 2018-2020 Endless OS Foundation LLC
+//
+// This is a GNOME Shell component to wrap the interactions over
+// D-Bus with the eos-payg system daemon.
+//
+// Licensed under the GNU General Public License Version 2
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+/* exported PaygManager, PaygErrorDomain, PaygError */
+
+const { Gio, GLib, GnomeDesktop, GObject, Shell } = imports.gi;
+
+const { loadInterfaceXML } = imports.misc.fileUtils;
+
+const Payg = imports.ui.payg;
+const Signals = imports.signals;
+
+const EOS_PAYG_NAME = 'com.endlessm.Payg1';
+const EOS_PAYG_PATH = '/com/endlessm/Payg1';
+
+const EOS_PAYG_IFACE = loadInterfaceXML('com.endlessm.Payg1');
+
+var PaygErrorDomain = GLib.quark_from_string('payg-error');
+
+var PaygError = {
+    INVALID_CODE: 0,
+    CODE_ALREADY_USED: 1,
+    TOO_MANY_ATTEMPTS: 2,
+    DISABLED: 3,
+    SHOW_ACCOUNT_ID: 4,
+};
+
+const DBusErrorsMapping = {
+    INVALID_CODE: 'com.endlessm.Payg1.Error.InvalidCode',
+    CODE_ALREADY_USED: 'com.endlessm.Payg1.Error.CodeAlreadyUsed',
+    TOO_MANY_ATTEMPTS: 'com.endlessm.Payg1.Error.TooManyAttempts',
+    DISABLED: 'com.endlessm.Payg1.Error.Disabled',
+    SHOW_ACCOUNT_ID: 'com.endlessm.Payg1.Error.DisplayAccountID',
+};
+
+// This list defines the different instants in time where we would
+// want to show notifications to the user reminding that the payg
+// subscription will be expiring soon, up to a max GLib.MAXUINT32.
+//
+// It contains a list of integers representing the number of seconds
+// earlier to the expiration time when we want to show a notification,
+// which needs to be sorted in DESCENDING order.
+const notificationAlertTimesSecs = [
+    60 * 60 * 48, // 2 days
+    60 * 60 * 24, // 1 day
+    60 * 60 * 2,  // 2 hours
+    60 * 60,      // 1 hour
+    60 * 30,      // 30 minutes
+    60 * 2,       // 2 minutes
+    30,           // 30 seconds
+];
+
+var PaygManager = GObject.registerClass({
+    Signals: {
+        'code-expired': {},
+        'code-format-changed': {},
+        'enabled-changed': { param_types: [GObject.TYPE_BOOLEAN] },
+        'expiry-time-changed': { param_types: [GObject.TYPE_UINT64] },
+        'initialized': {},
+        'rate-limit-end-time-changed':  { param_types: [GObject.TYPE_UINT64] },
+    },
+}, class PaygManager extends GObject.Object {
+    _init() {
+        super._init();
+
+        this._initialized = false;
+        this._proxy = null;
+
+        this._enabled = false;
+        this._expiryTime = 0;
+        this._lastTimeAdded = 0;
+        this._rateLimitEndTime = 0;
+        this._accountID = '';
+        this._codeFormat = '';
+        this._codeFormatRegex = null;
+        this._paygNotifier = new Payg.PaygNotifier();
+
+        // Keep track of clock changes to update notifications.
+        this._wallClock = new GnomeDesktop.WallClock({ time_only: true });
+        this._wallClockChangedId = this._wallClock.connect('notify::clock',
+            this._clockUpdated.bind(this));
+
+        // D-Bus related initialization code only below this point.
+        this._proxyInfo = Gio.DBusInterfaceInfo.new_for_xml(EOS_PAYG_IFACE);
+
+        this._codeExpiredId = 0;
+        this._impendingShutdownId = 0;
+        this._propertiesChangedId = 0;
+        this._expirationReminderId = 0;
+        this._clearNotificationId = 0;
+
+        this._cancellable = new Gio.Cancellable();
+        this._proxy = new Gio.DBusProxy({
+            g_connection: Gio.DBus.system,
+            g_interface_name: this._proxyInfo.name,
+            g_interface_info: this._proxyInfo,
+            g_name: EOS_PAYG_NAME,
+            g_object_path: EOS_PAYG_PATH,
+            g_flags: Gio.DBusProxyFlags.NONE,
+        });
+
+        this._proxy.init_async(GLib.PRIORITY_DEFAULT, this._cancellable,
+            this._onProxyConstructed.bind(this));
+
+        for (const errorCode in DBusErrorsMapping)
+            Gio.DBusError.register_error(PaygErrorDomain, PaygError[errorCode],
+                DBusErrorsMapping[errorCode]);
+    }
+
+    destroy() {
+        if (this._cancellable) {
+            this._cancellable.cancel();
+            this._cancellable = null;
+        }
+
+        if (this._wallClockChangedId > 0) {
+            this._wallClock.disconnect(this._wallClockChangedId);
+            this._wallClockChangedId = 0;
+        }
+
+        if (this._propertiesChangedId > 0) {
+            this._proxy.disconnect(this._propertiesChangedId);
+            this._propertiesChangedId = 0;
+        }
+
+        if (this._codeExpiredId > 0) {
+            this._proxy.disconnectSignal(this._codeExpiredId);
+            this._codeExpiredId = 0;
+        }
+
+        if (this._impendingShutdownId > 0) {
+            this._proxy.disconnectSignal(this._impendingShutdownId);
+            this._impendingShutdownId = 0;
+        }
+
+        if (this._expirationReminderId > 0) {
+            GLib.source_remove(this._expirationReminderId);
+            this._expirationReminderId = 0;
+        }
+
+        if (this._clearNotificationId > 0) {
+            GLib.source_remove(this._clearNotificationId);
+            this._clearNotificationId = 0;
+        }
+    }
+
+    _onProxyConstructed(object, res) {
+        let success = false;
+        try {
+            success = object.init_finish(res);
+        } catch (e) {
+            logError(e, 'Error while constructing D-Bus proxy for %s'.format(EOS_PAYG_NAME));
+        }
+
+        if (success) {
+            // Don't use the setters here to prevent emitting a -changed signal
+            // on startup, which is useless and confuses the screenshield when
+            // selecting the session mode to construct the right unlock dialog.
+            this._enabled = this._proxy.Enabled;
+            this._expiryTime = this._proxy.ExpiryTime;
+            this._rateLimitEndTime = this._proxy.RateLimitEndTime;
+            this._accountID = this._proxy.AccountID;
+            this._setCodeFormat(this._proxy.CodeFormat || '^[0-9]{8}$');
+
+            this._propertiesChangedId = this._proxy.connect('g-properties-changed', this._onPropertiesChanged.bind(this));
+            this._codeExpiredId = this._proxy.connectSignal('Expired', this._onCodeExpired.bind(this));
+            this._impendingShutdownId = this._proxy.connectSignal('ImpendingShutdown', this._onImpendingShutdown.bind(this));
+
+            this._maybeNotifyUser();
+            this._updateExpirationReminders();
+        }
+
+        this._initialized = true;
+        this.emit('initialized');
+    }
+
+    _onPropertiesChanged(proxy, changedProps) {
+        const propsDict = changedProps.deep_unpack();
+        if (propsDict.hasOwnProperty('Enabled'))
+            this._setEnabled(this._proxy.Enabled);
+
+        if (propsDict.hasOwnProperty('ExpiryTime'))
+            this._setExpiryTime(this._proxy.ExpiryTime);
+
+        if (propsDict.hasOwnProperty('RateLimitEndTime'))
+            this._setRateLimitEndTime(this._proxy.RateLimitEndTime);
+
+        if (propsDict.hasOwnProperty('CodeFormat'))
+            this._setCodeFormat(this._proxy.CodeFormat, true);
+    }
+
+    _setEnabled(value) {
+        if (this._enabled === value)
+            return;
+
+        this._enabled = value;
+        this.emit('enabled-changed', this._enabled);
+    }
+
+    _setExpiryTime(value) {
+        if (this._expiryTime === value)
+            return;
+
+        this._expiryTime = value;
+        this._updateExpirationReminders();
+
+        if (this._clearNotificationId > 0) {
+            GLib.source_remove(this._clearNotificationId);
+            this._clearNotificationId = 0;
+        }
+
+        this._clearNotificationId = GLib.idle_add(GLib.PRIORITY_DEFAULT, () => {
+            this._paygNotifier.clearNotification();
+            this._clearNotificationId = 0;
+            return GLib.SOURCE_REMOVE;
+        });
+        this.emit('expiry-time-changed', this._expiryTime);
+    }
+
+    _setRateLimitEndTime(value) {
+        if (this._rateLimitEndTime === value)
+            return;
+
+        this._rateLimitEndTime = value;
+        this.emit('rate-limit-end-time-changed', this._rateLimitEndTime);
+    }
+
+    _setCodeFormat(value, notify = false) {
+        if (this._codeFormat === value)
+            return;
+
+        this._codeFormat = value;
+        try {
+            this._codeFormatRegex = new GLib.Regex(
+                this._codeFormat,
+                GLib.RegexCompileFlags.DOLLAR_ENDONLY,
+                GLib.RegexMatchFlags.PARTIAL);
+        } catch (e) {
+            logError(e, 'Error compiling CodeFormat regex: %s'.format(this._codeFormat));
+            this._codeFormatRegex = null;
+        }
+
+        if (notify)
+            this.emit('code-format-changed');
+    }
+
+    _onCodeExpired() {
+        this.emit('code-expired');
+    }
+
+    _onImpendingShutdown(proxy, sender, [secondsRemaining, shutdownReason]) {
+        // TODO notify the user https://phabricator.endlessm.com/T27134
+    }
+
+    _clockUpdated() {
+        this._updateExpirationReminders();
+    }
+
+    _maybeNotifyUser() {
+        // Sanity check.
+        if (notificationAlertTimesSecs.length === 0)
+            return;
+
+        const secondsLeft = this.timeRemainingSecs();
+        if (secondsLeft > 0 && secondsLeft <= notificationAlertTimesSecs[0])
+            this._paygNotifier.notify(secondsLeft);
+    }
+
+    _updateExpirationReminders() {
+        if (this._expirationReminderId > 0) {
+            GLib.source_remove(this._expirationReminderId);
+            this._expirationReminderId = 0;
+        }
+
+        const secondsLeft = this.timeRemainingSecs();
+
+        // The interval passed to timeout_add_seconds needs to be a 32-bit
+        // unsigned integer, so don't bother with notifications otherwise.
+        if (secondsLeft <= 0 || secondsLeft >= GLib.MAXUINT32)
+            return;
+
+        // Look for the right time to set the alarm for.
+        let targetAlertTime = 0;
+        for (const alertTime of notificationAlertTimesSecs) {
+            if (secondsLeft > alertTime) {
+                targetAlertTime = alertTime;
+                break;
+            }
+        }
+
+        // Too late to set up an alarm now.
+        if (targetAlertTime == 0)
+            return;
+
+        this._expirationReminderId = GLib.timeout_add_seconds(
+            GLib.PRIORITY_DEFAULT,
+            secondsLeft - targetAlertTime,
+            () => {
+                // We want to show "round" numbers in the notification, matching
+                // whatever is specified in the notificationAlertTimeSecs array.
+                this._paygNotifier.notify(targetAlertTime);
+
+                // Reset _expirationReminderId before _updateExpirationReminders()
+                // to prevent an attempt to remove the same GSourceFunc twice.
+                this._expirationReminderId = 0;
+                this._updateExpirationReminders();
+
+                return GLib.SOURCE_REMOVE;
+            });
+    }
+
+    timeRemainingSecs() {
+        if (!this._enabled)
+            return Number.MAX_SAFE_INTEGER;
+
+        return Math.max(0, this._expiryTime - (Shell.util_get_boottime() / GLib.USEC_PER_SEC));
+    }
+
+    addCode(code, callback) {
+        if (!this._proxy) {
+            log('Unable to add PAYG code: No D-Bus proxy for %s'.format(EOS_PAYG_NAME));
+            return;
+        }
+
+        this._proxy.AddCodeRemote(code, (result, error) => {
+            if (!error)
+                this._lastTimeAdded = result;
+
+            if (callback)
+                callback(error);
+        }, this._cancellable);
+    }
+
+    clearCode() {
+        if (!this._proxy) {
+            log('Unable to clear PAYG code: No D-Bus proxy for %s'.format(EOS_PAYG_NAME));
+            return;
+        }
+
+        this._proxy.ClearCodeRemote();
+    }
+
+    validateCode(code, partial = false) {
+        if (!this._codeFormatRegex) {
+            log('Unable to validate PAYG code: no regex');
+            return false;
+        }
+
+        let is_match, match_info;
+
+        if (partial)
+            [is_match, match_info] = this._codeFormatRegex.match(this.codeFormatPrefix + code, 0);
+        else
+            [is_match, match_info] = this._codeFormatRegex.match(
+                this.codeFormatPrefix + code + this.codeFormatSuffix, 0);
+
+        return is_match || (partial && match_info.is_partial_match());
+    }
+
+    get initialized() {
+        return this._initialized;
+    }
+
+    get codeFormatPrefix() {
+        return this._proxy.CodeFormatPrefix;
+    }
+
+    get codeFormatSuffix() {
+        return this._proxy.CodeFormatSuffix;
+    }
+
+    get enabled() {
+        return this._enabled;
+    }
+
+    get expiryTime() {
+        return this._expiryTime;
+    }
+
+    get lastTimeAdded() {
+        return this._lastTimeAdded;
+    }
+
+    get rateLimitEndTime() {
+        return this._rateLimitEndTime;
+    }
+
+    get accountID() {
+        return this._accountID;
+    }
+
+    get isLocked() {
+        if (!this.enabled)
+            return false;
+
+        return this.timeRemainingSecs() <= 0;
+    }
+});

--- a/js/ui/main.js
+++ b/js/ui/main.js
@@ -29,6 +29,7 @@ const Overview = imports.ui.overview;
 const PadOsd = imports.ui.padOsd;
 const Panel = imports.ui.panel;
 const Params = imports.misc.params;
+const PaygManager = imports.misc.paygManager;
 const RunDialog = imports.ui.runDialog;
 const Layout = imports.ui.layout;
 const LoginManager = imports.misc.loginManager;
@@ -89,6 +90,7 @@ var inputMethod = null;
 var introspectService = null;
 var locatePointer = null;
 var customerSupport = null;
+var paygManager = null;
 let _startDate;
 let _defaultCssStylesheet = null;
 let _cssStylesheet = null;
@@ -213,6 +215,10 @@ function _initializeUI() {
     magnifier = new Magnifier.Magnifier();
     locatePointer = new LocatePointer.LocatePointer();
 
+    // The ScreenShield depends on the PaygManager, so this
+    // module needs to be initialized first.
+    paygManager = new PaygManager.PaygManager();
+
     // Centralized handling of things specific to customer support.
     customerSupport = new CustomerSupport.CustomerSupport();
 
@@ -278,7 +284,17 @@ function _initializeUI() {
 
     if (sessionMode.isGreeter && screenShield) {
         layoutManager.connect('startup-prepared', () => {
-            screenShield.showDialog();
+            // We can't show the login dialog (which is managed by the
+            // screenshield) until the PaygManager is initializd, since
+            // we need to check whether the machine is PAYG-locked first.
+            if (paygManager.initialized) {
+                screenShield.showDialog();
+            } else {
+                const paygManagerId = paygManager.connect('initialized', () => {
+                    screenShield.showDialog();
+                    paygManager.disconnect(paygManagerId);
+                });
+            }
         });
     }
 

--- a/js/ui/panel.js
+++ b/js/ui/panel.js
@@ -731,6 +731,7 @@ class AggregateMenu extends PanelMenu.Button {
             this._bluetooth = null;
 
         this._remoteAccess = new imports.ui.status.remoteAccess.RemoteAccessApplet();
+        this._payg = new imports.ui.status.payg.Indicator();
         this._power = new imports.ui.status.power.Indicator();
         this._rfkill = new imports.ui.status.rfkill.Indicator();
         this._volume = new imports.ui.status.volume.Indicator();
@@ -749,6 +750,8 @@ class AggregateMenu extends PanelMenu.Button {
             this._indicators.add_child(this._network);
         if (this._bluetooth)
             this._indicators.add_child(this._bluetooth);
+        if (this._payg)
+            this._indicators.add_child(this._payg);
         this._indicators.add_child(this._remoteAccess);
         this._indicators.add_child(this._rfkill);
         this._indicators.add_child(this._volume);
@@ -763,6 +766,8 @@ class AggregateMenu extends PanelMenu.Button {
 
         if (this._bluetooth)
             this.menu.addMenuItem(this._bluetooth.menu);
+        if (this._payg)
+            this.menu.addMenuItem(this._payg.menu);
 
         this.menu.addMenuItem(this._remoteAccess.menu);
         this.menu.addMenuItem(this._location.menu);

--- a/js/ui/payg.js
+++ b/js/ui/payg.js
@@ -1,0 +1,784 @@
+// -*- mode: js; js-indent-level: 4; indent-tabs-mode: nil -*-
+//
+// Copyright (C) 2018-2020 Endless OS Foundation LLC
+//
+// Licensed under the GNU General Public License Version 2
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+/* exported PaygUnlockCodeEntry, PaygUnlockUi, PaygUnlockWidget, PaygNotifier,
+     ApplyCodeNotification, SPINNER_ICON_SIZE_PIXELS, UnlockStatus, timeToString,
+     successMessage */
+
+const { Clutter, Gio, GLib, GObject, Shell, St } = imports.gi;
+
+const PaygManager = imports.misc.paygManager;
+
+const Gettext = imports.gettext;
+const Animation = imports.ui.animation;
+const Main = imports.ui.main;
+const MessageTray = imports.ui.messageTray;
+
+const SUCCESS_DELAY_SECONDS = 3;
+
+const SPINNER_ANIMATION_DELAY_MSECS = 1000;
+const SPINNER_ANIMATION_TIME_MSECS = 300;
+var SPINNER_ICON_SIZE_PIXELS = 16;
+
+const NOTIFICATION_TITLE_TEXT = _('Pay As You Go');
+const NOTIFICATION_EARLY_CODE_ENTRY_TEXT = _('Enter an unlock code to extend the time before your credit has expired.');
+const NOTIFICATION_DETAILED_FORMAT_STRING = _('Subscription runs out in %s.');
+
+var UnlockStatus = {
+    NOT_VERIFYING: 0,
+    VERIFYING: 1,
+    FAILED: 2,
+    TOO_MANY_ATTEMPTS: 3,
+    SUCCEEDED: 4,
+};
+
+var PaygUnlockCodeEntry = GObject.registerClass({
+    Signals: {
+        'code-changed': { param_types: [GObject.TYPE_STRING] },
+    },
+}, class PaygUnlockCodeEntry extends St.Entry {
+    _init(params) {
+        super._init(params);
+
+        this._code = '';
+        this._enabled = false;
+        this._buttonPressEventId = this.connect('button-press-event', this._onButtonPressEvent.bind(this));
+        this._capturedEventId = this.clutter_text.connect('captured-event', this._onCapturedEvent.bind(this));
+        this._textChangedId = this.clutter_text.connect('text-changed', this._onTextChanged.bind(this));
+
+        this.connect('destroy', this._onDestroy.bind(this));
+    }
+
+    _onDestroy() {
+        if (this._buttonPressEventId > 0) {
+            this.disconnect(this._buttonPressEventId);
+            this._buttonPressEventId = 0;
+        }
+
+        if (this._capturedEventId > 0) {
+            this.clutter_text.disconnect(this._capturedEventId);
+            this._capturedEventId = 0;
+        }
+
+        if (this._textChangedId > 0) {
+            this.clutter_text.disconnect(this._textChangedId);
+            this._textChangedId = 0;
+        }
+    }
+
+    _onCapturedEvent(textActor, event) {
+        if (event.type() !== Clutter.EventType.KEY_PRESS)
+            return Clutter.EVENT_PROPAGATE;
+
+        const keysym = event.get_key_symbol();
+        const isDeleteKey =
+            keysym === Clutter.KEY_Delete ||
+            keysym === Clutter.KEY_KP_Delete ||
+            keysym === Clutter.KEY_BackSpace;
+        const isEnterKey =
+            keysym === Clutter.KEY_Return ||
+            keysym === Clutter.KEY_KP_Enter ||
+            keysym === Clutter.KEY_ISO_Enter;
+        const isExitKey =
+            keysym === Clutter.KEY_Escape ||
+            keysym === Clutter.KEY_Tab;
+        const isMovementKey =
+            keysym === Clutter.KEY_Left ||
+            keysym === Clutter.KEY_Right ||
+            keysym === Clutter.KEY_Home ||
+            keysym === Clutter.KEY_KP_Home ||
+            keysym === Clutter.KEY_End ||
+            keysym === Clutter.KEY_KP_End;
+
+        // Make sure we can leave the entry and delete and
+        // navigate numbers with the keyboard.
+        if (isExitKey || isEnterKey || isDeleteKey || isMovementKey)
+            return Clutter.EVENT_PROPAGATE;
+
+        const character = event.get_key_unicode();
+        this.addCharacter(character);
+
+        return Clutter.EVENT_STOP;
+    }
+
+    _onTextChanged(textActor) {
+        this._code = textActor.text;
+        this.emit('code-changed', this._code);
+    }
+
+    _onButtonPressEvent() {
+        if (!this._enabled)
+            return;
+
+        this.grab_key_focus();
+        return false;
+    }
+
+    addCharacter(character) {
+        if (!this._enabled || !GLib.unichar_isprint(character) ||
+            character === Main.paygManager.codeFormatPrefix ||
+            character === Main.paygManager.codeFormatSuffix)
+            return;
+
+        const pos = this.clutter_text.get_cursor_position();
+        const before = pos === -1 ? this._code : this._code.slice(0, pos);
+        const after = pos === -1 ? '' : this._code.slice(pos);
+        const newCode = before + character + after;
+
+        if (!Main.paygManager.validateCode(newCode, true))
+            return;
+
+        this.clutter_text.insert_unichar(character);
+    }
+
+    setEnabled(value) {
+        if (this._enabled === value)
+            return;
+
+        this._enabled = value;
+        this.reactive = value;
+        this.can_focus = value;
+        this.clutter_text.reactive = value;
+        this.clutter_text.editable = value;
+        this.clutter_text.cursor_visible = value;
+    }
+
+    reset() {
+        this.text = '';
+    }
+
+    get code() {
+        return this._code;
+    }
+
+    get length() {
+        return this._code.length;
+    }
+});
+
+var PaygUnlockUi = GObject.registerClass({
+    Signals: {
+        'code-reset': {},
+    },
+}, class PaygUnlockUi extends St.Widget {
+
+    // the following properties and functions are required for any subclasses of
+    // this class
+
+    // properties
+    // -----------
+    // applyButton
+    // entryCode
+    // spinner
+    // verificationStatus
+
+    // functions
+    // ----------
+    // entryReset
+    // entrySetEnabled
+    // onCodeAdded
+    // reset
+
+    _init(params = {}) {
+        super._init(params);
+        this._clearTooManyAttemptsId = 0;
+        this.connect('destroy', this._onDestroy.bind(this));
+    }
+
+    updateApplyButtonSensitivity() {
+        const sensitive = this.validateCurrentCode(false) &&
+            this.verificationStatus !== UnlockStatus.VERIFYING &&
+            this.verificationStatus !== UnlockStatus.SUCCEEDED &&
+            this.verificationStatus !== UnlockStatus.TOO_MANY_ATTEMPTS;
+
+        this.applyButton.reactive = sensitive;
+        this.applyButton.can_focus = sensitive;
+    }
+
+    updateSensitivity() {
+        const shouldEnableEntry =
+            this.verificationStatus !== UnlockStatus.VERIFYING &&
+            this.verificationStatus !== UnlockStatus.SUCCEEDED &&
+            this.verificationStatus !== UnlockStatus.TOO_MANY_ATTEMPTS;
+
+        this.updateApplyButtonSensitivity();
+        this.entrySetEnabled(shouldEnableEntry);
+    }
+
+    processError(error) {
+        logError(error, 'Error adding PAYG code');
+
+        // The 'too many errors' case is a bit special, and sets a different state.
+        if (error.matches(PaygManager.PaygErrorDomain, PaygManager.PaygError.TOO_MANY_ATTEMPTS)) {
+            const currentTime = Shell.util_get_boottime() / GLib.USEC_PER_SEC;
+            const secondsLeft = Main.paygManager.rateLimitEndTime - currentTime;
+            if (secondsLeft > 30) {
+                const minutesLeft = Math.max(0, Math.ceil(secondsLeft / 60));
+                this.setErrorMessage(
+                    Gettext.ngettext(
+                        'Too many attempts. Try again in %s minute.',
+                        'Too many attempts. Try again in %s minutes.', minutesLeft)
+                        .format(minutesLeft));
+            } else {
+                this.setErrorMessage(_('Too many attempts. Try again in a few seconds.'));
+            }
+
+            // Make sure to clean the status once the time is up (if this dialog is still alive)
+            // and make sure that we install this callback at some point in the future (+1 sec).
+            this._clearTooManyAttemptsId = GLib.timeout_add_seconds(
+                GLib.PRIORITY_DEFAULT,
+                Math.max(1, secondsLeft),
+                () => {
+                    this._verificationStatus = UnlockStatus.NOT_VERIFYING;
+                    this._clearError();
+                    this._updateSensitivity();
+                    return GLib.SOURCE_REMOVE;
+                });
+
+            this.verificationStatus = UnlockStatus.TOO_MANY_ATTEMPTS;
+            return;
+        }
+
+        // Common errors after this point.
+        if (error.matches(PaygManager.PaygErrorDomain, PaygManager.PaygError.INVALID_CODE)) {
+            this.setErrorMessage(_('Invalid code. Please try again.'));
+        } else if (error.matches(PaygManager.PaygErrorDomain, PaygManager.PaygError.CODE_ALREADY_USED)) {
+            this.setErrorMessage(_('Code already used. Please enter a new code.'));
+        } else if (error.matches(Gio.IOErrorEnum, Gio.IOErrorEnum.TIMED_OUT)) {
+            this.setErrorMessage(_('Time exceeded while verifying the code'));
+        } else if (error.matches(PaygManager.PaygErrorDomain, PaygManager.PaygError.SHOW_ACCOUNT_ID)) {
+            this.setErrorMessage(_('Your Pay As You Go Account ID is: %s').format(Main.paygManager.accountID));
+        } else {
+            // We don't consider any other error here (and we don't consider DISABLED explicitly,
+            // since that should not happen), but still we need to show something to the user.
+            this.setErrorMessage(_('Unknown error'));
+        }
+
+        this.verificationStatus = UnlockStatus.FAILED;
+    }
+
+    processReset() {
+        // If time has been removed entirely, we show the user the according message
+        // that the time has been reset to zero.
+        this.emit('code-reset');
+        this.verificationStatus = UnlockStatus.FAILED;
+    }
+
+    _onDestroy() {
+        if (this._clearTooManyAttemptsId > 0) {
+            GLib.source_remove(this._clearTooManyAttemptsId);
+            this._clearTooManyAttemptsId = 0;
+        }
+    }
+
+    setErrorMessage(message) {
+        if (message) {
+            this.errorLabel.text = message;
+            this.errorLabel.opacity = 255;
+        } else {
+            this.errorLabel.text = '';
+            this.errorLabel.opacity = 0;
+        }
+    }
+
+    clearError() {
+        this.setErrorMessage(null);
+    }
+
+    startSpinning() {
+        this.spinner.play();
+        this.spinner.show();
+        this.spinner.ease({
+            opacity: 255,
+            delay: SPINNER_ANIMATION_DELAY_MSECS,
+            duration: SPINNER_ANIMATION_TIME_MSECS,
+            mode: Clutter.AnimationMode.LINEAR,
+        });
+    }
+
+    stopSpinning() {
+        this.spinner.hide();
+        this.spinner.opacity = 0;
+        this.spinner.stop();
+    }
+
+    reset() {
+        this.stopSpinning();
+        this.entryReset();
+        this.updateSensitivity();
+    }
+
+    validateCurrentCode(partial=true) {
+        return Main.paygManager.validateCode(this.entryCode, partial);
+    }
+
+    startVerifyingCode() {
+        if (!this.validateCurrentCode(false))
+            return;
+
+        this.verificationStatus = UnlockStatus.VERIFYING;
+        this.startSpinning();
+        this.updateSensitivity();
+        this.cancelled = false;
+
+        const code = '%s%s%s'.format(
+            Main.paygManager.codeFormatPrefix,
+            this.entryCode,
+            Main.paygManager.codeFormatSuffix);
+
+        Main.paygManager.addCode(code, error => {
+            // We don't care about the result if we're closing the dialog.
+            if (this.cancelled) {
+                this.verificationStatus = UnlockStatus.NOT_VERIFYING;
+                return;
+            }
+
+            if (error) {
+                this.processError(error);
+            } else if (Main.paygManager.lastTimeAdded <= 0) {
+                this.processReset();
+            } else {
+                this.verificationStatus = UnlockStatus.SUCCEEDED;
+                this.onCodeAdded();
+            }
+
+            this.reset();
+        });
+    }
+});
+
+var PaygUnlockWidget = GObject.registerClass({
+    Signals: {
+        'code-added': {},
+        'code-rejected': { param_types: [GObject.TYPE_STRING] },
+    },
+}, class PaygUnlockWidget extends PaygUnlockUi {
+    _init() {
+        super._init();
+
+        this._verificationStatus = UnlockStatus.NOT_VERIFYING;
+        this._codeEntry = this._createCodeEntry();
+        this._spinner = this._createSpinner();
+        const entrySpinnerBox = new St.BoxLayout({
+            style_class: 'notification-actions',
+            x_expand: false,
+        });
+        if (Main.paygManager.codeFormatPrefix !== '') {
+            const prefix = new St.Label({
+                style_class: 'notification-payg-code-entry',
+                text: Main.paygManager.codeFormatPrefix,
+                x_align: Clutter.ActorAlign.CENTER,
+            });
+
+            entrySpinnerBox.add_child(prefix);
+        }
+        entrySpinnerBox.add_child(this._codeEntry);
+        entrySpinnerBox.add_child(this._spinner);
+
+        if (Main.paygManager.codeFormatSuffix !== '') {
+            const suffix = new St.Label({
+                style_class: 'notification-payg-code-entry',
+                text: Main.paygManager.codeFormatSuffix,
+                x_align: Clutter.ActorAlign.CENTER,
+            });
+
+            entrySpinnerBox.add_child(suffix);
+        }
+
+        this._buttonBox = new St.BoxLayout({
+            style_class: 'notification-actions',
+            x_expand: true,
+            vertical: true,
+        });
+        global.focus_manager.add_group(this._buttonBox);
+        this._buttonBox.add_child(entrySpinnerBox);
+
+        this._applyButton = this._createApplyButton();
+        this._applyButton.connect('clicked', this.startVerifyingCode.bind(this));
+        this._buttonBox.add_child(this._applyButton);
+
+        this.updateSensitivity();
+    }
+
+    _createCodeEntry() {
+        const codeEntry = new PaygUnlockCodeEntry({
+            style_class: 'notification-payg-entry',
+            x_expand: true,
+            can_focus: true,
+        });
+        codeEntry.clutter_text.connect('activate', this.startVerifyingCode.bind(this));
+        codeEntry.clutter_text.connect('text-changed', this.updateApplyButtonSensitivity.bind(this));
+        codeEntry._enabled = true;
+
+        return codeEntry;
+    }
+
+    _createSpinner() {
+        // We make the most of the spacer to show the spinner while verifying the code.
+        const spinnerIcon = Gio.File.new_for_uri('resource:///org/gnome/shell/theme/process-working.svg');
+        const spinner = new Animation.AnimatedIcon(spinnerIcon, SPINNER_ICON_SIZE_PIXELS);
+        spinner.opacity = 0;
+        spinner.hide();
+
+        return spinner;
+    }
+
+    _createApplyButton() {
+        const box = new St.BoxLayout();
+
+        const label = new St.Bin({
+            x_expand: true,
+            child: new St.Label({
+                x_expand: true,
+                x_align: Clutter.ActorAlign.CENTER,
+                text: _('Apply Code'),
+            }),
+        });
+        box.add_child(label);
+
+        const button = new St.Button({
+            child: box,
+            x_expand: true,
+            button_mask: St.ButtonMask.ONE,
+            style_class: 'hotplug-notification-item button',
+        });
+
+        return button;
+    }
+
+    setErrorMessage(message) {
+        this.emit('code-rejected', message);
+    }
+
+    _onEntryChanged() {
+        this.updateApplyButtonSensitivity();
+    }
+
+    onCodeAdded() {
+        this.emit('code-added');
+    }
+
+    entryReset() {
+        this._codeEntry.set_text('');
+    }
+
+    entrySetEnabled(enabled) {
+        if (this._codeEntry._enabled === enabled)
+            return;
+
+        this._codeEntry._enabled = enabled;
+        this._codeEntry.reactive = enabled;
+        this._codeEntry.can_focus = enabled;
+        this._codeEntry.clutter_text.reactive = enabled;
+        this._codeEntry.clutter_text.editable = enabled;
+        this._codeEntry.clutter_text.cursor_visible = enabled;
+    }
+
+    get entryCode() {
+        return this._codeEntry.get_text();
+    }
+
+    get verificationStatus() {
+        return this._verificationStatus;
+    }
+
+    set verificationStatus(value) {
+        this._verificationStatus = value;
+    }
+
+    get spinner() {
+        return this._spinner;
+    }
+
+    get applyButton() {
+        return this._applyButton;
+    }
+
+    get buttonBox() {
+        return this._buttonBox;
+    }
+
+});
+
+var ApplyCodeNotification = GObject.registerClass({
+    Signals: {
+        'done-displaying': {},
+    },
+}, class ApplyCodeNotification extends MessageTray.Notification {
+    _init(source, title, banner) {
+        super._init(source, title, banner);
+
+        this._titleOrig = title;
+
+        // Note: "banner" is actually the string displayed in the banner, not a
+        // banner object. This variable name simply follows the convention of
+        // the parent class.
+        this._bannerOrig = banner;
+        this._verificationStatus = UnlockStatus.NOT_VERIFYING;
+
+        this._codeAddedId = 0;
+        this._codeRejectedId = 0;
+        this._doneId = 0;
+
+        this.connect('destroy', this._onDestroy.bind(this));
+    }
+
+    _onDestroy() {
+        if (this._codeAddedId > 0) {
+            this._unlockWidget.disconnect(this._codeAddedId);
+            this._codeAddedId = 0;
+        }
+
+        if (this._codeRejectedId > 0) {
+            this._unlockWidget.disconnect(this._codeRejectedId);
+            this._codeRejectedId = 0;
+        }
+
+        if (this._doneId > 0) {
+            GLib.source_remove(this._doneId);
+            this._doneId = 0;
+        }
+    }
+
+    createBanner() {
+        if (this._codeAddedId > 0) {
+            this._unlockWidget.disconnect(this._codeAddedId);
+            this._codeAddedId = 0;
+        }
+
+        if (this._codeRejectedId > 0) {
+            this._unlockWidget.disconnect(this._codeRejectedId);
+            this._codeRejectedId = 0;
+        }
+
+        this._banner = new MessageTray.NotificationBanner(this);
+        this._unlockWidget = new PaygUnlockWidget();
+        this._codeAddedId = this._unlockWidget.connect('code-added', this._onCodeAdded.bind(this));
+        this._codeRejectedId = this._unlockWidget.connect('code-rejected', this._onCodeRejected.bind(this));
+        this._banner.setActionArea(this._unlockWidget.buttonBox);
+
+        return this._banner;
+    }
+
+    _onCodeAdded() {
+        this._setMessage(successMessage());
+
+        if (this._doneId > 0) {
+            GLib.source_remove(this._doneId);
+            this._doneId = 0;
+        }
+
+        this._doneId = GLib.timeout_add_seconds(
+            GLib.PRIORITY_DEFAULT,
+            SUCCESS_DELAY_SECONDS,
+            () => {
+                this.emit('done-displaying');
+                this.destroy();
+
+                return GLib.SOURCE_REMOVE;
+            });
+    }
+
+    // if errorMessage is unspecified, a default message will be populated based
+    // on whether time remains
+    _onCodeRejected(unlockWidget, errorMessage) {
+        this._setMessage(errorMessage ? errorMessage : this._bannerOrig);
+    }
+
+    _setMessage(message) {
+        this.update(this._titleOrig, message);
+    }
+
+    activate() {
+        // We get here if the Apply button is inactive when we try to click it.
+        // Unless we're already done, exit early so we don't destroy the
+        // notification)
+        if (this._verificationStatus !== UnlockStatus.SUCCEEDED)
+            return;
+
+        super.activate();
+    }
+});
+
+// Takes a number of seconds and returns a string
+// with a precision level appropriate to show to the user.
+//
+// The returned string will be formatted just in seconds for times
+// under 1 minute, in minutes for times under 2 hours, in hours and
+// minutes (if applicable) for times under 1 day, and then in days
+// and hours (if applicable) for anything longer than that in days.
+//
+// Some examples:
+//   - 45 seconds => "45 seconds"
+//   - 60 seconds => "1 minute"
+//   - 95 seconds => "1 minute"
+//   - 120 seconds => "2 minutes"
+//   - 3600 seconds => "60 minutes"
+//   - 4500 seconds => "75 minutes"
+//   - 7200 seconds => "2 hours"
+//   - 8640 seconds => "2 hours 24 minutes"
+//   - 86400 seconds => "1 day"
+//   - 115200 seconds => "1 day 8 hours"
+//   - 172800 seconds => "2 days"
+function timeToString(seconds) {
+    if (seconds < 60)
+        return Gettext.ngettext('%s second', '%s seconds', seconds).format(Math.floor(seconds));
+
+    const minutes = Math.floor(seconds / 60);
+    if (minutes < 120)
+        return Gettext.ngettext('%s minute', '%s minutes', minutes).format(minutes);
+
+    const hours = Math.floor(minutes / 60);
+    if (hours < 24) {
+        const hoursStr = Gettext.ngettext('%s hour', '%s hours', hours).format(hours);
+
+        const minutesPast = minutes % 60;
+        if (minutesPast === 0)
+            return hoursStr;
+
+        const minutesStr = Gettext.ngettext('%s minute', '%s minutes', minutesPast).format(minutesPast);
+        return '%s %s'.format(hoursStr, minutesStr);
+    }
+
+    const days = Math.floor(hours / 24);
+    const daysStr = Gettext.ngettext('%s day', '%s days', days).format(days);
+
+    const hoursPast = hours % 24;
+    if (hoursPast === 0)
+        return daysStr;
+
+    const hoursStr = Gettext.ngettext('%s hour', '%s hours', hoursPast).format(hoursPast);
+    return '%s %s'.format(daysStr, hoursStr);
+}
+
+// Similar to timeToString, but does not process partial time,
+// since it's meant to be used for expiration time changes, with
+// a wider range of periods
+function successMessage() {
+    const seconds = Main.paygManager.lastTimeAdded;
+    if (seconds < 60) {
+        return Gettext.ngettext("%s second has been added to your Pay As You Go credit.",
+                                "%s seconds have been added to your Pay As You Go credit.",
+                                Math.floor(seconds))
+                                .format(Math.floor(seconds));
+    }
+
+    const minutes = Math.floor(seconds / 60);
+    if (minutes < 120) {
+        return Gettext.ngettext("%s minute has been added to your Pay As You Go credit.",
+                                "%s minutes have been added to your Pay As You Go credit.",
+                                Math.floor(minutes))
+                                .format(Math.floor(minutes));
+    }
+
+    const hours = Math.floor(minutes / 60);
+    if (hours < 24) {
+        return Gettext.ngettext("%s hour has been added to your Pay As You Go credit.",
+                                "%s hours have been added to your Pay As You Go credit.",
+                                Math.floor(hours))
+                                .format(Math.floor(hours));
+    }
+
+    const days = Math.floor(hours / 24);
+    if (days < 30) {
+        return Gettext.ngettext("%s day has been added to your Pay As You Go credit.",
+                                "%s days have been added to your Pay As You Go credit.",
+                                Math.floor(days))
+                                .format(Math.floor(days));
+    }
+
+    const months = Math.floor(days / 30);
+    if (months < 12) {
+        return Gettext.ngettext("%s month has been added to your Pay As You Go credit.",
+                                "%s months have been added to your Pay As You Go credit.",
+                                Math.floor(months))
+                                .format(Math.floor(months));
+    }
+
+    const year = Math.floor(months / 12);
+    if (year == 1)
+        return _("1 year has been added to your Pay As You Go credit.");
+
+    //Unlock permanently message
+    return _("You have successfully unlocked your Endless Machine");
+}
+
+var PaygNotifier = GObject.registerClass(
+class PaygNotifier extends GObject.Object {
+    _init() {
+        super._init();
+
+        this._notification = null;
+    }
+
+    notify(secondsLeft) {
+        // Only notify when in an regular session, not in GDM or initial-setup.
+        if (!Main.sessionMode.hasOverview)
+            return;
+
+        // Clear previous notification
+        this.clearNotification();
+
+        const source = new MessageTray.SystemNotificationSource();
+        Main.messageTray.add(source);
+
+        // by default, this notification is for early entry of an unlock code
+        let messageText = NOTIFICATION_EARLY_CODE_ENTRY_TEXT;
+        let urgency = MessageTray.Urgency.NORMAL;
+        let userInitiated = false;
+
+        // in case this is a "only X time left" warning notification
+        if (secondsLeft >= 0) {
+            const timeLeft = timeToString(secondsLeft);
+            messageText = NOTIFICATION_DETAILED_FORMAT_STRING.format(timeLeft);
+            urgency = MessageTray.Urgency.HIGH;
+        } else {
+            userInitiated = true;
+        }
+
+        this._notification = new ApplyCodeNotification(
+            source,
+            NOTIFICATION_TITLE_TEXT,
+            messageText);
+
+        if (userInitiated)
+            this._notification.setResident(true);
+
+        this._notification.setTransient(false);
+        this._notification.setUrgency(urgency);
+        source.showNotification(this._notification);
+
+        // if the user triggered this notification, immediately expand so the
+        // user sees the input field
+        if (userInitiated)
+            Main.messageTray._expandActiveNotification();
+
+        this._notification.connect('destroy', () => {
+            this._notification = null;
+        });
+    }
+
+    clearNotification() {
+        if (this._notification) {
+            this._notification.destroy();
+            this._notification = null;
+        }
+    }
+});

--- a/js/ui/paygUnlockDialog.js
+++ b/js/ui/paygUnlockDialog.js
@@ -1,0 +1,536 @@
+// -*- mode: js; js-indent-level: 4; indent-tabs-mode: nil -*-
+//
+// Copyright (C) 2018-2020 Endless OS Foundation LLC
+//
+// Licensed under the GNU General Public License Version 2
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+/* exported PaygUnlockDialog */
+
+const { Atk, Clutter, GLib,
+    GObject, Meta, Pango, Shell, St }  = imports.gi;
+
+const Payg = imports.ui.payg;
+
+const Animation = imports.ui.animation;
+const Main = imports.ui.main;
+const LayoutManager = imports.ui.layout;
+
+const MSEC_PER_SEC = 1000;
+
+// The timeout before going back automatically to the lock screen
+const IDLE_TIMEOUT_SECS = 2 * 60;
+
+var PaygUnlockDialog = GObject.registerClass({
+    Signals: {
+        'code-added': {},
+        'failed': {},
+        'success-message-shown': {},
+        'wake-up-screen': {},
+    },
+}, class PaygUnlockDialog extends Payg.PaygUnlockUi {
+    _init(parentActor) {
+        super._init({
+            accessible_role: Atk.Role.WINDOW,
+            style_class: 'unlock-dialog-payg',
+            layout_manager: new Clutter.BoxLayout(),
+            visible: false,
+        });
+
+        this._parentActor = parentActor;
+        this._entry = null;
+        this._errorMessage = null;
+        this._cancelButton = null;
+        this._nextButton = null;
+        this._spinner = null;
+        this._cancelled = false;
+
+        this._verificationStatus = Payg.UnlockStatus.NOT_VERIFYING;
+
+        // Clear the clipboard to make sure nothing can be copied into the entry.
+        St.Clipboard.get_default().set_text(St.ClipboardType.CLIPBOARD, '');
+        St.Clipboard.get_default().set_text(St.ClipboardType.PRIMARY, '');
+
+        this.add_constraint(new LayoutManager.MonitorConstraint({ primary: true }));
+
+        this._parentActor.add_child(this);
+
+        const mainBox = new St.BoxLayout({
+            vertical: true,
+            x_align: Clutter.ActorAlign.FILL,
+            y_align: Clutter.ActorAlign.FILL,
+            x_expand: true,
+            y_expand: true,
+        });
+        this.add_child(mainBox);
+
+        const paygEnterCodeBox = new St.BoxLayout({
+            vertical: true,
+            x_align: Clutter.ActorAlign.FILL,
+            y_align: Clutter.ActorAlign.CENTER,
+            x_expand: true,
+            y_expand: true,
+            style_class: 'unlock-dialog-payg-layout',
+        });
+        mainBox.add_child(paygEnterCodeBox);
+
+        const titleLabel = new St.Label({
+            style_class: 'unlock-dialog-payg-title',
+            text: _('Your Pay As You Go usage credit has expired.'),
+            x_align: Clutter.ActorAlign.CENTER,
+        });
+        paygEnterCodeBox.add_child(titleLabel);
+
+        const promptBox = new St.BoxLayout({
+            vertical: true,
+            x_align: Clutter.ActorAlign.CENTER,
+            y_align: Clutter.ActorAlign.CENTER,
+            x_expand: true,
+            y_expand: true,
+            style_class: 'unlock-dialog-payg-promptbox',
+        });
+        promptBox.connect('key-press-event', (actor, event) => {
+            if (event.get_key_symbol() === Clutter.KEY_Escape)
+                this._onCancelled();
+
+            return Clutter.EVENT_PROPAGATE;
+        });
+        paygEnterCodeBox.add_child(promptBox);
+
+        const promptLabel = new St.Label({
+            style_class: 'unlock-dialog-payg-label',
+            text: _('Enter a new code to unlock your computer:'),
+            x_align: Clutter.ActorAlign.START,
+        });
+        promptLabel.clutter_text.line_wrap = true;
+        promptLabel.clutter_text.ellipsize = Pango.EllipsizeMode.NONE;
+        promptBox.add_child(promptLabel);
+
+        const entryBox = this._createEntryArea();
+        promptBox.add_child(entryBox);
+
+        this._errorMessage = new St.Label({
+            opacity: 0,
+            styleClass: 'unlock-dialog-payg-message',
+        });
+        this._errorMessage.clutter_text.line_wrap = true;
+        this._errorMessage.clutter_text.ellipsize = Pango.EllipsizeMode.NONE;
+        promptBox.add_child(this._errorMessage);
+
+        this._buttonBox = this._createButtonsArea();
+        promptBox.add_child(this._buttonBox);
+
+        // Use image-specific instructions if present, or the fallback text otherwise.
+        const instructionsLine1 = Main.customerSupport.paygInstructionsLine1
+            ? Main.customerSupport.paygInstructionsLine1 : _('Don’t have an unlock code? That’s OK!');
+
+        const helpLineMain = new St.Label({
+            style_class: 'unlock-dialog-payg-help-main',
+            text: instructionsLine1,
+            x_align: Clutter.ActorAlign.START,
+        });
+        helpLineMain.clutter_text.line_wrap = true;
+        helpLineMain.clutter_text.ellipsize = Pango.EllipsizeMode.NONE;
+
+        promptBox.add_child(helpLineMain);
+
+        // Default to the fallback text, before figuring out whether
+        // we can show something more image-specific to the user.
+        let instructionsLine2;
+        if (Main.customerSupport.paygInstructionsLine2) {
+            // Overrides for the entire line take priority over everything else.
+            instructionsLine2 = Main.customerSupport.paygInstructionsLine2;
+        } else if (Main.customerSupport.paygContactName && Main.customerSupport.paygContactNumber) {
+            // The second possible override is to use the template text below
+            // with the contact's name and phone number, if BOTH are present.
+            instructionsLine2 = _('Talk to your sales representative to purchase a new code. Call or text %s at %s')
+                .format(Main.customerSupport.paygContactName, Main.customerSupport.paygContactNumber);
+        } else {
+            // No overrides present, default to fallback text.
+            instructionsLine2 = _('Talk to your sales representative to purchase a new code.');
+        }
+
+        const helpLineSub = new St.Label({
+            style_class: 'unlock-dialog-payg-help-sub',
+            text: instructionsLine2,
+            x_align: Clutter.ActorAlign.START,
+        });
+        helpLineSub.clutter_text.line_wrap = true;
+        helpLineSub.clutter_text.ellipsize = Pango.EllipsizeMode.NONE;
+
+        promptBox.add_child(helpLineSub);
+
+        // The standard value for an empty ACCOUNT_ID is 0, which implies the backend provider doesn't
+        // support the feature.
+        if (Main.paygManager.accountID !== '0') {
+            const infoBox = new St.BoxLayout({
+                vertical: true,
+                x_align: Clutter.ActorAlign.START,
+                y_align: Clutter.ActorAlign.END,
+                x_expand: true,
+                style_class: 'unlock-dialog-payg-layout',
+            });
+
+            const accountIDText = _('Pay As You Go Account ID: %s').format(Main.paygManager.accountID);
+            const accountIDInfo = new St.Label({
+                style_class: 'unlock-dialog-payg-account-id',
+                text: accountIDText,
+            });
+
+            infoBox.add_child(accountIDInfo);
+            mainBox.add_child(infoBox);
+        }
+
+        Main.ctrlAltTabManager.addGroup(promptBox, _('Unlock Machine'), 'dialog-password-symbolic');
+
+        this._cancelButton.connect('clicked', () => {
+            this._onCancelled();
+        });
+        this._nextButton.connect('clicked', () => {
+            this.startVerifyingCode();
+        });
+
+        this._entry.connect('code-changed', () => {
+            this.updateApplyButtonSensitivity();
+        });
+
+        this._entry.clutter_text.connect('activate', () => {
+            this.startVerifyingCode();
+        });
+
+        this.connect('code-added', () => {
+            this.remove_child(mainBox);
+            this._successScreen();
+        });
+
+        this.connect('code-reset', () => {
+            this._paygUnlockDialog = mainBox;
+            this.remove_child(mainBox);
+            this._resetScreen();
+        });
+
+        this._idleMonitor = Meta.IdleMonitor.get_core();
+        this._idleWatchId = this._idleMonitor.add_idle_watch(IDLE_TIMEOUT_SECS * MSEC_PER_SEC, this._onCancelled.bind(this));
+
+        this.updateSensitivity();
+        this._entry.grab_key_focus();
+    }
+
+    _onDestroy() {
+        this.popModal();
+
+        if (this._idleWatchId) {
+            this._idleMonitor.remove_watch(this._idleWatchId);
+            this._idleWatchId = 0;
+        }
+
+        if (this._clearTooManyAttemptsId > 0) {
+            GLib.source_remove(this._clearTooManyAttemptsId);
+            this._clearTooManyAttemptsId = 0;
+        }
+    }
+
+    _createButtonsArea() {
+        const buttonsBox = new St.BoxLayout({
+            style_class: 'unlock-dialog-payg-button-box',
+            vertical: false,
+            x_expand: true,
+            x_align: Clutter.ActorAlign.FILL,
+            y_expand: true,
+            y_align: Clutter.ActorAlign.END,
+        });
+
+        this._cancelButton = new St.Button({
+            style_class: 'modal-dialog-button button',
+            button_mask: St.ButtonMask.ONE | St.ButtonMask.THREE,
+            reactive: true,
+            can_focus: true,
+            label: _('Cancel'),
+            x_align: St.Align.START,
+            y_align: St.Align.END,
+        });
+        buttonsBox.add_child(this._cancelButton);
+
+        const buttonSpacer = new St.Widget({
+            layout_manager: new Clutter.BinLayout(),
+            x_expand: true,
+            x_align: Clutter.ActorAlign.END,
+        });
+        buttonsBox.add_child(buttonSpacer);
+
+        // We make the most of the spacer to show the spinner while verifying the code.
+        this._spinner = new Animation.Spinner(Payg.SPINNER_ICON_SIZE_PIXELS, {
+            animate: true,
+            hideOnStop: true,
+        });
+        buttonSpacer.add_child(this._spinner);
+
+        this._nextButton = new St.Button({
+            style_class: 'modal-dialog-button button',
+            button_mask: St.ButtonMask.ONE | St.ButtonMask.THREE,
+            reactive: true,
+            can_focus: true,
+            label: _('Unlock'),
+            x_align: St.Align.END,
+            y_align: St.Align.END,
+        });
+        this._nextButton.add_style_pseudo_class('default');
+        buttonsBox.add_child(this._nextButton);
+
+        return buttonsBox;
+    }
+
+    _createEntryArea() {
+        const entryBox = new St.BoxLayout({
+            vertical: false,
+            x_expand: true,
+            x_align: Clutter.ActorAlign.FILL,
+        });
+
+        if (Main.paygManager.codeFormatPrefix !== '') {
+            const prefix = new St.Label({
+                style_class: 'unlock-dialog-payg-code-entry',
+                text: Main.paygManager.codeFormatPrefix,
+                x_align: Clutter.ActorAlign.CENTER,
+            });
+
+            entryBox.add_child(prefix);
+        }
+
+        this._entry = new Payg.PaygUnlockCodeEntry({
+            style_class: 'unlock-dialog-payg-entry',
+            reactive: true,
+            can_focus: true,
+            x_align: Clutter.ActorAlign.FILL,
+            x_expand: true,
+            y_expand: false,
+        });
+        this._entry.clutter_text.ellipsize = Pango.EllipsizeMode.NONE;
+        this._entry.clutter_text.x_align = Clutter.ActorAlign.CENTER;
+
+        entryBox.add_child(this._entry);
+
+        if (Main.paygManager.codeFormatSuffix !== '') {
+            const suffix = new St.Label({
+                style_class: 'unlock-dialog-payg-code-entry',
+                text: Main.paygManager.codeFormatSuffix,
+                x_align: Clutter.ActorAlign.CENTER,
+            });
+            entryBox.add_child(suffix);
+        }
+
+        return entryBox;
+    }
+
+    _createMessageBox() {
+        const messageBox = new St.BoxLayout({
+            vertical: true,
+            x_align: Clutter.ActorAlign.FILL,
+            y_align: Clutter.ActorAlign.CENTER,
+            x_expand: true,
+            y_expand: true,
+            style_class: 'unlock-dialog-payg-layout',
+        });
+
+        return messageBox;
+    }
+
+    _createMessageButtonArea(buttonLabel) {
+        const messageButtonBox = new St.BoxLayout({
+            style_class: 'unlock-dialog-payg-button-box',
+            vertical: false,
+            x_expand: true,
+            x_align: Clutter.ActorAlign.CENTER,
+            y_expand: true,
+            y_align: Clutter.ActorAlign.END,
+        });
+
+        this._messageButton = new St.Button({
+            style_class: 'modal-dialog-button button',
+            button_mask: St.ButtonMask.ONE | St.ButtonMask.THREE,
+            reactive: true,
+            can_focus: true,
+            label: buttonLabel,
+            x_align: St.Align.MIDDLE,
+            y_align: St.Align.END,
+        });
+
+        this._messageButton.add_style_pseudo_class('default');
+        messageButtonBox.add_child(this._messageButton);
+
+        return messageButtonBox;
+    }
+
+    _createMessageString(string) {
+        const messageString = new St.Label({
+            style_class: 'unlock-dialog-payg-success',
+            text: string,
+            x_align: Clutter.ActorAlign.CENTER,
+        });
+
+        return messageString;
+    }
+
+    _successScreen() {
+        const messageBox = this._createMessageBox();
+        this.add_child(messageBox);
+
+        // successMessage will handle the formatting of the string
+        messageBox.add_child(this._createMessageString(Payg.successMessage()));
+        messageBox.add_child(this._createMessageButtonArea(_('Success!')));
+        this._messageButton.grab_key_focus();
+
+        this._timeoutId = GLib.timeout_add_seconds(
+            GLib.PRIORITY_DEFAULT,
+            3,
+            () => {
+                this.emit('success-message-shown');
+                return GLib.SOURCE_REMOVE;
+            });
+        this._messageButton.connect('button-press-event', () => {
+            GLib.source_remove(this._timeoutId);
+            this.emit('success-message-shown');
+        });
+        this._messageButton.connect('key-press-event', () => {
+            GLib.source_remove(this._timeoutId);
+            this.emit('success-message-shown');
+        });
+    }
+
+    _resetScreen() {
+        const messageBox = this._createMessageBox();
+        this.add_child(messageBox);
+
+        messageBox.add_child(this._createMessageString(_('Remaining time cleared!')));
+        messageBox.add_child(this._createMessageButtonArea(_('OK!')));
+        this._messageButton.grab_key_focus();
+
+        this._timeoutId = GLib.timeout_add_seconds(
+            GLib.PRIORITY_DEFAULT,
+            3,
+            () => {
+                this.add_child(this._paygUnlockDialog);
+                this.remove_child(messageBox);
+                return GLib.SOURCE_REMOVE;
+            });
+        this._messageButton.connect('button-press-event', () => {
+            this._restorePaygUnlockCodeEntry();
+            this.remove_child(messageBox);
+        });
+        this._messageButton.connect('key-press-event', () => {
+            this._restorePaygUnlockCodeEntry();
+            this.remove_child(messageBox);
+        });
+    }
+
+    _restorePaygUnlockCodeEntry() {
+        GLib.source_remove(this._timeoutId);
+        this.add_child(this._paygUnlockDialog);
+        this.updateSensitivity();
+        this._entry.grab_key_focus();
+    }
+
+    _onCancelled() {
+        this._cancelled = true;
+        this.reset();
+
+        // The ScreenShield will connect to the 'failed' signal
+        // to know when to cancel the unlock dialog.
+        if (this._verificationStatus !== Payg.UnlockStatus.SUCCEEDED)
+            this.emit('failed');
+    }
+
+    entrySetEnabled(enabled) {
+        this._entry.setEnabled(enabled);
+    }
+
+    entryReset() {
+        this._entry.reset();
+    }
+
+    onCodeAdded() {
+        this.emit('code-added');
+        this.clearError();
+    }
+
+    get entryCode() {
+        return this._entry.code;
+    }
+
+    get verificationStatus() {
+        return this._verificationStatus;
+    }
+
+    set verificationStatus(value) {
+        this._verificationStatus = value;
+    }
+
+    get cancelled() {
+        return this._cancelled;
+    }
+
+    set cancelled(value) {
+        this._cancelled = value;
+    }
+
+    get errorLabel() {
+        return this._errorMessage;
+    }
+
+    get spinner() {
+        return this._spinner;
+    }
+
+    get applyButton() {
+        return this._nextButton;
+    }
+
+    cancel() {
+        this.entryReset();
+    }
+
+    finish(onComplete) {
+        // Nothing to do other than calling the callback.
+        if (onComplete)
+            onComplete();
+    }
+
+    open(timestamp) {
+        this.show();
+
+        if (this._isModal)
+            return true;
+
+        if (!Main.pushModal(this, {
+            timestamp,
+            actionMode: Shell.ActionMode.UNLOCK_SCREEN,
+        }))
+            return false;
+
+        this._isModal = true;
+
+        this._entry.grab_key_focus();
+
+        return true;
+    }
+
+    popModal(timestamp) {
+        if (this._isModal) {
+            Main.popModal(this, timestamp);
+            this._isModal = false;
+        }
+    }
+});

--- a/js/ui/screenShield.js
+++ b/js/ui/screenShield.js
@@ -8,9 +8,9 @@ const GnomeSession = imports.misc.gnomeSession;
 const OVirt = imports.gdm.oVirt;
 const LoginManager = imports.misc.loginManager;
 const Lightbox = imports.ui.lightbox;
+const MessageTray = imports.ui.messageTray;
 const Main = imports.ui.main;
 const Overview = imports.ui.overview;
-const MessageTray = imports.ui.messageTray;
 const ShellDBus = imports.ui.shellDBus;
 const SmartcardManager = imports.misc.smartcardManager;
 
@@ -142,6 +142,60 @@ var ScreenShield = class {
         this._cursorTracker = Meta.CursorTracker.get_for_display(global.display);
 
         this._syncInhibitor();
+
+        Main.paygManager.connect('code-expired', () => {
+            this._clearCurrentDialog();
+            if (Main.sessionMode.isGreeter)
+                this.showDialog();
+            else
+                this.lock(true);
+        });
+        Main.paygManager.connect('expiry-time-changed', () => {
+            const userManager = AccountsService.UserManager.get_default();
+            const user = userManager.get_user(GLib.get_user_name());
+
+            // A new valid code has been introduced but the machine is
+            // not unlocked yet -> Make sure we stay in the locked state.
+            if (Main.paygManager.isLocked) {
+                this._clearCurrentDialog();
+                this.lock(false);
+                return;
+            }
+
+            // The time may have been extended using the tray applet from a
+            // logged in session.
+            if (!this._dialog)
+                return;
+
+            // Take the dialog instance and wait for the success message to be shown
+            this._dialog.connect('success-message-shown', () => {
+                // A new valid code unlocked the machine and user has no
+                // password set -> Go straight to the user's session.
+                if (user.password_mode == AccountsService.UserPasswordMode.NONE) {
+                    this.deactivate(false);
+                    return;
+                }
+
+                const paygExpectedMode = this._isGreeter ? 'gdm-unlock-dialog-payg' : 'unlock-dialog-payg';
+                if (Main.sessionMode.currentMode === paygExpectedMode) {
+                    // This is the most common case.
+                    Main.sessionMode.popMode(paygExpectedMode);
+                }
+
+                // The machine is unlocked but we still need to unlock the
+                // user's session with the password, so don't deactivate yet.
+                this._clearCurrentDialog();
+
+                this.showDialog();
+            });
+        });
+    }
+
+    _clearCurrentDialog() {
+        if (this._dialog) {
+            this._dialog.destroy();
+            this._dialog = null;
+        }
     }
 
     _setActive(active) {
@@ -171,7 +225,7 @@ var ScreenShield = class {
             return;
 
         this._dialog.cancel();
-        if (this._isGreeter) {
+        if (this._isGreeter && !Main.paygManager.isLocked) {
             // LoginDialog.cancel() will grab the key focus
             // on its own, so ensure it stays on lock screen
             // instead
@@ -266,7 +320,12 @@ var ScreenShield = class {
             GLib.Source.set_name_by_id(this._lockTimeoutId, '[gnome-shell] this.lock');
         }
 
-        this._activateFade(this._longLightbox, STANDARD_FADE_TIME);
+        // Leave the screen on for the PAYG unlock code entry. It's difficult
+        // to distinguish the "lock due to credit expiration" case from the
+        // "lock due to idle timeout" one, and we don't want a blank screen in
+        // the former which includes right after the FBE.
+        if (!Main.paygManager.isLocked)
+            this._activateFade(this._longLightbox, STANDARD_FADE_TIME);
     }
 
     _activateFade(lightbox, time) {
@@ -323,6 +382,10 @@ var ScreenShield = class {
         this.actor.show();
         this._isGreeter = Main.sessionMode.isGreeter;
         this._isLocked = true;
+
+        if (this._isGreeter && Main.paygManager.isLocked)
+            Main.sessionMode.pushMode('gdm-unlock-dialog-payg');
+
         this._ensureUnlockDialog(true);
     }
 
@@ -393,7 +456,6 @@ var ScreenShield = class {
         }
 
         this._dialog.allowCancel = allowCancel;
-        this._dialog.grab_key_focus();
         return true;
     }
 
@@ -495,6 +557,10 @@ var ScreenShield = class {
     _continueDeactivate(animate) {
         this._hideLockScreen(animate);
 
+        if (Main.sessionMode.currentMode === 'gdm-unlock-dialog-payg')
+            Main.sessionMode.popMode('gdm-unlock-dialog-payg');
+        if (Main.sessionMode.currentMode === 'unlock-dialog-payg')
+            Main.sessionMode.popMode('unlock-dialog-payg');
         if (Main.sessionMode.currentMode == 'unlock-dialog')
             Main.sessionMode.popMode('unlock-dialog');
 
@@ -555,25 +621,41 @@ var ScreenShield = class {
         this._isLocked = false;
         this.emit('locked-changed');
         global.set_runtime_state(LOCKED_STATE_STR, null);
+
+        // Sanity check, in case we made it this far while being locked
+        if (Main.paygManager.isLocked)
+            this.lock(false);
     }
 
     activate(animate) {
         if (this._activationTime == 0)
             this._activationTime = GLib.get_monotonic_time();
 
+        this._isGreeter = Main.sessionMode.isGreeter;
+        if (!this._isGreeter) {
+            const userManager = AccountsService.UserManager.get_default();
+            const user = userManager.get_user(GLib.get_user_name());
+
+            if (Main.sessionMode.currentMode !== 'unlock-dialog' &&
+                Main.sessionMode.currentMode !== 'unlock-dialog-payg' &&
+                user.password_mode !== AccountsService.UserPasswordMode.NONE)
+                Main.sessionMode.pushMode('unlock-dialog');
+
+            if (Main.sessionMode.currentMode !== 'unlock-dialog-payg' &&
+                Main.paygManager.isLocked) {
+                Main.sessionMode.pushMode('unlock-dialog-payg');
+                this._clearCurrentDialog();
+                this._ensureUnlockDialog(true);
+            }
+        }
+
         if (!this._ensureUnlockDialog(true))
             return;
 
         this.actor.show();
 
-        if (Main.sessionMode.currentMode !== 'unlock-dialog') {
-            this._isGreeter = Main.sessionMode.isGreeter;
-            if (!this._isGreeter)
-                Main.sessionMode.pushMode('unlock-dialog');
-        }
-
         this._resetLockScreen({ animateLockScreen: animate,
-                                fadeToBlack: true });
+                                fadeToBlack: Main.sessionMode.currentMode != 'unlock-dialog-payg' });
         // On wayland, a crash brings down the entire session, so we don't
         // need to defend against being restarted unlocked
         if (!Meta.is_wayland_compositor())
@@ -592,7 +674,11 @@ var ScreenShield = class {
     }
 
     lock(animate) {
-        if (this._lockSettings.get_boolean(DISABLE_LOCK_KEY)) {
+        // This does not make sense outside of the user's session for PAYG
+        if (Main.sessionMode.isGreeter && Main.paygManager.isLocked)
+            return;
+
+        if (this._lockSettings.get_boolean(DISABLE_LOCK_KEY) && !Main.paygManager.isLocked) {
             log('Screen lock is locked down, not locking'); // lock, lock - who's there?
             return;
         }
@@ -616,7 +702,7 @@ var ScreenShield = class {
         if (this._isGreeter)
             this._isLocked = true;
         else
-            this._isLocked = user.password_mode != AccountsService.UserPasswordMode.NONE;
+            this._isLocked = Main.paygManager.isLocked || (user.password_mode != AccountsService.UserPasswordMode.NONE);
 
         this.activate(animate);
 
@@ -625,10 +711,15 @@ var ScreenShield = class {
 
     // If the previous shell crashed, and gnome-session restarted us, then re-lock
     lockIfWasLocked() {
-        if (!this._settings.get_boolean(LOCK_ENABLED_KEY))
+        // We need to add some extra checks for PAYG becasue we don't want to
+        // end up loging the screen for not regular sessions (e.g. initial-setup).
+        const shouldLockForPayg = Main.paygManager.isLocked && Main.sessionMode.hasOverview;
+
+        if (!this._settings.get_boolean(LOCK_ENABLED_KEY) && !shouldLockForPayg)
             return;
+
         let wasLocked = global.get_runtime_state('b', LOCKED_STATE_STR);
-        if (wasLocked === null)
+        if (wasLocked === null && !shouldLockForPayg)
             return;
         Meta.later_add(Meta.LaterType.BEFORE_REDRAW, () => {
             this.lock(false);

--- a/js/ui/sessionMode.js
+++ b/js/ui/sessionMode.js
@@ -56,9 +56,14 @@ const _modes = {
         panelStyle: 'login-screen',
     },
 
+    'gdm-unlock-dialog-payg': {
+        parentMode: 'gdm',
+        unlockDialog: imports.ui.paygUnlockDialog.PaygUnlockDialog,
+    },
+
     'unlock-dialog': {
         isLocked: true,
-        unlockDialog: undefined,
+        unlockDialog: imports.ui.unlockDialog.UnlockDialog,
         allowExtensions: true,
         enabledExtensions: ['eos-desktop@endlessm.com', 'eos-panel@endlessm.com'],
         components: ['polkitAgent', 'telepathyClient'],
@@ -68,6 +73,16 @@ const _modes = {
             right: ['dwellClick', 'a11y', 'keyboard', 'aggregateMenu'],
         },
         panelStyle: 'unlock-screen',
+    },
+
+    'unlock-dialog-payg': {
+        parentMode: 'unlock-dialog',
+        unlockDialog: imports.ui.paygUnlockDialog.PaygUnlockDialog,
+        panel: {
+            left: [],
+            center: [],
+            right: ['a11y', 'keyboard', 'aggregateMenu'],
+        },
     },
 
     'user': {

--- a/js/ui/shellDBus.js
+++ b/js/ui/shellDBus.js
@@ -356,7 +356,10 @@ var ScreenSaverDBus = class {
     constructor(screenShield) {
         this._screenShield = screenShield;
         screenShield.connect('active-changed', shield => {
-            this._dbusImpl.emit_signal('ActiveChanged', GLib.Variant.new('(b)', [shield.active]));
+            // Don't blank the screen if locking for PAYG, so the unlock code
+            // entry screen is visible e.g. after the FBE.
+            if (!Main.paygManager.isLocked)
+                this._dbusImpl.emit_signal('ActiveChanged', GLib.Variant.new('(b)', [shield.active]));
         });
         screenShield.connect('wake-up-screen', () => {
             this._dbusImpl.emit_signal('WakeUpScreen', null);

--- a/js/ui/status/payg.js
+++ b/js/ui/status/payg.js
@@ -1,0 +1,155 @@
+// -*- mode: js; js-indent-level: 4; indent-tabs-mode: nil -*-
+//
+// Copyright (C) 2018-2020 Endless OS Foundation LLC
+//
+// Licensed under the GNU General Public License Version 2
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+/* exported Indicator */
+
+const { Gio, GLib, GObject } = imports.gi;
+
+const Main = imports.ui.main;
+const PanelMenu = imports.ui.panelMenu;
+const Payg = imports.ui.payg;
+const PopupMenu = imports.ui.popupMenu;
+const PaygManager = imports.misc.paygManager;
+
+const REFRESH_TIME_SECS = 60;
+
+var Indicator = GObject.registerClass(
+class PaygIndicator extends PanelMenu.SystemIndicator {
+    _init() {
+        super._init();
+
+        this._paygManager = new PaygManager.PaygManager();
+        this._indicator = this._addIndicator();
+        this._item = new PopupMenu.PopupSubMenuMenuItem('', true);
+        this._paygNotifier = new Payg.PaygNotifier();
+        this._item.menu.addAction(_('Enter unlock code…'), () => {
+            this._paygNotifier.notify(-1);
+        });
+        this.menu.addMenuItem(this._item);
+
+        // show this status applet if PAYG is enabled and fill in
+        // "determining time..." label and icon
+        this._sync();
+
+        // fill in current values as soon as _paygManager is initialized
+        this._updateTimeRemainingAndSyncWhenReady();
+
+        // update immediately when the user extends their time (so they don't
+        // have to wait for the up to REFRESH_TIME_SECS seconds which would
+        // likely be long enough that they might worry something went wrong)
+        this._expiryTimeChangedId = this._paygManager.connect('expiry-time-changed', () => {
+            this._updateTimeRemainingAndSyncWhenReady();
+        });
+
+        // refresh the displayed icon and "time remaining" label periodically
+        this._timeoutRefreshId = GLib.timeout_add_seconds(
+            GLib.PRIORITY_DEFAULT,
+            REFRESH_TIME_SECS,
+            () => this._timeoutRefresh());
+        GLib.Source.set_name_by_id(this._timeoutRefreshId, '[gnome-shell] this._timeoutRefresh');
+    }
+
+    _timeoutRefresh() {
+        this._updateTimeRemainingAndSyncWhenReady();
+        return GLib.SOURCE_CONTINUE;
+    }
+
+    _onDestroy() {
+        super._onDestroy();
+
+        if (this._expiryTimeChangedId !== 0)
+            this._paygManager.disconnect(this._expiryTimeChangedId);
+
+        if (this._timeoutRefreshId !== 0)
+            GLib.source_remove(this._timeoutRefreshId);
+    }
+
+    _getMenuGicon() {
+        const URGENT_EXPIRATION_S = 15 * 60;
+        const timeLeftSeconds = this._paygManager.timeRemainingSecs();
+
+        let iconUri = 'resource:///org/gnome/shell/theme/payg-normal-symbolic.svg';
+        // if time left <= 0, we haven't yet determined it, so fall back to
+        // "normal" icon
+        if (timeLeftSeconds >= 0 && timeLeftSeconds <= URGENT_EXPIRATION_S)
+            iconUri = 'resource:///org/gnome/shell/theme/payg-near-expiration-symbolic.svg';
+
+        return new Gio.FileIcon({ file: Gio.File.new_for_uri(iconUri) });
+    }
+
+    _getTimeRemainingString() {
+        // the time will be invalid if the manager hasn't been
+        // intitialized yet so return with a default message in that case
+        if (!this._paygManager.initialized)
+            return _('Getting time…');
+
+        // if PAYG is disabled, nothing should be showing this label
+        if (!this._paygManager.enabled)
+            return '';
+
+        const seconds = this._paygManager.timeRemainingSecs();
+        if (seconds == 0)
+            return _('Subscription expired');
+        if (seconds < 60)
+            return _('Less than 1 minute');
+
+        return Payg.timeToString(seconds);
+    }
+
+    _sync() {
+        const sensitive = !Main.sessionMode.isLocked && !Main.sessionMode.isGreeter && this._paygManager.enabled;
+        this.menu.setSensitive(sensitive);
+        this._item.actor.visible = this._indicator.visible = this._paygManager.enabled;
+        this._item.label.text = this._getTimeRemainingString();
+        this._item.icon.gicon = this._getMenuGicon();
+        this._indicator.gicon = this._item.icon.gicon;
+    }
+
+    _updateTimeRemainingAndSyncWhenReady() {
+        // We can't use the PaygManager until it's initialized
+        if (this._paygManager.initialized) {
+            this._sync();
+        } else {
+            const paygManagerId = this._paygManager.connect('initialized', () => {
+                this._sync();
+                this._initializeAccountIDMenu();
+                this._paygManager.disconnect(paygManagerId);
+            });
+        }
+    }
+
+    // Differently from the remaining time counter, we just want to show the account ID
+    // when the backend properly supports it.
+    _initializeAccountIDMenu() {
+        if (this._verifyValidAccountID()) {
+            this._paygItem = new PopupMenu.PopupSubMenuMenuItem('', true);
+            this._paygItem.setSensitive(false);
+            this._paygItem.actor.visible = this._indicator.visible = this._paygManager.enabled;
+            this._paygItem.label.text = _('Account ID: %s').format(this._paygManager.accountID);
+            this._paygItem.icon.gicon = this._getMenuGicon();
+
+            this.menu.addMenuItem(this._paygItem);
+        }
+    }
+
+    _verifyValidAccountID() {
+        return Main.paygManager.accountID !== '0';
+    }
+});

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -8,6 +8,7 @@ js/dbusServices/extensions/ui/extension-prefs-dialog.ui
 js/gdm/authPrompt.js
 js/gdm/loginDialog.js
 js/gdm/util.js
+js/misc/paygManager.js
 js/misc/systemActions.js
 js/misc/util.js
 js/portalHelper/main.js
@@ -44,6 +45,7 @@ js/ui/overviewControls.js
 js/ui/overview.js
 js/ui/padOsd.js
 js/ui/panel.js
+js/ui/payg.js
 js/ui/popupMenu.js
 js/ui/runDialog.js
 js/ui/screenShield.js

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -45,6 +45,7 @@ js/ui/overviewControls.js
 js/ui/overview.js
 js/ui/padOsd.js
 js/ui/panel.js
+js/ui/paygUnlockDialog.js
 js/ui/payg.js
 js/ui/popupMenu.js
 js/ui/runDialog.js

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -61,6 +61,7 @@ js/ui/status/keyboard.js
 js/ui/status/location.js
 js/ui/status/network.js
 js/ui/status/nightLight.js
+js/ui/status/payg.js
 js/ui/status/power.js
 js/ui/status/remoteAccess.js
 js/ui/status/rfkill.js

--- a/src/shell-util.c
+++ b/src/shell-util.c
@@ -753,3 +753,27 @@ shell_util_get_translated_folder_name (const char *name)
 {
   return shell_app_cache_translate_folder (shell_app_cache_get_default (), name);
 }
+
+/**
+ * shell_util_get_boottime:
+ *
+ * Like g_get_monotonic_time(), but also includes any time the system is
+ * suspended. Uses `CLOCK_BOOTTIME`, hence the name, but is not guaranteed to be
+ * the time since boot.
+ *
+ * Returns: the time since some unspecified starting point, in microseconds
+ */
+gint64
+shell_util_get_boottime (void)
+{
+  struct timespec ts;
+  gint result;
+
+  result = clock_gettime (CLOCK_BOOTTIME, &ts);
+
+  if (G_UNLIKELY (result != 0))
+    g_error ("clock_gettime (CLOCK_BOOTTIME) failed: %s",
+             g_strerror (errno));
+
+  return (((gint64) ts.tv_sec) * 1000000) + (ts.tv_nsec / 1000);
+}

--- a/src/shell-util.h
+++ b/src/shell-util.h
@@ -78,6 +78,8 @@ char *shell_util_get_translated_folder_name (const char *name);
 
 gint shell_util_get_uid (void);
 
+gint64 shell_util_get_boottime (void);
+
 G_END_DECLS
 
 #endif /* __SHELL_UTIL_H__ */


### PR DESCRIPTION
Changes here depend on (are on top of) https://github.com/endlessm/gnome-shell/pull/690.

This PR includes the following:
- **pick** 7d4512ea5 payg: Initial implementation of the PAYG manager component
  - small conflict mainly on build system
- **pick** ca6825e79 payg: Add a new screen to allow unlocking PAYG machines
  - small conflict on build system
  - also changed the default panel layout for the "unlock-dialog-payg" session mode to not include the "powerMenu" indicator (as it was in the original commit). The reason is that upstream does not have the "powerMenu" indicator (functionality included in the "aggregateMenu" upstream which is also included in the default layout when on "unlock-dialog-payg" session mode) and we want this layout to work if the panel extension is disabled (the panel extension will set the layout as it was before, but that only works if the extension is enabled)
- **pick** 5fb80182d payg: Wait for the PaygManager before showing the screenshield's dialog
  - no conflict
- **pick** 315c9b320 payg: Make sure to initialize the users list after startup has completed
  - no conflict
- **pick** 46ff68c19 payg: Integrate the PAYG unlock screen with the login screen
  - no conflict
- **pick** 07354b7c6 payg: Support image-specific overrides for text in the unlock dialog
  - no conflict
- **pick** e7f14449a payg: Show image-specific instructions for PAYG, if available
  - no conflict
- **pick** 86b0763b1 payg: tweak code entry field for longer codes
  - no conflict
- **pick** b1e871703 js/ui/payg.js: PayGo UI utilities
  - small conflict on build system
- **pick** c4830ceaf payg: factor out reminder notifications
  - no conflict
- **pick** 19c26bf40 status/payg: new applet for PAYG account details and actions
  - small conflict on build system
- **pick** b5aee404f status/payg: add menu action to apply a code before PayGo time is expired
  - no conflict
- **pick** bdf9069be payg: Add success screen
  - no conflict
- **pick** c990764b7 eos-payg: Add prefix and sufix characters for code insert
  - no conflict
- **pick** 1015c4ec5 eos-payg: Better segregate Pay As You Go classes
  - no conflict
- **pick** 09a6fb4ee eos-payg: Add the character enforcement for payg-tray
  - no conflict
- **pick** a4e24227a paygManager: Update iface for ImpendingShutdown signal
  - no conflict
- **pick** 8faf6c84d payg: Add AccountID support for the UI
  - no conflict
- **pick** ea9edb103 payg: Add AccountID info on the applet
  - no conflict
- **pick** ddc404d63 fixup! payg: Add a new screen to allow unlocking PAYG machines
  - no conflict
  - squashed in original commit
- **pick** e3775d4dc fixup! payg: Initial implementation of the PAYG manager component
  - no conflict
  - squashed in original commit
- **pick** 969bb35eb fixup! js/ui/payg.js: PayGo UI utilities
  - no conflict
  - squashed in original commit
- **pick**  d30cb337a fixup! payg: factor out reminder notifications
  - no conflict
  - squashed in original commit
- **pick** e9d48d2d8 fixup! status/payg: add menu action to apply a code before PayGo time is expired
  - no conflict
  - squashed in original commit
- **pick** 0daaf5f88 fixup! payg: Initial implementation of the PAYG manager component
  - no conflict
  - squashed in original commit
- **pick** 8c6f20b03 fixup! payg: Add a new screen to allow unlocking PAYG machines
  - no conflict
  - squashed in original commit
- **pick**  1042dea32 fixup! payg: factor out reminder notifications
  - no conflict
  - squashed in original commit
- **pick** 150a61fff fixup! payg: Add success screen
  - no conflict
  - squashed in original commit
- **pick** 0d2f4de2f fixup! payg: Add a new screen to allow unlocking PAYG machines
  - small conflict due to upstream changes
  - squashed in original commit
- **pick** 8e1edb516 fixup! payg: Add success screen
  - no conflict
  - squashed in original commit
- **pick** 4f0403a12 fixup! payg: Add a new screen to allow unlocking PAYG machines
  - no conflict
  - squashed in original commit
- **pick** eac6b4c3a payg: Fix a couple comments
  - no conflict
- **pick** 90b73b11a payg: Properly display credit expired in tray applet
  - no conflict
- **pick** 67fde3d03 payg: Fix ngettext usage
  - no conflict
- **pick** 22d11360b payg: Don’t calculate times if PAYG is disabled
  - no conflict
- **pick** 2c6d99c92 screenShield: Properly show PaygUnlockDialog on login screen
  - no conflict
- **pick** aa5a452c0 screenShield: Lock for PAYG after FBE
  - no conflict
- **pick** 75c4361cf screenShield: Don't fade to black for payg lock
  - no conflict
- **pick** e37767c0b payg: Make Success button clickable
  - no conflict
- **pick** 6f892ecd1 screenShield: Don't grab dialog key focus
  - no conflict
- **pick** 105e5ace0 paygUnlockDialog: Focus entry by default
  - no conflict
- **pick** aef7a8ca9 screenShield: Don't try to use an undefined dialog object
  - no conflict

https://phabricator.endlessm.com/T30647