### PR TITLE
keyboard: Ensure a Latin layout is always available

### DIFF
--- a/js/misc/keyboardManager.js
+++ b/js/misc/keyboardManager.js
@@ -1,7 +1,7 @@
 // -*- mode: js; js-indent-level: 4; indent-tabs-mode: nil -*-
 /* exported getKeyboardManager, holdKeyboard, releaseKeyboard */
 
-const { GLib, GnomeDesktop } = imports.gi;
+const { GLib, GnomeDesktop, Shell } = imports.gi;
 
 const Main = imports.ui.main;
 
@@ -155,6 +155,16 @@ var KeyboardManager = class {
     _buildOptionsString() {
         let options = this._xkbOptions.join(',');
         return options;
+    }
+
+    isLatinLayout(id) {
+        const info = this._layoutInfos[id];
+        if (!info)
+            return false;
+        const options = this._buildOptionsString();
+        const [, variants] = this._buildGroupStrings(info.group);
+        const [, , , layout, _variant] = this._xkbInfo.get_layout_info(id);
+        return !Shell.util_needs_secondary_layout(layout, variants, options);
     }
 
     get currentLayout() {

--- a/js/ui/status/keyboard.js
+++ b/js/ui/status/keyboard.js
@@ -553,6 +553,7 @@ var InputSourceManager = class extends Signals.EventEmitter {
         this._ibusSources = {};
 
         let infosList = [];
+        let hasLatinLayout = false;
         for (let i = 0; i < nSources; i++) {
             let displayName;
             let shortName;
@@ -563,6 +564,7 @@ var InputSourceManager = class extends Signals.EventEmitter {
             if (type == INPUT_SOURCE_TYPE_XKB) {
                 [exists, displayName, shortName] =
                     this._xkbInfo.get_layout_info(id);
+                hasLatinLayout ||= this._keyboardManager.isLatinLayout(id);
             } else if (type == INPUT_SOURCE_TYPE_IBUS) {
                 if (this._disableIBus)
                     continue;
@@ -581,9 +583,10 @@ var InputSourceManager = class extends Signals.EventEmitter {
 
             if (exists)
                 infosList.push({ type, id, displayName, shortName });
+            /* TODO: update hasLatinLayout if this engine can enter Latin characters */
         }
 
-        if (infosList.length == 0) {
+        if (infosList.length == 0 || !hasLatinLayout) {
             let type = INPUT_SOURCE_TYPE_XKB;
             let id = KeyboardManager.DEFAULT_LAYOUT;
             let [, displayName, shortName] = this._xkbInfo.get_layout_info(id);

--- a/meson.build
+++ b/meson.build
@@ -96,6 +96,9 @@ gnome_desktop_dep = dependency('gnome-desktop-3.0', version: gnome_desktop_req)
 # Endless-specific: Metrics
 eosmetrics_dep = dependency('eosmetrics-0')
 
+# Endless-specific: Required to determine whether layouts can enter Latin characters
+xkbcommon_dep = dependency('xkbcommon')
+
 nm_deps = []
 if get_option('networkmanager')
   nm_deps += dependency('libnm', version: nm_req)

--- a/src/meson.build
+++ b/src/meson.build
@@ -63,6 +63,7 @@ gnome_shell_deps = [
   gcr_dep,
   libsystemd_dep,
   eosmetrics_dep,
+  xkbcommon_dep,
 ]
 
 gnome_shell_deps += nm_deps

--- a/src/shell-util.c
+++ b/src/shell-util.c
@@ -23,6 +23,7 @@
 #include <gdk-pixbuf/gdk-pixbuf.h>
 #include <meta/display.h>
 #include <meta/meta-x11-display.h>
+#include <xkbcommon/xkbcommon.h>
 
 #include <locale.h>
 #ifdef HAVE__NL_TIME_FIRST_WEEKDAY
@@ -37,6 +38,15 @@
 #define sd_notify(u, m)            do {} while (0)
 #define sd_notifyf(u, m, ...)      do {} while (0)
 #endif
+
+#define DEFAULT_XKB_RULES_FILE "evdev"
+#define DEFAULT_XKB_MODEL "pc105"
+
+typedef struct _FindLatinKeysymsState
+{
+  gboolean *required_keysyms_found;
+  int n_required_keysyms;
+} FindLatinKeysymsState;
 
 static void
 stop_pick (ClutterActor *actor)
@@ -875,4 +885,91 @@ shell_util_get_boottime (void)
              g_strerror (errno));
 
   return (((gint64) ts.tv_sec) * 1000000) + (ts.tv_nsec / 1000);
+}
+
+static void
+find_latin_keysym (struct xkb_keymap *keymap,
+                   xkb_keycode_t      key,
+                   void              *data)
+{
+  FindLatinKeysymsState *state = data;
+  int n_keysyms, i;
+  const xkb_keysym_t *keysyms;
+
+  n_keysyms = xkb_keymap_key_get_syms_by_level (keymap,
+                                                key,
+                                                0,
+                                                0,
+                                                &keysyms);
+  for (i = 0; i < n_keysyms; i++)
+    {
+      xkb_keysym_t keysym = keysyms[i];
+      if (keysym >= XKB_KEY_a && keysym <= XKB_KEY_z)
+        {
+          unsigned int keysym_index = keysym - XKB_KEY_a;
+          if (!state->required_keysyms_found[keysym_index])
+            {
+              state->required_keysyms_found[keysym_index] = TRUE;
+              state->n_required_keysyms--;
+            }
+        }
+    }
+}
+
+static struct xkb_keymap *
+create_keymap (struct xkb_context *context,
+               const char         *layouts,
+               const char         *variants,
+               const char         *options)
+{
+    struct xkb_keymap *keymap;
+    struct xkb_rule_names rmlvo = {
+        .rules = DEFAULT_XKB_RULES_FILE,
+        .model = DEFAULT_XKB_MODEL,
+        .layout = layouts,
+        .variant = variants,
+        .options = options
+    };
+
+    if (!layouts || !variants || !options)
+        keymap = xkb_keymap_new_from_names (context, NULL, 0);
+    else
+        keymap = xkb_keymap_new_from_names (context, &rmlvo, 0);
+    if (!keymap)
+      {
+        fprintf (stderr,
+                 "Failed to compile RMLVO: '%s', '%s', '%s'\n",
+                 layouts, variants, options);
+        return NULL;
+      }
+
+    return keymap;
+}
+
+gboolean
+shell_util_needs_secondary_layout (const char *layouts,
+                                   const char *variants,
+                                   const char *options)
+{
+  gboolean required_keysyms_found[26] = { FALSE, };
+  FindLatinKeysymsState state = {
+    .required_keysyms_found = required_keysyms_found,
+    .n_required_keysyms = G_N_ELEMENTS (required_keysyms_found),
+  };
+  struct xkb_keymap *keymap;
+  struct xkb_context *ctx;
+  enum xkb_context_flags ctx_flags;
+
+  ctx_flags = XKB_CONTEXT_NO_DEFAULT_INCLUDES;
+  ctx = xkb_context_new (ctx_flags);
+  xkb_context_include_path_append_default (ctx);
+
+  keymap = create_keymap (ctx, layouts, variants, options);
+
+  xkb_keymap_key_for_each (keymap, find_latin_keysym, &state);
+
+  xkb_keymap_unref (keymap);
+  xkb_context_unref (ctx);
+
+  return state.n_required_keysyms != 0;
 }

--- a/src/shell-util.h
+++ b/src/shell-util.h
@@ -90,6 +90,10 @@ gint shell_util_get_uid (void);
 
 gint64 shell_util_get_boottime (void);
 
+gboolean shell_util_needs_secondary_layout (const char *layouts,
+                                            const char *variants,
+                                            const char *options);
+
 G_END_DECLS
 
 #endif /* __SHELL_UTIL_H__ */


### PR DESCRIPTION
In past versions of Endless OS, we added the concept of a “password mode” to
GNOME Shell, which is triggered either within GNOME Shell's own password
fields, or from applications by setting a D-Bus property on the shell. In this
mode, Shell would check whether any configured input source could type the
English letters a through z, and if not, append the US English keyboard layout
to the list of available sources. The intent is to ensure, for example, that it
is possible to type Wi-Fi passwords, which typically use only English ASCII
letters even in regions where the local language uses some other script, even
if the user's keyboard layout is (say) Thai.

This approach requires coöperation from applications (which we previously
patched GNOME Initial Setup to do, for example) and does not solve the related
problem that URLs and email addresses are also typically written in English
ASCII letters throughout the world.

For Endless OS 6, we had removed this feature entirely, but I am concerned that
existing users may be relying on this feature to enter their account password
using Latin characters at GDM while only having a non-Latin input source
configured.

So, reintroduce the logic, but apply it at all times, rather than when a
password is being entered. This will, for example, allow entering URLs on a
system configured with only a Thai layout.

The logic for detecting whether a fallback method is needed is a little
simplistic and does not handle some cases correctly. Some IBus methods, such as
libzhuyin for Chinese, provide a built-in passthrough mode to enter English
text; but this logic will add a fallback US English method if libzhuyin is the
only configured method. This seems acceptable as a stop-gap.

There is ongoing work in GNOME to solve this problem more generally, including
handling the case of some IBus methods providing their own passthrough mode.
See https://gitlab.gnome.org/GNOME/gnome-initial-setup/-/merge_requests/213 and
linked issues & merge requests.

https://phabricator.endlessm.com/T31812

---

I structured this PR as a cherry-pick (fixing conflicts) of the old code, followed by deleting bits of it, to make it easier to review the changes compared both to the current eos6.0 code, and to what we shipped in previous Endless OSes.

TODO:

- [x] Move “Make eosmetrics dependency optional” to a separate PR (or abandon it)
- [x] Remove more dead code
- [x] Remove `log()` messages used in development