### PR TITLE
calendar-server: Fix double-free detection abort

### DIFF
--- a/src/calendar-server/gnome-shell-calendar-server.c
+++ b/src/calendar-server/gnome-shell-calendar-server.c
@@ -405,8 +405,7 @@ app_notify_events_added (App *app)
                                  (gboolean) appt->is_all_day,
                                  (gint64) start_time,
                                  (gint64) end_time,
-                                 extras_builder);
-          g_variant_builder_clear (&extras_builder);
+                                 &extras_builder);
         }
     }
 


### PR DESCRIPTION
app_notify_events_added uses an intermediate builder to construct an
array that is then added to the main variant using g_variant_builder_add
which should clear the intermediate, but doesn't due to the way it is
passed: by value, rather than as a pointer.

This was debugged with the help of Eduardo Habkost, who believes it
works on x86 due to big structs being passed as pointers.

Fixed: https://gitlab.gnome.org/GNOME/gnome-shell/-/issues/3440
Part-of: <https://gitlab.gnome.org/GNOME/gnome-shell/-/merge_requests/1848>

(cherry picked from commit 404ca91941226faaf2479609f0109244e66d4bcd)
(cherry picked from commit f212512c0e877222837c6816bbef24369a2edc86)

https://phabricator.endlessm.com/T32772