### PR TITLE
Backport two upstream fixes for startup animation

### DIFF
--- a/js/ui/layout.js
+++ b/js/ui/layout.js
@@ -658,7 +658,7 @@ var LayoutManager = GObject.registerClass({
                 if (this.primaryMonitor) {
                     this._systemBackground.show();
                     global.stage.show();
-                    this._prepareStartupAnimation();
+                    this._prepareStartupAnimation().catch(logError);
                     return GLib.SOURCE_REMOVE;
                 } else {
                     return GLib.SOURCE_CONTINUE;

--- a/js/ui/overviewControls.js
+++ b/js/ui/overviewControls.js
@@ -853,7 +853,7 @@ class ControlsManager extends St.Widget {
             delay: STARTUP_ANIMATION_TIME,
             duration: STARTUP_ANIMATION_TIME,
             mode: Clutter.AnimationMode.EASE_OUT_QUAD,
-            onComplete: () => callback(),
+            onStopped: () => callback(),
         });
     }
 


### PR DESCRIPTION
The [first patch](https://gitlab.gnome.org/GNOME/gnome-shell/-/commit/7a5f1e5c9e96b04a41407d1ae9d9f242b31ed1cf) is part of upstream 45.0 and newer.

The second was [accepted upstream](https://gitlab.gnome.org/GNOME/gnome-shell/-/merge_requests/3422) and will be in 47.beta.

https://phabricator.endlessm.com/T34453