### PR TITLE
Re-add metrics support to new shell

### DIFF
--- a/js/ui/viewSelector.js
+++ b/js/ui/viewSelector.js
@@ -1,7 +1,8 @@
 // -*- mode: js; js-indent-level: 4; indent-tabs-mode: nil -*-
 /* exported ViewSelector */
 
-const { Clutter, Gio, GObject, Meta, Shell, St } = imports.gi;
+const { EosMetrics, Clutter, Gio,
+        GLib, GObject, Meta, Shell, St } = imports.gi;
 const Signals = imports.signals;
 
 const AppDisplay = imports.ui.appDisplay;
@@ -16,6 +17,22 @@ const IconGrid = imports.ui.iconGrid;
 
 const SHELL_KEYBINDINGS_SCHEMA = 'org.gnome.shell.keybindings';
 var PINCH_GESTURE_THRESHOLD = 0.7;
+
+const SEARCH_ACTIVATION_TIMEOUT = 50;
+
+const SEARCH_METRIC_INACTIVITY_TIMEOUT_SECONDS = 3;
+
+// Occurs when a user initiates a search from the desktop. The payload, with
+// type `(us)`, consists of an enum value from the DesktopSearchProvider enum
+// telling what kind of search was requested; followed by the search query.
+const EVENT_DESKTOP_SEARCH = 'b02266bc-b010-44b2-ae0f-8f116ffa50eb';
+
+// Represents the various search providers that can be used for searching from
+// the desktop. Keep in sync with the corresponding enum in
+// https://github.com/endlessm/eos-analytics/tree/master/src/main/java/com/endlessm/postprocessing/query/SearchQuery.java.
+const DesktopSearchProvider = {
+    MY_COMPUTER: 0,
+};
 
 var ViewPage = {
     WINDOWS: 1,
@@ -176,6 +193,8 @@ var ViewSelector = GObject.registerClass({
             new WorkspacesView.WorkspacesDisplay(workspaceAdjustment);
         this._workspacesPage = this._addPage(this._workspacesDisplay,
                                              _("Windows"), 'focus-windows-symbolic');
+
+        this._localSearchMetricTimeoutId = 0;
 
         this.appDisplay = new AppDisplay.AppDisplay();
         this._appsPage = this._addPage(this.appDisplay,
@@ -515,11 +534,24 @@ var ViewSelector = GObject.registerClass({
         return this._text.text == this._entry.get_text();
     }
 
+    _recordDesktopSearchMetric(query, searchProvider) {
+        const eventRecorder = EosMetrics.EventRecorder.get_default();
+        const auxiliaryPayload = new GLib.Variant('(us)', [searchProvider, query]);
+        eventRecorder.record_event(EVENT_DESKTOP_SEARCH, auxiliaryPayload);
+    }
+
     _onTextChanged() {
         let terms = getTermsForSearchString(this._entry.get_text());
 
         this._searchActive = terms.length > 0;
         this._searchResults.setTerms(terms);
+
+        // Cancel previous metric recording in case the user deleted what
+        // they wrote (or cancelled the search) and left it at that.
+        if (this._localSearchMetricTimeoutId > 0) {
+            GLib.source_remove(this._localSearchMetricTimeoutId);
+            this._localSearchMetricTimeoutId = 0;
+        }
 
         if (this._searchActive) {
             this._showPage(this._searchPage);
@@ -530,6 +562,21 @@ var ViewSelector = GObject.registerClass({
                 this._iconClickedId = this._entry.connect('secondary-icon-clicked',
                                                           this.reset.bind(this));
             }
+
+            // Since the search is live, only record a metric a few seconds after
+            // the user has stopped typing.
+            this._localSearchMetricTimeoutId = GLib.timeout_add_seconds(
+                GLib.PRIORITY_DEFAULT,
+                SEARCH_METRIC_INACTIVITY_TIMEOUT_SECONDS,
+                () => {
+                    const query = terms.join(' ');
+                    if (query !== '') {
+                        this._recordDesktopSearchMetric(query,
+                            DesktopSearchProvider.MY_COMPUTER);
+                    }
+                    this._localSearchMetricTimeoutId = 0;
+                    return GLib.SOURCE_REMOVE;
+                });
         } else {
             if (this._iconClickedId > 0) {
                 this._entry.disconnect(this._iconClickedId);

--- a/meson.build
+++ b/meson.build
@@ -106,6 +106,9 @@ if enable_recorder
   recorder_deps += [gst_dep, gst_base_dep, gtk_dep, x11_dep]
 endif
 
+# Endless-specific: Metrics
+eosmetrics_dep = dependency('eosmetrics-0')
+
 # Endless-specific: Required for keyboard layout switcher in password entries
 xkbcommon_dep = dependency('xkbcommon')
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -62,6 +62,7 @@ gnome_shell_deps = [
   polkit_dep,
   gcr_dep,
   libsystemd_dep,
+  eosmetrics_dep,
   xkbcommon_dep,
 ]
 


### PR DESCRIPTION
This PR includes:
- **pick** dfa64aada4  shell-app-system: Report an event when an application opens/closes
  - small conflict on build system
  - sends `SHELL_APP_IS_OPEN_EVENT` metric
- **pick** 1e349a1304  viewSelector: Record metric when user initiates a desktop search
  - reworked the patch a bit to adjust to upstream changes
  - sends  `EVENT_DESKTOP_SEARCH` metric

Tested and both events above are sent as expected.

Apart from those we also had the following metrics on 3.8:
- `SHELL_APP_ADDED_EVENT`:  when an app was added to the grid
- `SHELL_APP_REMOVED_EVENT`: as above but when removed from the grid

Given we don't support adding/removing apps to/from grid anymore I did not include those.

https://phabricator.endlessm.com/T30661