### PR TITLE
payg: Port PaygUnlockDialog to new MetaIdleAdd API

### DIFF
--- a/js/ui/paygUnlockDialog.js
+++ b/js/ui/paygUnlockDialog.js
@@ -222,7 +222,7 @@ var PaygUnlockDialog = GObject.registerClass({
             this._resetScreen();
         });
 
-        this._idleMonitor = Meta.IdleMonitor.get_core();
+        this._idleMonitor = global.backend.get_core_idle_monitor();
         this._idleWatchId = this._idleMonitor.add_idle_watch(IDLE_TIMEOUT_SECS * MSEC_PER_SEC, this._onCancelled.bind(this));
 
         this.updateSensitivity();


### PR DESCRIPTION
This causes a regression where the PAYG unlock dialog doesn't
show up, which is pretty bad considering this screenshield is
what's shown during initial setup.

This commit should be squashed on commit 96cf95a6b "payg: Add PAYG
infrastructure" during the next rebase.

https://phabricator.endlessm.com/T33021