### PR TITLE
fixup! payg: Integrate with screen shield and GDM screen

### DIFF
--- a/js/ui/screenShield.js
+++ b/js/ui/screenShield.js
@@ -631,6 +631,9 @@ var ScreenShield = class {
         if (this._activationTime == 0)
             this._activationTime = GLib.get_monotonic_time();
 
+        if (!this._ensureUnlockDialog(true))
+            return;
+
         this._isGreeter = Main.sessionMode.isGreeter;
         if (!this._isGreeter) {
             const userManager = AccountsService.UserManager.get_default();
@@ -648,9 +651,6 @@ var ScreenShield = class {
                 this._ensureUnlockDialog(true);
             }
         }
-
-        if (!this._ensureUnlockDialog(true))
-            return;
 
         this.actor.show();
 


### PR DESCRIPTION
When this payg was applied after the 3.38 rebase, the changes to the
activate() function were applied in the wrong place. Bring back the
early return introduced by commit f02feca1f "screenShield: Fix use of
null this._dialog" on the eos3.8 branch. This means gnome-shell will
correctly still show gnome-initial-setup after resuming from suspend.
Locking for PAYG still works as _ensureUnlockDialog() will return true
in the session modes where we need to lock.

https://phabricator.endlessm.com/T30915