### PR TITLE
data: Lower down gnome-shell process' OOM score

### DIFF
--- a/data/org.gnome.Shell@wayland.service.in
+++ b/data/org.gnome.Shell@wayland.service.in
@@ -32,3 +32,6 @@ ExecStopPost=-/bin/sh -c 'test "$SERVICE_RESULT" != "exec-condition" && systemct
 Restart=no
 # Kill any stubborn child processes after this long
 TimeoutStopSec=5
+
+# Lower down gnome-shell's OOM score to avoid being killed by OOM-killer too early
+OOMScoreAdjust=-1000

--- a/data/org.gnome.Shell@x11.service.in
+++ b/data/org.gnome.Shell@x11.service.in
@@ -37,3 +37,6 @@ Restart=always
 RestartSec=0ms
 # Kill any stubborn child processes after this long
 TimeoutStopSec=5
+
+# Lower down gnome-shell's OOM score to avoid being killed by OOM-killer too early
+OOMScoreAdjust=-1000


### PR DESCRIPTION
When GNOME shell runs on a less memory system (for example 3 GB RAM), it is usually killed by the kernel OOM-killer easily. Because, it has a higher OOM score. However, GNOME desktop environment cannot do anything when the GNOME shell is killed.

This commit adjusts and lowers down gnome-shell process' OOM score to avoid being killed by the kernel OOM-killer too early. In other words, sacrifices other processes first.

https://phabricator.endlessm.com/T34139