### PR TITLE
payg: UI support for backends with different code lengths

### DIFF
--- a/data/dbus-interfaces/com.endlessm.Payg1.xml
+++ b/data/dbus-interfaces/com.endlessm.Payg1.xml
@@ -17,5 +17,6 @@
     <property name="CodeFormat" type="s" access="read"/>
     <property name="CodeFormatPrefix" type="s" access="read"/>
     <property name="CodeFormatSuffix" type="s" access="read"/>
+    <property name="CodeLength" type="u" access="read"/>
   </interface>
 </node>

--- a/js/misc/paygManager.js
+++ b/js/misc/paygManager.js
@@ -389,6 +389,10 @@ var PaygManager = GObject.registerClass({
         return this._proxy.CodeFormatSuffix;
     }
 
+    get codeLength() {
+        return this._proxy.CodeLength;
+    }
+
     get enabled() {
         return this._enabled;
     }

--- a/js/ui/payg.js
+++ b/js/ui/payg.js
@@ -37,10 +37,6 @@ const SPINNER_ANIMATION_DELAY_MSECS = 1000;
 const SPINNER_ANIMATION_TIME_MSECS = 300;
 var SPINNER_ICON_SIZE_PIXELS = 16;
 
-const NOTIFICATION_TITLE_TEXT = _('Pay As You Go');
-const NOTIFICATION_EARLY_CODE_ENTRY_TEXT = _('Enter a 14-digit keycode to extend the time before your credit expires.');
-const NOTIFICATION_DETAILED_FORMAT_STRING = _('Subscription expires in %s.');
-
 var UnlockStatus = {
     NOT_VERIFYING: 0,
     VERIFYING: 1,
@@ -740,14 +736,18 @@ class PaygNotifier extends GObject.Object {
         Main.messageTray.add(source);
 
         // by default, this notification is for early entry of an unlock keycode
-        let messageText = NOTIFICATION_EARLY_CODE_ENTRY_TEXT;
+        let codeLength = Main.paygManager.codeLength;
+        let messageText = Gettext.ngettext(
+            'Enter a new keycode (%s character) to extend the time before your credit expires.',
+            'Enter a new keycode (%s characters) to extend the time before your credit expires.',
+            codeLength).format(codeLength);
         let urgency = MessageTray.Urgency.NORMAL;
         let userInitiated = false;
 
         // in case this is a "only X time left" warning notification
         if (secondsLeft >= 0) {
             const timeLeft = timeToString(secondsLeft);
-            messageText = NOTIFICATION_DETAILED_FORMAT_STRING.format(timeLeft);
+            messageText = _('Subscription expires in %s.').format(timeLeft);
             urgency = MessageTray.Urgency.HIGH;
         } else {
             userInitiated = true;
@@ -755,7 +755,7 @@ class PaygNotifier extends GObject.Object {
 
         this._notification = new ApplyCodeNotification(
             source,
-            NOTIFICATION_TITLE_TEXT,
+            _('Pay As You Go'),
             messageText);
 
         if (userInitiated)

--- a/js/ui/paygUnlockDialog.js
+++ b/js/ui/paygUnlockDialog.js
@@ -29,6 +29,8 @@ const Animation = imports.ui.animation;
 const Main = imports.ui.main;
 const LayoutManager = imports.ui.layout;
 
+const Gettext = imports.gettext;
+
 const MSEC_PER_SEC = 1000;
 
 // The timeout before going back automatically to the lock screen
@@ -110,9 +112,12 @@ var PaygUnlockDialog = GObject.registerClass({
         });
         paygEnterCodeBox.add_child(promptBox);
 
+        let codeLength = Main.paygManager.codeLength;
         const promptLabel = new St.Label({
             style_class: 'unlock-dialog-payg-label',
-            text: _('Enter a new 14-digit keycode to unlock your computer:'),
+            text: Gettext.ngettext('Enter a new keycode (%s character) to unlock your computer:',
+                                   'Enter a new keycode (%s characters) to unlock your computer:',
+                                   codeLength).format(codeLength),
             x_align: Clutter.ActorAlign.START,
         });
         promptLabel.clutter_text.line_wrap = true;


### PR DESCRIPTION
Make use of the CodeLength D-Bus property on eos-paygd's interface to
inform the user how many characters should be entered.

This commit should be squashed on commit 96cf95a6b "payg: Add PAYG
infrastructure" during the next rebase.

https://phabricator.endlessm.com/T33325