### PR TITLE
welcomeDialog: Welcome users to Endless OS, not GNOME

### DIFF
--- a/js/ui/welcomeDialog.js
+++ b/js/ui/welcomeDialog.js
@@ -32,8 +32,7 @@ class WelcomeDialog extends ModalDialog.ModalDialog {
     }
 
     _buildLayout() {
-        const [majorVersion] = Config.PACKAGE_VERSION.split('.');
-        const title = _('Welcome to GNOME %s').format(majorVersion);
+        const title = _('Welcome to Endless OS 5');
         const description = _('If you want to learn your way around, check out the tour.');
         const content = new Dialog.MessageDialogContent({ title, description });
 


### PR DESCRIPTION
An Endless OS user will likely not be familiar with the term GNOME.

I took a quick look at whether we could use some field of
/etc/os-release rather than hardcoding "Endless OS 5" here. The short
answer is no. All fields of os-release that have a version number
contain the full x.y.z.

PRETTY_NAME is supposed to be:

> A pretty operating system name in a format suitable for presentation
> to the user. May or may not contain a release code name or OS version
> of some kind, as suitable.
>
> Example: "PRETTY_NAME="Fedora 17 (Beefy Miracle)"".

Ours is:

    PRETTY_NAME="Endless OS 5.0.0"

But if we change this to "Endless OS 5", the full 5.y.z version number
will no longer be visible in Settings → About. The BUILD_ID (OSTree
build timestamp) is shown there, but this is less useful than the
version number.

So for now, just hardcode it. We're changing a translatable string
anyway.

https://phabricator.endlessm.com/T33945
