### PR TITLE
fixup! payg: Add panel indicator for PAYG account details and actions

### DIFF
--- a/js/ui/status/payg.js
+++ b/js/ui/status/payg.js
@@ -290,7 +290,7 @@ const PaygAccountToggle = GObject.registerClass({
         this.menu.setHeader(_getNormalGIcon(), _('Pay As You Go'));
 
         this._paygNotifier = new Payg.PaygNotifier();
-        this._unlockMenuItem = this.menu.addAction('Enter unlock code…', () => {
+        this._unlockMenuItem = this.menu.addAction(_('Enter unlock code…'), () => {
             Main.panel.closeQuickSettings();
             this._paygNotifier.notify(-1);
         });


### PR DESCRIPTION
The string “Enter unlock code…” was not marked for translation since
d50cd8dc60f400882db9ce425da13003b0561965 which reworked this interface
for the newer quick settings menu.

https://phabricator.endlessm.com/T35611
