### PR TITLE
eos-launch: Add launcher for 'endlessm-app://' schemes

### DIFF
--- a/data/dbus-interfaces/meson.build
+++ b/data/dbus-interfaces/meson.build
@@ -1,4 +1,5 @@
 dbus_interfaces = [
+  'org.gnome.Shell.AppLauncher.xml',
   'org.gnome.Shell.Extensions.xml',
   'org.gnome.Shell.Introspect.xml',
   'org.gnome.Shell.PadOsd.xml',

--- a/data/dbus-interfaces/org.gnome.Shell.AppLauncher.xml
+++ b/data/dbus-interfaces/org.gnome.Shell.AppLauncher.xml
@@ -1,0 +1,16 @@
+<node>
+  <interface name="org.gnome.Shell.AppLauncher">
+    <method name="Launch">
+      <arg type="s" direction="in" name="name" />
+      <arg type="u" direction="in" name="timestamp" />
+    </method>
+    <method name="LaunchViaDBusCall">
+      <arg type="s" direction="in" name="name" />
+      <arg type="s" direction="in" name="busName" />
+      <arg type="s" direction="in" name="objectPath" />
+      <arg type="s" direction="in" name="interfaceName" />
+      <arg type="s" direction="in" name="methodName" />
+      <arg type="v" direction="in" name="args" />
+    </method>
+  </interface>
+</node>

--- a/data/eos-launch.desktop.in.in
+++ b/data/eos-launch.desktop.in.in
@@ -1,0 +1,8 @@
+[Desktop Entry]
+Name=EOS Launch
+Comment=Utility to launch EndlessOS applications
+Exec=gjs @pkgdatadir@/eos-launch.js %U
+Categories=EndlessOS;Utility;Core;
+MimeType=x-scheme-handler/endlessm-app;
+Type=Application
+NoDisplay=true

--- a/data/gnome-shell-dbus-interfaces.gresource.xml
+++ b/data/gnome-shell-dbus-interfaces.gresource.xml
@@ -39,6 +39,7 @@
     <file preprocess="xml-stripblanks">org.gnome.SettingsDaemon.Power.Screen.xml</file>
     <file preprocess="xml-stripblanks">org.gnome.SettingsDaemon.Rfkill.xml</file>
     <file preprocess="xml-stripblanks">org.gnome.SettingsDaemon.Wacom.xml</file>
+    <file preprocess="xml-stripblanks">org.gnome.Shell.AppLauncher.xml</file>
     <file preprocess="xml-stripblanks">org.gnome.Shell.AudioDeviceSelection.xml</file>
     <file preprocess="xml-stripblanks">org.gnome.Shell.CalendarServer.xml</file>
     <file preprocess="xml-stripblanks">org.gnome.Shell.ClocksIntegration.xml</file>

--- a/data/meson.build
+++ b/data/meson.build
@@ -1,6 +1,7 @@
 desktop_files = [
   'org.gnome.Shell.desktop',
   'org.gnome.Shell.Extensions.desktop',
+  'eos-launch.desktop',
 ]
 service_files = []
 
@@ -13,6 +14,7 @@ desktopconf = configuration_data()
 # We substitute in bindir so it works as an autostart
 # file when built in a non-system prefix
 desktopconf.set('bindir', bindir)
+desktopconf.set('pkgdatadir', pkgdatadir)
 desktopconf.set('systemd_hidden', have_systemd ? 'true' : 'false')
 
 foreach desktop_file : desktop_files

--- a/js/misc/eos-launch.js
+++ b/js/misc/eos-launch.js
@@ -1,0 +1,57 @@
+const { Gio, GLib } = imports.gi;
+
+const AppLauncherIface = '<node> \
+<interface name="org.gnome.Shell.AppLauncher"> \
+<method name="Launch"> \
+    <arg type="s" direction="in" name="name" /> \
+    <arg type="u" direction="in" name="timestamp" /> \
+</method> \
+</interface> \
+</node>';
+
+const AppLauncherProxy = Gio.DBusProxy.makeProxyWrapper(AppLauncherIface);
+
+function getLocalizedAppNames(appName) {
+    // trim .desktop part, if present
+    const idx = appName.indexOf('.desktop');
+    if (idx !== -1)
+        appName = appName.substring(0, idx);
+
+    const appNames = [appName];
+    const languageNames = GLib.get_language_names();
+    const variants = GLib.get_locale_variants(languageNames[0]);
+    variants.filter(variant => {
+        // discard variants with an encoding
+        return variant.indexOf('.') === -1;
+    }).forEach(variant => {
+        appNames.push(`${appName}.${variant}`);
+    });
+
+    appNames.push(`${appName}.en`);
+    return appNames;
+}
+
+function createProxyAndLaunch(appName) {
+    try {
+        const proxy = new AppLauncherProxy(
+            Gio.DBus.session,
+            'org.gnome.Shell',
+            '/org/gnome/Shell');
+        proxy.LaunchSync(appName, 0);
+        return true;
+    } catch (error) {
+        logError(error, `Failed to launch application '${appName}'`);
+        return false;
+    }
+}
+
+var uri = ARGV[0];
+if (!uri) {
+    print('Usage: eos-launch endlessm-app://<application-name>\n');
+} else {
+    const tokens = uri.match(/(endlessm-app:\/\/|)([0-9,a-z,A-Z,-_.]+)/);
+    if (tokens) {
+        const appNames = getLocalizedAppNames(tokens[2]);
+        appNames.some(createProxyAndLaunch);
+    }
+}

--- a/js/misc/meson.build
+++ b/js/misc/meson.build
@@ -15,3 +15,5 @@ config_js = configure_file(
   output: 'config.js',
   configuration: jsconf
 )
+
+install_data('eos-launch.js', install_dir: pkgdatadir)

--- a/js/ui/shellDBus.js
+++ b/js/ui/shellDBus.js
@@ -1,7 +1,7 @@
 // -*- mode: js; js-indent-level: 4; indent-tabs-mode: nil -*-
 /* exported GnomeShell, ScreenSaverDBus */
 
-const { Gio, GLib, Meta } = imports.gi;
+const { Gio, GLib, Meta, Shell } = imports.gi;
 
 const Config = imports.misc.config;
 const ExtensionDownloader = imports.ui.extensionDownloader;
@@ -21,6 +21,8 @@ var GnomeShell = class {
 
         this._extensionsService = new GnomeShellExtensions();
         this._screenshotService = new Screenshot.ScreenshotService();
+
+        this._appLauncherService = new AppLauncher();
 
         this._grabbedAccelerators = new Map();
         this._grabbers = new Map();
@@ -398,5 +400,94 @@ var ScreenSaverDBus = class {
             return Math.floor((GLib.get_monotonic_time() - started) / 1000000);
         else
             return 0;
+    }
+};
+
+const AppLauncherIface = loadInterfaceXML('org.gnome.Shell.AppLauncher');
+
+var AppLauncher = class {
+    constructor() {
+        this._dbusImpl = Gio.DBusExportedObject.wrapJSObject(AppLauncherIface, this);
+        this._dbusImpl.export(Gio.DBus.session, '/org/gnome/Shell');
+
+        this._appSys = Shell.AppSystem.get_default();
+    }
+
+    LaunchAsync(params, invocation) {
+        const [appName, timestamp] = params;
+
+        const app = this._appForAppName(appName);
+        if (!app) {
+            invocation.return_error_literal(
+                Gio.IOErrorEnum,
+                Gio.IOErrorEnum.NOT_FOUND,
+                `Unable to launch app ${appName}: Not installed`);
+            return;
+        }
+
+        app.activate_full(-1, timestamp);
+        invocation.return_value(null);
+    }
+
+    LaunchViaDBusCallAsync(params, invocation) {
+        const [appName, busName, path, interfaceName, method, args] = params;
+
+        const app = this._appForAppName(appName);
+        if (!app) {
+            invocation.return_error_literal(
+                Gio.IOErrorEnum,
+                Gio.IOErrorEnum.NOT_FOUND,
+                `Unable to launch app ${appName}: Not installed`);
+            return;
+        }
+
+        this._activateViaDBusCall(busName, path, interfaceName, method, args, (error, result) => {
+            if (error) {
+                logError(error);
+                invocation.return_error_literal(
+                    Gio.IOErrorEnum,
+                    Gio.IOErrorEnum.FAILED,
+                    `Unable to launch app ${appName} through DBus call on ${busName} ${path} ${interfaceName} ${method}: ${String(error)}`);
+            } else {
+                invocation.return_value(result);
+            }
+        });
+    }
+
+    _appForAppName(appName) {
+        if (!appName.endsWith('.desktop'))
+            appName += '.desktop';
+
+        return this._appSys.lookup_app(appName);
+    }
+
+    _activateViaDBusCall(busName, path, interfaceName, method, args, done) {
+        Gio.bus_get(Gio.BusType.SESSION, null, (source, result) => {
+            let bus = null;
+            try {
+                bus = Gio.bus_get_finish(result);
+            } catch (error) {
+                done(error, null);
+                return;
+            }
+
+            const proxy = new Gio.DBusProxy({
+                g_bus_type: Gio.BusType.SESSION,
+                g_connection: bus,
+                g_default_timeout: GLib.MAXINT32,
+                g_flags: Gio.DBusProxyFlags.NONE,
+                g_interface_name: interfaceName,
+                g_name: busName,
+                g_object_path: path,
+            });
+
+            proxy.call(method, args, Gio.DBusCallFlags.NONE, -1, null, (source2, result2) => {
+                try {
+                    done(null, proxy.call_finish(result2));
+                } catch (error) {
+                    done(error, null);
+                }
+            });
+        });
     }
 };


### PR DESCRIPTION
Reworked changes to not depend on downstream `AppActivation` support. The `AppActivation` support was responsible for handling the integration with the speedwagon as well as to ensure the `X-Endless-Maximized` desktop key was respected. Both speedwagon and `X-Endless-Maximized` will be dropped on 3.9 so let's simplify the launcher impl.

Also fixed a small issue where `eos-launch` would try launching (and report an error) the locale specific apps even if the app requested had already launched successfully (can be easily reproduced on 3.8 by clicking on "Give Us Feedback" on Help Center and looking at the journal).

https://phabricator.endlessm.com/T30293
https://phabricator.endlessm.com/T30172