### PR TITLE
extensions: Allow desktop ID to be ‘endless’ or ‘Endless’

### DIFF
--- a/js/ui/extensionDownloader.js
+++ b/js/ui/extensionDownloader.js
@@ -37,7 +37,7 @@ async function installExtension(uuid, invocation) {
         shell_version: Config.PACKAGE_VERSION,
     };
 
-    if (Desktop.is('endless') && Main.extensionManager.isModeExtension(uuid)) {
+    if ((Desktop.is('endless') || Desktop.is('Endless')) && Main.extensionManager.isModeExtension(uuid)) {
         const title = _("Can't install “%s”:").format(uuid);
         const message = _("This is an extension enabled by your current mode, you can't install manually any update in that session.");
         Main.notifyError(title, message);
@@ -172,7 +172,7 @@ async function checkForUpdates() {
     Main.extensionManager.getUuids().forEach(uuid => {
         let extension = Main.extensionManager.lookup(uuid);
         // don't updates out of repository mode extension
-        if (Desktop.is('endless') && Main.extensionManager.isModeExtension(uuid))
+        if ((Desktop.is('endless') || Desktop.is('Endless')) && Main.extensionManager.isModeExtension(uuid))
             return;
         if (extension.type !== ExtensionUtils.ExtensionType.PER_USER)
             return;

--- a/js/ui/extensionSystem.js
+++ b/js/ui/extensionSystem.js
@@ -609,7 +609,7 @@ var ExtensionManager = class {
             let type = dir.has_prefix(perUserDir)
                 ? ExtensionType.PER_USER
                 : ExtensionType.SYSTEM;
-            if (Desktop.is('endless') && this.isModeExtension(uuid) && type === ExtensionType.PER_USER) {
+            if ((Desktop.is('endless') || Desktop.is('Endless')) && this.isModeExtension(uuid) && type === ExtensionType.PER_USER) {
                 log(`Found user extension ${uuid}, but not loading from ${dir.get_path()} directory as part of session mode.`);
                 return;
             }


### PR DESCRIPTION
Historically we’ve defined it as ‘endless’ (e.g.
`XDG_CURRENT_DESKTOP=endless:GNOME`). We’re now looking to standardise the desktop ID, and for that it would be better if it were capitalised like other desktop IDs.

See: https://gitlab.freedesktop.org/xdg/xdg-specs/-/merge_requests/73