### PR TITLE
build: Drop incorrect positional arg

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -18,7 +18,7 @@ desktopconf.set('pkgdatadir', pkgdatadir)
 desktopconf.set('systemd_hidden', have_systemd ? 'true' : 'false')
 
 foreach desktop_file : desktop_files
-  i18n.merge_file('desktop',
+  i18n.merge_file(
     input: configure_file(
       input: desktop_file + '.in.in',
       output: desktop_file + '.in',

--- a/src/calendar-server/meson.build
+++ b/src/calendar-server/meson.build
@@ -27,7 +27,7 @@ configure_file(
   install_dir: servicedir
 )
 
-i18n.merge_file('evolution-calendar.desktop',
+i18n.merge_file(
   input: 'evolution-calendar.desktop.in',
   output: 'evolution-calendar.desktop',
   po_dir: po_dir,

--- a/subprojects/extensions-app/data/meson.build
+++ b/subprojects/extensions-app/data/meson.build
@@ -14,7 +14,7 @@ desktopconf.set('bindir', bindir)
 desktopconf.set('app_id', app_id)
 desktopconf.set('prgname', prgname)
 
-i18n.merge_file('desktop',
+i18n.merge_file(
   input: configure_file(
     input: base_id + '.desktop.in.in',
     output: desktop_file + '.in',

--- a/subprojects/extensions-app/data/metainfo/meson.build
+++ b/subprojects/extensions-app/data/metainfo/meson.build
@@ -1,5 +1,5 @@
 metainfo = app_id + '.metainfo.xml'
-i18n.merge_file(metainfo,
+i18n.merge_file(
   input: base_id + '.metainfo.xml.in',
   output: metainfo,
   po_dir: po_dir,

--- a/subprojects/extensions-tool/src/templates/meson.build
+++ b/subprojects/extensions-tool/src/templates/meson.build
@@ -4,7 +4,7 @@ template_metas = [
 ]
 template_deps = []
 foreach template : template_metas
-  template_deps += i18n.merge_file(template,
+  template_deps += i18n.merge_file(
     input: template + '.in',
     output: template,
     po_dir: po_dir,


### PR DESCRIPTION
Unlike other targets that take a name, i18n.merge_file() does not.

Part-of: <https://gitlab.gnome.org/GNOME/gnome-shell/-/merge_requests/2078>
(cherry picked from commit 65450a836ee9e0722a2d4c3327f52345eae293c6)

gnome-shell is currently failing to build:

```
Executing subproject extensions-tool 

extensions-tool| Project name: gnome-extensions-tool
extensions-tool| Project version: 41.2
extensions-tool| C compiler for the host machine: cc (gcc 10.2.1 "cc (Debian 10.2.1-6) 10.2.1 20210110")
extensions-tool| C linker for the host machine: cc ld.bfd 2.35.2
extensions-tool| Dependency gio-2.0 found: YES 2.70.4 (cached)
extensions-tool| Dependency gio-unix-2.0 found: YES 2.70.4 (cached)
extensions-tool| Run-time dependency gnome-autoar-0 found: YES 0.4.3
extensions-tool| Run-time dependency json-glib-1.0 found: YES 1.6.2
extensions-tool| Run-time dependency bash-completion found: YES 2.11
extensions-tool| Checking for function "bind_textdomain_codeset" : YES
extensions-tool| Configuring config.h using configuration

../subprojects/extensions-tool/src/templates/meson.build:7:2: ERROR: Function does not take positional arguments.
```

I'm pretty sure this is the fix.