### PR TITLE
Rename hack and onboarding extensions

### DIFF
--- a/debian/endless-session-mods/endless.json
+++ b/debian/endless-session-mods/endless.json
@@ -2,8 +2,8 @@
     "parentMode": "user",
     "enabledExtensions": [
         "eos-desktop@endlessm.com",
-        "eos-hack@endlessm.com",
-        "eos-onboarding@endlessm.com",
+        "eos-hack@endlessos.org",
+        "eos-onboarding@endlessos.org",
         "eos-panel@endlessm.com",
         "eos-watermark@endlessm.com",
         "force-quit-dialog-extension@endlessm.com",


### PR DESCRIPTION
We've changed the name for the `eos-hack` and `eos-onboarding` extensions, to use the new `endlessos.org` domain.

https://phabricator.endlessm.com/T30888
https://phabricator.endlessm.com/T30887