### PR TITLE
fixup! passwordReset: Implement Endless-specific password reset feature

### DIFF
--- a/js/gdm/authPrompt.js
+++ b/js/gdm/authPrompt.js
@@ -783,7 +783,6 @@ var AuthPrompt = GObject.registerClass({
         // Translators: During a password reset, prompt for the "secret code" provided by customer support.
         this.setQuestion(_('Enter unlock code'));
         this.setMessage(
-            GdmUtil.PASSWORD_SERVICE_NAME,
             // Translators: The first %s is the password reset website URL and the second is a verification code.
             _('Please open %s in a web browser, and enter the verification code %s. The service will provide you with an unlock code, which you can enter here.').format(
                 _PASSWORD_RESET_SERVER,


### PR DESCRIPTION
The 'setMessage()' method was modified by commit a38219f37a621 to not receive the service name anymore. However, during the rebasing of commit ecf5fb02aa8cfb, this signature change was not accounted for, passing GdmUtil.PASSWORD_SERVICE_NAME (i.e. 'gdm-password') as the message to be displayed.

Fix that by simply not passing the service name.

https://phabricator.endlessm.com/T34880