### PR TITLE
shell-app-system: Adjust start_aggregate_timer call

### DIFF
--- a/src/shell-app-system.c
+++ b/src/shell-app-system.c
@@ -569,7 +569,6 @@ _shell_app_system_notify_app_state_changed (ShellAppSystem *self,
           aggregate_timer =
             emtr_event_recorder_start_aggregate_timer (emtr_event_recorder_get_default (),
                                                        DAILY_APP_USAGE_EVENT,
-                                                       g_variant_new_string (app_info_id),
                                                        g_variant_new_string (app_info_id));
           g_hash_table_insert (self->priv->aggregate_timers,
                                g_strdup (app_info_id),


### PR DESCRIPTION
The aggregate_key parameter has been removed from the API.

This should be squashed into 37d580ba276bc5336d85f35a84e0736e4e2a9298
("shell-app-system: Report application times") in the next rebase.

Depends on https://github.com/endlessm/eos-metrics/pull/47

https://phabricator.endlessm.com/T33252