### PR TITLE
Revert to default background color from upstream

### DIFF
--- a/data/theme/gnome-shell-sass/_endless.scss
+++ b/data/theme/gnome-shell-sass/_endless.scss
@@ -11,12 +11,6 @@
 // is probably the best way forward (e.g. modifying _common.css for $font-family)).
 
 
-// Lock screen
-
-#lockDialogGroup {
-  background: #12282e;
-}
-
 // Password Recovery & Hint
 
 .login-dialog-password-recovery-label {

--- a/js/ui/background.js
+++ b/js/ui/background.js
@@ -101,7 +101,7 @@ const LoginManager = imports.misc.loginManager;
 const Main = imports.ui.main;
 const Params = imports.misc.params;
 
-var DEFAULT_BACKGROUND_COLOR = Clutter.Color.from_pixel(0x12282eff);
+var DEFAULT_BACKGROUND_COLOR = Clutter.Color.from_pixel(0x2e3436ff);
 
 const BACKGROUND_SCHEMA = 'org.gnome.desktop.background';
 const PRIMARY_COLOR_KEY = 'primary-color';


### PR DESCRIPTION
This partially reverts commit 9d0025bdfb6c92fcf4a69e99309abc6300718c1d
"Update default background color for login and lock screens".

For the new bootsplash animation we are going to stick with upstream's
current background color and texture.

https://phabricator.endlessm.com/T32724