### PR TITLE
status/remoteAccess: Show remote access indicator on X11

### DIFF
--- a/js/ui/status/remoteAccess.js
+++ b/js/ui/status/remoteAccess.js
@@ -16,13 +16,6 @@ class RemoteAccessApplet extends PanelMenu.SystemIndicator {
         if (!controller)
             return;
 
-        // We can't possibly know about all types of screen sharing on X11, so
-        // showing these controls on X11 might give a false sense of security.
-        // Thus, only enable these controls when using Wayland, where we are
-        // in control of sharing.
-        if (!Meta.is_wayland_compositor())
-            return;
-
         this._handles = new Set();
         this._sharedIndicator = null;
         this._recordingIndicator = null;


### PR DESCRIPTION
On Endless we only enable X11 for now, let's make sure the remote access indicator (screen sharing and recording) is displayed on X11 as well.

https://phabricator.endlessm.com/T30172