### PR TITLE
Remove Hack from 'endless' session mode

### DIFF
--- a/debian/endless-session-mods/endless.json
+++ b/debian/endless-session-mods/endless.json
@@ -2,7 +2,6 @@
     "parentMode": "user",
     "enabledExtensions": [
         "eos-desktop@endlessm.com",
-        "eos-hack@endlessos.org",
         "eos-watermark@endlessm.com",
         "force-quit-dialog-extension@endlessm.com",
         "ubuntu-appindicators@ubuntu.com"


### PR DESCRIPTION
We have removed the extension from the OS.

Listing it here when it is not installed does not seem to cause any
harm, but it can't do any good either.

https://phabricator.endlessm.com/T35054
