### PR TITLE
Redisplay when page changes

### DIFF
--- a/js/ui/appDisplay.js
+++ b/js/ui/appDisplay.js
@@ -829,11 +829,12 @@ var PageManager = GObject.registerClass({
     _init() {
         super._init();
 
+        this._updatingPages = false;
+        this._loadPages();
+
         global.settings.connect('changed::app-picker-layout',
             this._loadPages.bind(this));
 
-        this._updatingPages = false;
-        this._loadPages();
     }
 
     _loadPages() {

--- a/js/ui/appDisplay.js
+++ b/js/ui/appDisplay.js
@@ -888,6 +888,7 @@ class AppDisplay extends BaseAppView {
         });
 
         this._pageManager = new PageManager();
+        this._pageManager.connect('layout-changed', () => this._redisplay());
 
         this._scrollView.add_style_class_name('all-apps');
 

--- a/js/ui/appDisplay.js
+++ b/js/ui/appDisplay.js
@@ -832,13 +832,15 @@ var PageManager = GObject.registerClass({
         global.settings.connect('changed::app-picker-layout',
             this._loadPages.bind(this));
 
+        this._updatingPages = false;
         this._loadPages();
     }
 
     _loadPages() {
         const layout = global.settings.get_value('app-picker-layout');
         this._pages = layout.recursiveUnpack();
-        this.emit('layout-changed');
+        if (!this._updatingPages)
+            this.emit('layout-changed');
     }
 
     getAppPosition(appId) {
@@ -869,8 +871,12 @@ var PageManager = GObject.registerClass({
             packedPages.push(pageData);
         }
 
+        this._updatingPages = true;
+
         const variant = new GLib.Variant('aa{sv}', packedPages);
         global.settings.set_value('app-picker-layout', variant);
+
+        this._updatingPages = false;
     }
 
     get pages() {


### PR DESCRIPTION
Backport of https://gitlab.gnome.org/GNOME/gnome-shell/-/merge_requests/1428

Together with https://github.com/endlessm/eos-desktop-extension/pull/15, helps with the grid and the clones getting out of sync.

https://phabricator.endlessm.com/T30623