### PR TITLE
Remove eos-watermark from 'endless' session mode

### DIFF
--- a/debian/endless-session-modes/endless.json
+++ b/debian/endless-session-modes/endless.json
@@ -2,7 +2,6 @@
     "parentMode": "user",
     "enabledExtensions": [
         "eos-desktop@endlessm.com",
-        "eos-watermark@endlessm.com",
         "force-quit-dialog-extension@endlessm.com",
         "ubuntu-appindicators@ubuntu.com"
     ]


### PR DESCRIPTION
We are removing this from the OS.

This is very lightly used, not enough to justify updating it for GNOME
43 compatibility.

If we wish to bring this functionality back in future, we should instead
package https://pagure.io/background-logo-extension, which is actually
the ancestral source of the eos-watermark-extension code and which is
actively maintained by a core Shell developer for each Fedora release.

https://phabricator.endlessm.com/T35077